### PR TITLE
make github workflows callable instead of using workflow-dispatch-action

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Infer images to document
         uses: tj-actions/changed-files@v35
         id: changed-files
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         with:
           dir_names: "true"
           separator: ","
@@ -51,8 +51,11 @@ jobs:
         run: |
           set -ex
 
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]
-          then
+          case "${{ github.event_name }}" in
+          workflow_dispatch|workflow_call)
+            img_path="oci/${{ inputs.oci-image-name }}"
+            ;;
+          *)
             img_path="${{ steps.changed-files.outputs.all_changed_files }}"
             occurrences="${img_path//[^,]}"
             if [ ${#occurrences} -ne 0 ]
@@ -60,9 +63,8 @@ jobs:
               echo "ERR: can only build documentation for 1 image at a time, but trying to document ${img_path}"
               exit 1
             fi
-          else
-            img_path="oci/${{ inputs.oci-image-name }}"
-          fi
+            ;;
+          esac
           test -d "${img_path}"
           echo "img-name=$(basename ${img_path})" >> "$GITHUB_OUTPUT"
           echo "img-path=${img_path}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -15,6 +15,12 @@ on:
         required: false
         type: string
         default: "default-id"
+  workflow_call:
+    inputs:
+      oci-image-name:
+        description: 'OCI image to generate the documentation for'
+        required: true
+        type: string
 
 jobs:
   validate-documentation-request:

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Infer number of image triggers
         uses: tj-actions/changed-files@v35
         id: changed-files
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         with:
           separator: ","
           dir_names: "true"

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -73,8 +73,11 @@ jobs:
         run: |
           set -ex
 
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]
-          then
+          case "${{ github.event_name }}" in
+          workflow_dispatch|workflow_call)
+            img_path="oci/${{ inputs.oci-image-name }}"
+            ;;
+          *)
             img_path="${{ steps.changed-files.outputs.all_changed_files }}"
             occurrences="${img_path//[^,]}"
             if [ ${#occurrences} -ne 0 ]
@@ -82,9 +85,8 @@ jobs:
               echo "ERR: can only build 1 image at a time, but trying to trigger ${img_path}"
               exit 1
             fi
-          else
-            img_path="oci/${{ inputs.oci-image-name }}"
-          fi
+            ;;
+          esac
           test -d "${img_path}"
 
           echo "img-name=$(basename ${img_path})" >> "$GITHUB_OUTPUT"
@@ -471,10 +473,10 @@ jobs:
 
   release:
     name: Release
-    needs: [prepare-releases]
+    needs: [prepare-build, prepare-releases]
     uses: ./.github/workflows/Release.yaml
     with:
-      oci-image-name: "${{ inputs.oci-image-name }}"
+      oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
       image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
     secrets: inherit
 

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -472,7 +472,7 @@ jobs:
   release:
     name: Release
     needs: [prepare-releases]
-    uses: canonical/oci-factory/.github/workflows/Release.yaml@main
+    uses: ./.github/workflows/Release.yaml
     with:
       oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
       image-trigger-cache-key: "${{ github.run_id }}-image-trigger"

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix: ${{ fromJSON(needs.prepare-build.outputs.build-matrix) }}
-    uses: canonical/oci-factory/.github/workflows/Tests.yaml@main
+    uses: ./.github/workflows/Tests.yaml
     with:
       oci-image-name: "${{ matrix.name }}_${{ matrix.commit }}_${{ matrix.revision }}"
       oci-image-path: "oci/${{ matrix.name }}"
@@ -409,8 +409,8 @@ jobs:
   # We need this job because we want to make the releases all in one go,
   # so that we know which revisions to release, and so that we can update
   # and commit the _releases.json file in a single commit, outside a matrix job
-  dispatch-releases:
-    name: Dispatch releases
+  prepare-releases:
+    name: Prepare releases
     needs: [prepare-build, upload]
     runs-on: ubuntu-22.04
     if: ${{ needs.prepare-build.outputs.release-to != '' }}
@@ -469,38 +469,14 @@ jobs:
           path: ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
           key: ${{ github.run_id }}-image-trigger
 
-  dispatch-releases-workflow:
-    name: Dispatch Releases workflow
-    needs: [dispatch-releases]
+  release:
+    name: Release
+    needs: [prepare-releases]
     uses: canonical/oci-factory/.github/workflows/Release.yaml@main
     with:
       oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
       image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
     secrets: inherit
-
-  write-dispatch-releases-summary:
-    name: Write dispatch releases summary
-    needs: [dispatch-releases-workflow]
-    runs-on: ubuntu-22.04
-    if: ${{ needs.prepare-build.outputs.release-to != '' }}
-    concurrency:
-      group: ${{ needs.prepare-build.outputs.oci-img-path }}
-      cancel-in-progress: true
-    env:
-      REVISION_DATA_DIR: revision-data
-    steps:
-      - name: Write step summary
-        run: |
-          url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-releases.outputs.run-id }}'
-          echo " - Triggered releases for '${{ needs.prepare-build.outputs.oci-img-name }}' at [${url}](${url})" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Enforce release conclusion
-        if: ${{ steps.run-releases.outputs.run-conclusion != 'success' }}
-        # The previous step doesn't always raise an error
-        run: |
-          url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-releases.outputs.run-id }}'
-          echo "Failed to release '${{ needs.prepare-build.outputs.oci-img-name }}' at [${url}](${url})."
-          exit 1
 
   generate-provenance:
     name: Generate SLSA provenance
