### PR TITLE
Ignore upstream CVE in Alertmanager pending a fix

### DIFF
--- a/oci/alertmanager/.trivyignore
+++ b/oci/alertmanager/.trivyignore
@@ -1,0 +1,3 @@
+
+# Fix not available in upstream, see https://github.com/prometheus/alertmanager/discussions/3471
+CVE-2022-41723


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
The current upstream code base is suffering from a potential HTTP/2 DoS vulnerability in the Golang standard libraries and is still pending a dependency upgrade.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
- https://github.com/prometheus/alertmanager/discussions/3471
---

*Picture of a cool ROCK:*
![image](https://github.com/canonical/oci-factory/assets/1596025/cf36b812-cf95-4a01-a25d-9adcb75a67fd)
