### PR TITLE
fix: remove prometheus 2.45.0 and fix mattermost id

### DIFF
--- a/oci/prometheus/contacts.yaml
+++ b/oci/prometheus/contacts.yaml
@@ -2,4 +2,4 @@ notify:
   emails:
     - observability@lists.launchpad.net
   mattermost-channels:
-    - rjkzqmate38ffgi4smsrtcg8ur
+    - 1ayd5kim67bbing34i3h1x9uac

--- a/oci/prometheus/image.yaml
+++ b/oci/prometheus/image.yaml
@@ -17,15 +17,3 @@ upload:
         end-of-life: "2024-08-01T00:00:00Z"
         risks:
           - stable
-  - source: canonical/prometheus-rock
-    commit: c7a8b4eeaf34b1bf7f7cb7bdf71e90369fb60031
-    directory: 2.45.0
-    release:
-      2.45.0-22.04:
-        end-of-life: "2024-08-01T00:00:00Z"
-        risks:
-          - stable
-      2.45-22.04:
-        end-of-life: "2024-08-01T00:00:00Z"
-        risks:
-          - stable


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

Remove Prometheus 2.45.0 as it's not passing the vulnerability check, and fix the Mattermost channel ID with the correct one.

---

*Picture of a cool ROCK:*