@@ -574,7 +550,7 @@ jobs:
   notify:
     runs-on: ubuntu-22.04
     name: Notify
-    needs: [prepare-build, run-build, upload, dispatch-releases, generate-provenance]
+    needs: [prepare-build, run-build, upload, prepare-releases, generate-provenance]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -469,13 +469,26 @@ jobs:
           path: ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
           key: ${{ github.run_id }}-image-trigger
 
-      - name: Dispatch Releases workflow
-        uses: canonical/oci-factory/.github/workflows/Release.yaml@main
-        id: run-releases
-        with:
-          oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
-          image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
+  dispatch-releases-workflow:
+    name: Dispatch Releases workflow
+    needs: [dispatch-releases]
+    uses: canonical/oci-factory/.github/workflows/Release.yaml@main
+    with:
+      oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
+      image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
+    secrets: inherit
 
+  write-dispatch-releases-summary:
+    name: Write dispatch releases summary
+    needs: [dispatch-releases-workflow]
+    runs-on: ubuntu-22.04
+    if: ${{ needs.prepare-build.outputs.release-to != '' }}
+    concurrency:
+      group: ${{ needs.prepare-build.outputs.oci-img-path }}
+      cancel-in-progress: true
+    env:
+      REVISION_DATA_DIR: revision-data
+    steps:
       - name: Write step summary
         run: |
           url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-releases.outputs.run-id }}'

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -27,6 +27,16 @@ on:
         required: false
         type: string
         default: "default-id"
+    workflow_call:
+      inputs:
+        oci-image-name:
+          description: "OCI image to build and test"
+          required: true
+        upload:
+          description: "Upload image to GHCR"
+          required: true
+          type: boolean
+          default: false
 
 env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"
@@ -460,20 +470,11 @@ jobs:
           key: ${{ github.run_id }}-image-trigger
 
       - name: Dispatch Releases workflow
-        # Using this action because others can have this problem:
-        # https://github.com/convictional/trigger-workflow-and-wait/issues/61
-        uses: mathze/workflow-dispatch-action@v1.2.0
+        uses: canonical/oci-factory/.github/workflows/Release.yaml@main
         id: run-releases
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.ref_name }}
-          fail-on-error: true
-          workflow-name: Release.yaml
-          payload: '{ "oci-image-name": "${{ needs.prepare-build.outputs.oci-img-name }}", "image-trigger-cache-key": "${{ github.run_id }}-image-trigger"}'
-          run-id: dummy
-          trigger-timeout: "10m"
-          wait-timeout: "20m"
-          use-marker-step: true
+          oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
+          image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
 
       - name: Write step summary
         run: |

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -474,7 +474,7 @@ jobs:
     needs: [prepare-releases]
     uses: ./.github/workflows/Release.yaml
     with:
