### PR TITLE
feat: add alertmanager rock

### DIFF
--- a/oci/alertmanager/contacts.yaml
+++ b/oci/alertmanager/contacts.yaml
@@ -1,0 +1,5 @@
+notify:
+  emails:
+    - observability@lists.launchpad.net
+  mattermost-channels:
+    - 1ayd5kim67bbing34i3h1x9uac

--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -8,6 +8,10 @@ description: >
   many other mechanisms thanks to the webhook receiver. It also takes care of
   silencing and inhibition of alerts.
   Read more on the [official documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
+
+  Please note that this repository is now holding a ROCK, not a
+  Dockerfile-based image. As such the entrypoint is now Pebble. Read more on
+  the [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/).
 # --- USAGE INFORMATION ---
 docker:
   parameters:

--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -2,7 +2,7 @@ version: 1
 # --- OVERVIEW INFORMATION ---
 application: alertmanager
 description: >
-  The Alertmanager handles alerts sent by client application such as the
+  The Alertmanager handles alerts sent by client applications such as the
   Prometheus server. It takes care of deduplicating, grouping, and routing them
   to the correct receiver integrations such as email, PagerDuty, OpSGenie, or
   many other mechanisms thanks to the webhook receiver. It also takes care of

--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -48,5 +48,5 @@ debug:
     To get an interactive shell:
 
     ```bash
-    docker exec -it alertmanager-container /bin/bash
+    docker exec -it alertmanager-container exec /bin/bash
     ```

--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -1,0 +1,48 @@
+version: 1
+# --- OVERVIEW INFORMATION ---
+application: alertmanager
+description: >
+  The Alertmanager handles alerts sent by client application such as the
+  Prometheus server. It takes care of deduplicating, grouping, and routing them
+  to the correct receiver integrations such as email, PagerDuty, OpSGenie, or
+  many other mechanisms thanks to the webhook receiver. It also takes care of
+  silencing and inhibition of alerts.
+  Read more on the [official documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
+# --- USAGE INFORMATION ---
+docker:
+  parameters:
+    - -p 9093:9093
+  access: Access your Alertmanager instance at `http://localhost:9093`.
+parameters:
+  - type: -e
+    value: 'TZ=UTC'
+    description: Timezone.
+  - type: -p
+    value: '9093:9093'
+    description: Expose Alertmanager on `localhost:9093`.
+  - type: -v 
+    value: "/path/to/alertmanager.yml:/etc/prometheus/alertmanager.yml"
+    description: Local configuration file `alertmanager.yml`.
+  - type: -v
+    value: "/path/to/persisted/data:/alertmaanger"
+    description: >
+      Persist data instead of initializing a new database for each newly
+      launched container. **Important note**: the directory you will be using
+      to persist the data needs to belong to `nogroup:nobody`. You can run
+      `chown nogroup:nobody <path_to_persist_data>` before launching your
+      container.
+debug:
+  text: |
+    ### Debugging
+    
+    To debug the container:
+
+    ```bash
+    docker logs -f alertmanager-container
+    ```
+
+    To get an interactive shell:
+
+    ```bash
+    docker exec -it alertmanager-container /bin/bash
+    ```

--- a/oci/alertmanager/image.yaml
+++ b/oci/alertmanager/image.yaml
@@ -1,0 +1,19 @@
+version: 1
+
+upload:
+  - source: canonical/alertmanager-rock
+    commit: c0e06b43e246a3a35fd62619bdeead6433bd79a8
+    directory: 0.25.0
+    release:
+      0.25.0-22.04:
+        end-of-life: "2024-08-16T00:00:00Z"
+        risks:
+          - stable
+      0.25-22.04:
+        end-of-life: "2024-08-16T00:00:00Z"
+        risks:
+          - stable
+      0-22.04:
+        end-of-life: "2024-08-16T00:00:00Z"
+        risks:
+          - stable


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR adds the Alertmanager ROCK to the oci-factory.

Please note that this should go to a new `alertmanager` repository that's yet to be created. There currently exists a [prometheus-alertmanager](https://hub.docker.com/r/ubuntu/prometheus-alertmanager) repository, but that one should be deprecated.

### Related issues
#42 
