### PR TITLE
Rocks 973/dont update rock if eol is reached

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -1,32 +1,32 @@
 {
     "latest": {
         "candidate": {
-            "target": "151"
+            "target": "1.0-22.04_candidate"
         },
         "beta": {
-            "target": "151"
+            "target": "latest_candidate"
         },
         "edge": {
-            "target": "151"
+            "target": "latest_beta"
         }
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "151"
+            "target": "154"
         },
         "beta": {
-            "target": "151"
+            "target": "154"
         },
         "edge": {
-            "target": "151"
+            "target": "154"
         }
     },
     "test": {
         "beta": {
-            "target": "151"
+            "target": "1.0-22.04_beta"
         },
         "edge": {
-            "target": "151"
+            "target": "test_beta"
         }
     }
 }


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

The OCI Factory currently auto-updates a ROCK whenever there is a new base ubuntu image upstream.

This task involves using the end-of-life field to infer whether the rock should be updated or not.

## Acceptance Criteria

* PR is rejected if eol is in the past
* Vulnerability scan is stopped if eol is reached
* Auto update is stopped if eol is reached


