### PR TITLE
fix: extract revision numbers only from the revision dicts

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "185"
+            "target": "186"
         },
         "beta": {
-            "target": "185"
+            "target": "186"
         },
         "edge": {
-            "target": "185"
+            "target": "186"
         },
         "end-of-life": "2024-05-01T00:00:00Z"
     },

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "184"
+            "target": "185"
         },
         "beta": {
-            "target": "184"
+            "target": "185"
         },
         "edge": {
-            "target": "184"
+            "target": "185"
         },
         "end-of-life": "2024-05-01T00:00:00Z"
     },

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "183"
+            "target": "184"
         },
         "beta": {
-            "target": "183"
+            "target": "184"
         },
         "edge": {
-            "target": "183"
+            "target": "184"
         },
         "end-of-life": "2024-05-01T00:00:00Z"
     },

--- a/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -56,6 +56,8 @@ def find_released_revisions(releases_json: dict) -> list:
             try:
                 if isinstance(targets, dict):
                     revision = int(targets["target"])
+                else:
+                    continue
             except ValueError:
                 # this target is following another tag and thus is not
                 # a revision number

--- a/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -54,7 +54,8 @@ def find_released_revisions(releases_json: dict) -> list:
     for track, risks in releases_json.items():
         for risk, targets in risks.items():
             try:
-                revision = int(targets["target"])
+                if isinstance(targets, dict):
+                    revision = int(targets["target"])
             except ValueError:
                 # this target is following another tag and thus is not
                 # a revision number

--- a/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -54,11 +54,8 @@ def find_released_revisions(releases_json: dict) -> list:
     for track, risks in releases_json.items():
         for risk, targets in risks.items():
             try:
-                if isinstance(targets, dict):
-                    revision = int(targets["target"])
-                else:
-                    continue
-            except ValueError:
+                revision = int(targets["target"])
+            except (ValueError, TypeError):
                 # this target is following another tag and thus is not
                 # a revision number
                 continue


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Fix issue in https://github.com/canonical/oci-factory/actions/runs/8073081089/job/22056099446 caused by eol value being misused as a revisions dict.