-      oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
+      oci-image-name: "${{ inputs.oci-image-name }}"
       image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
     secrets: inherit
 

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -147,8 +147,8 @@ jobs:
           files: oci/${{ inputs.oci-image-name }}/_releases.json
 
 
-  dispatch-documentation:
-    name: Dispatch documentation
+  update-documentation:
+    name: Update documentation
     needs: [do-releases]
     uses: ./.github/workflows/Documentation.yaml
     with:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -16,6 +16,16 @@ on:
         required: false
         type: string
         default: "default-id"
+  workflow_call:
+    inputs:
+      oci-image-name:
+        description: 'OCI image to run releases for'
+        required: true
+        type: string
+      image-trigger-cache-key:
+        description: 'Cache key (to fetch image trigger from cache)'
+        required: false
+        type: string
            
 jobs:
   validate-push-release-request:
@@ -143,19 +153,10 @@ jobs:
     needs: [do-releases]
     steps:
       - name: Run documentation
-        # Using this actions cause others can have this problem:
-        # https://github.com/convictional/trigger-workflow-and-wait/issues/61
-        uses: mathze/workflow-dispatch-action@v1.2.0
+        uses: canonical/oci-factory/.github/workflows/Documentation.yaml@main
         id: run-documentation
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.ref_name }}
-          fail-on-error: true
-          workflow-name: Documentation.yaml
-          payload: '{ "oci-image-name": "${{ inputs.oci-image-name }}"}'
-          use-marker-step: true
-          trigger-timeout: '30m'
-          run-id: dummy
+          oci-image-name: "${{ inputs.oci-image-name }}"
 
       - name: Write step summary
         run: |

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -150,29 +150,10 @@ jobs:
   dispatch-documentation:
     name: Dispatch documentation
     needs: [do-releases]
-    uses: canonical/oci-factory/.github/workflows/Documentation.yaml@main
+    uses: ./.github/workflows/Documentation.yaml
     with:
       oci-image-name: "${{ inputs.oci-image-name }}"
     secrets: inherit
-
-
-  write-documentation-dispatch-summary:
-    runs-on: ubuntu-22.04
-    name: Write documentation dispatch summary
-    needs: [dispatch-documentation]
-    steps:
-      - name: Write step summary
-        run: |
-          url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-documentation.outputs.run-id }}'
-          echo " - Triggered documentation updates for '${{ inputs.oci-image-name }}' at [${url}](${url})" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Enforce docs conclusion
-        if: ${{ steps.run-documentation.outputs.run-conclusion != 'success' }}
-        # The previous step doesn't always raise an error
-        run: |
-          url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-documentation.outputs.run-id }}'
-          echo "Failed to generate docs for '${{ inputs.oci-image-name }}' at [${url}](${url})."
-          exit 1
 
 
   do-github-release:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -148,16 +148,19 @@ jobs:
 
 
   dispatch-documentation:
-    runs-on: ubuntu-22.04
     name: Dispatch documentation
     needs: [do-releases]
-    steps:
-      - name: Run documentation
-        uses: canonical/oci-factory/.github/workflows/Documentation.yaml@main
-        id: run-documentation
-        with:
-          oci-image-name: "${{ inputs.oci-image-name }}"
+    uses: canonical/oci-factory/.github/workflows/Documentation.yaml@main
+    with:
+      oci-image-name: "${{ inputs.oci-image-name }}"
+    secrets: inherit
 
+
+  write-documentation-dispatch-summary:
+    runs-on: ubuntu-22.04
+    name: Write documentation dispatch summary
+    needs: [dispatch-documentation]
+    steps:
       - name: Write step summary
         run: |
           url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-documentation.outputs.run-id }}'

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -18,20 +18,11 @@ jobs:
         oci-image: [mock-rock]
     steps:
       - name: Trigger image workflows for ${{ matrix.oci-image }}
