### PR TITLE
fix: replace workflow call/dispatch check with more reliable tests

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -51,11 +51,12 @@ jobs:
         run: |
           set -ex
 
-          case "${{ github.event_name }}" in
-          workflow_dispatch|workflow_call)
+          # check if this is coming from a workflow dispatch/call
+          # as checking github.event_name isn't reliable here
+          if [ "${{ inputs.oci-image-name }}" != "" ]
+          then
             img_path="oci/${{ inputs.oci-image-name }}"
-            ;;
-          *)
+          else
             img_path="${{ steps.changed-files.outputs.all_changed_files }}"
             occurrences="${img_path//[^,]}"
             if [ ${#occurrences} -ne 0 ]
@@ -63,8 +64,7 @@ jobs:
               echo "ERR: can only build documentation for 1 image at a time, but trying to document ${img_path}"
               exit 1
             fi
-            ;;
-          esac
+          fi
           test -d "${img_path}"
           echo "img-name=$(basename ${img_path})" >> "$GITHUB_OUTPUT"
           echo "img-path=${img_path}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -74,11 +74,12 @@ jobs:
         run: |
           set -ex
 
-          case "${{ github.event_name }}" in
-          workflow_dispatch|workflow_call)
+          # check if this is coming from a workflow dispatch/call
+          # as checking github.event_name isn't reliable here
+          if [ "${{ inputs.oci-image-name }}" != "" ]
+          then
             img_path="oci/${{ inputs.oci-image-name }}"
-            ;;
-          *)
+          else
             img_path="${{ steps.changed-files.outputs.all_changed_files }}"
             occurrences="${img_path//[^,]}"
             if [ ${#occurrences} -ne 0 ]
@@ -86,8 +87,7 @@ jobs:
               echo "ERR: can only build 1 image at a time, but trying to trigger ${img_path}"
               exit 1
             fi
-            ;;
-          esac
+          fi
           test -d "${img_path}"
 
           echo "img-name=$(basename ${img_path})" >> "$GITHUB_OUTPUT"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -12,13 +12,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "169"
+            "target": "170"
         },
         "beta": {
-            "target": "169"
+            "target": "170"
         },
         "edge": {
-            "target": "169"
+            "target": "170"
         }
     },
     "test": {


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Follow up on merged PR#123, since _Tests workflow didn't seem to pass after the merge.

This changes the check for worflow dispatch/call from relying on `github.event_name` to check whether `inputs.oci-image-name` exists, as the latter is always provided by a workflow dispatch/call.

The issue arised from the fact the the called workflows are inherting the event name from their calling parents, so `github.event_name` isn't a fit anymore for the current purpose.
