### PR TITLE
[DPE-3232] Apache ZooKeeper <> OCI Factory Integration

### DIFF
--- a/oci/zookeeper/.trivyignore
+++ b/oci/zookeeper/.trivyignore
@@ -1,0 +1,2 @@
+# CVEs in upstream
+

--- a/oci/zookeeper/contacts.yaml
+++ b/oci/zookeeper/contacts.yaml
@@ -1,0 +1,4 @@
+# Who and how to notify about the build progress.
+notify:
+  mattermost-channels:  # These are channel IDs and not names.
+    - 5dom1psz9bbzfcff8kzdei7p5h  # data platform alerts

--- a/oci/zookeeper/contacts.yaml
+++ b/oci/zookeeper/contacts.yaml
@@ -1,4 +1,6 @@
 # Who and how to notify about the build progress.
 notify:
-  mattermost-channels:  # These are channel IDs and not names.
-    - 5dom1psz9bbzfcff8kzdei7p5h  # data platform alerts
+  emails:
+    - data-platform@lists.launchpad.net
+  mattermost-channels:
+    - wxppdtg4obdg9csp9wxnqs1wqw  # alerts on DataPlatform OCI channel

--- a/oci/zookeeper/documentation.yaml
+++ b/oci/zookeeper/documentation.yaml
@@ -18,7 +18,8 @@ description: |
   whereas from version 3.8.2 onward the images are now ROCKs. As such the
   entrypoint is now Pebble. Read more on the
   [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/).
- --- USAGE INFORMATION ---
+
+# --- USAGE INFORMATION ---
 docker:
   parameters:
     - -p 2181:2181

--- a/oci/zookeeper/documentation.yaml
+++ b/oci/zookeeper/documentation.yaml
@@ -18,6 +18,41 @@ description: |
   whereas from version 3.8.2 onward the images are now ROCKs. As such the
   entrypoint is now Pebble. Read more on the
   [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/).
-
-
-  
+ --- USAGE INFORMATION ---
+docker:
+  parameters:
+    - -p 2181:2181
+  access: Access your ZooKeeper server at `http://localhost:2181`.
+parameters:
+  - type: -e
+    value: 'TZ=UTC'
+    description: Timezone.
+  - type: -p
+    value: '2181:2181'
+    description: Expose ZooKeeper server on `localhost:2181`.
+  - type: -v
+    value: "/path/to/config/file:/etc/zookeeper/zoo.cfg"
+    description: Local ZooKeeper configuration file.
+  - type: -v
+    value: "zookeeperData:/var/lib/zookeeper/data"
+    description: > 
+      "Persist data in a docker volume named `zookeeperData`. "
+      "Make sure that the mount point is consistent with the configuration property `dataDir`.
+  - type: -v
+    value: "zookeeperLogData:/var/lib/zookeeper/data-log"
+    description: > 
+      "Persist data in a docker volume named `zookeeperLogData`. "
+      "Make sure that the mount point is consistent with the configuration property `dataLogDir`.
+debug:
+  text: |
+    ### Debugging
+    
+    To debug the container:
+    ```bash
+    docker logs -f <zookeeper-container>
+    ```
+    
+    To get an interactive shell:
+    ```bash
+    docker exec -it <zookeeper-container> /bin/bash
+    ```

--- a/oci/zookeeper/documentation.yaml
+++ b/oci/zookeeper/documentation.yaml
@@ -13,6 +13,11 @@ description: |
   All of these kinds of services are used in some form or another by 
   distributed applications. Read more on the Apache website. This image is 
   shipped in support of the Apache Kafka image.
+  
+  Please note that the images tagged up to 3.1 are Dockerfile-base images,
+  whereas from version 3.8.2 onward the images are now ROCKs. As such the
+  entrypoint is now Pebble. Read more on the
+  [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/).
 
 
   

--- a/oci/zookeeper/documentation.yaml
+++ b/oci/zookeeper/documentation.yaml
@@ -1,0 +1,18 @@
+version: 1
+application: zookeeper
+is_chiselled: False
+description: |
+  Current Apache ZooKeeper Docker Image from Canonical, based on Ubuntu. 
+  Receives security updates and tracks the newest combination of Apache 
+  ZooKeeper and Ubuntu. **This repository is free to use and exempted from 
+  per-user rate limits.**
+  
+  # About Apache ZooKeeper
+  ZooKeeper is a centralized service for maintaining configuration information, 
+  naming, providing distributed synchronization, and providing group services. 
+  All of these kinds of services are used in some form or another by 
+  distributed applications. Read more on the Apache website. This image is 
+  shipped in support of the Apache Kafka image.
+
+
+  

--- a/oci/zookeeper/image.yaml
+++ b/oci/zookeeper/image.yaml
@@ -2,7 +2,7 @@ version: 1
     
 upload:  
   - source: "canonical/zookeeper-rock"
-    commit: 1a5e053705c24c0126ab1f4965d57e2bdd3f1c32
+    commit: 01d8701ca4a684740952ccd375f46c98cc58ac3d
     directory: .
     release:
       3.8.2-22.04:

--- a/oci/zookeeper/image.yaml
+++ b/oci/zookeeper/image.yaml
@@ -2,7 +2,7 @@ version: 1
     
 upload:  
   - source: "canonical/zookeeper-rock"
-    commit: 01d8701ca4a684740952ccd375f46c98cc58ac3d
+    commit: 1781da1dacbacf647319731ff25ba4ad00082140
     directory: .
     release:
       3.8.2-22.04:

--- a/oci/zookeeper/image.yaml
+++ b/oci/zookeeper/image.yaml
@@ -1,0 +1,15 @@
+version: 1
+    
+upload:  
+  - source: "canonical/zookeeper-rock"
+    commit: 1a5e053705c24c0126ab1f4965d57e2bdd3f1c32
+    directory: .
+    release:
+      3.8.2-22.04:
+        end-of-life: "2024-05-01T00:00:00Z"
+        risks:
+          - edge
+      3:
+        end-of-life: "2024-05-01T00:00:00Z"
+        risks:
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
We have recently created a Rock for packaging Apache ZooKeeper [here](https://github.com/canonical/zookeeper-rock/pull/1). The binaries are the same as the ones used in Charmed ZooKeeper images, but here we just reduce only to the Apache ZooKeeper, leaving outside all the extra components and dependencies. 

The idea of the image would be to replace the current Apache ZooKeeper images in DockerHub that are not integrated with Rock and OCI Factory pipeline. 