-        # Using this actions cause others can have this problem:
-        # https://github.com/convictional/trigger-workflow-and-wait/issues/61
-        uses: mathze/workflow-dispatch-action@v1.2.0
+        uses: canonical/oci-factory/.github/workflows/Image.yaml@main
         id: run-image
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.ref_name }}
-          fail-on-error: true
-          workflow-name: Image.yaml
-          payload: '{ "oci-image-name": "${{ matrix.oci-image }}", "upload": true }'
-          trigger-timeout: "5m"
-          wait-timeout: "30m"
-          use-marker-step: true
-          run-id: dummy
+          oci-image-name: "${{ matrix.oci-image }}"
+          upload: true
 
       - name: Enforce conclusion
         if: ${{ steps.run-image.outputs.run-conclusion != 'success' }}

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -11,19 +11,24 @@ on:
 
 jobs:
   test-workflows:
+    name: Trigger image workflows for ${{ matrix.oci-image }}
+    strategy:
+      matrix:
+        oci-image: [mock-rock]
+    uses: canonical/oci-factory/.github/workflows/Image.yaml@main
+    with:
+      oci-image-name: "${{ matrix.oci-image }}"
+      upload: true
+    secrets: inherit
+
+  enforce-conclusion:
     name: Test OCI Factory workflows
+    needs: [test-workflows]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         oci-image: [mock-rock]
     steps:
-      - name: Trigger image workflows for ${{ matrix.oci-image }}
-        uses: canonical/oci-factory/.github/workflows/Image.yaml@main
-        id: run-image
-        with:
-          oci-image-name: "${{ matrix.oci-image }}"
-          upload: true
-
       - name: Enforce conclusion
         if: ${{ steps.run-image.outputs.run-conclusion != 'success' }}
         # The previous step doesn't always raise an error

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -15,24 +15,8 @@ jobs:
     strategy:
       matrix:
         oci-image: [mock-rock]
-    uses: canonical/oci-factory/.github/workflows/Image.yaml@main
+    uses: ./.github/workflows/Image.yaml
     with:
       oci-image-name: "${{ matrix.oci-image }}"
       upload: true
     secrets: inherit
-
-  enforce-conclusion:
-    name: Test OCI Factory workflows
-    needs: [test-workflows]
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        oci-image: [mock-rock]
-    steps:
-      - name: Enforce conclusion
-        if: ${{ steps.run-image.outputs.run-conclusion != 'success' }}
-        # The previous step doesn't always raise an error
-        run: |
-          url='${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ steps.run-image.outputs.run-id }}'
-          echo "Image '${{ matrix.oci-image }}' workflow at [${url}](${url}) failed."
-          exit 1

--- a/IMAGE_MAINTAINER_AGREEMENT.md
+++ b/IMAGE_MAINTAINER_AGREEMENT.md
@@ -159,7 +159,7 @@ and stating:
       deb-security-manifest:
         plugin: nil
         after:
-          - # make this runs after all other parts that install overlay packages
+          - # make this run after all other parts that install overlay packages
         override-prime: |
           set -x
           mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -12,13 +12,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "167"
+            "target": "168"
         },
         "beta": {
-            "target": "167"
+            "target": "168"
         },
         "edge": {
-            "target": "167"
+            "target": "168"
         }
     },
     "test": {

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -1,32 +1,32 @@
 {
     "latest": {
         "candidate": {
-            "target": "151"
+            "target": "1.0-22.04_candidate"
         },
         "beta": {
-            "target": "151"
+            "target": "latest_candidate"
         },
         "edge": {
-            "target": "151"
+            "target": "latest_beta"
         }
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "151"
+            "target": "164"
         },
         "beta": {
-            "target": "151"
+            "target": "164"
         },
         "edge": {
-            "target": "151"
+            "target": "164"
         }
     },
     "test": {
         "beta": {
-            "target": "151"
+            "target": "1.0-22.04_beta"
         },
         "edge": {
-            "target": "151"
+            "target": "test_beta"
         }
     }
 }

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -12,13 +12,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "164"
+            "target": "167"
         },
         "beta": {
-            "target": "164"
+            "target": "167"
         },
         "edge": {
-            "target": "164"
+            "target": "167"
         }
     },
     "test": {


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

Currently, workflows in `Documentation.yaml`, `Image.yaml` and `Release.yaml` are dispatched via `mathze/workflow-dispatch-action`. We’ll still still need the dispatch on some, at least for those that the Temporal workflows will trigger. But internally (on PRs and commits), those workflows are to be made callable.
