### PR TITLE
feat: add support for arm64 runners and builds

### DIFF
--- a/.github/workflows/Announcements.yaml
+++ b/.github/workflows/Announcements.yaml
@@ -18,7 +18,7 @@ jobs:
       mattermost-channels: ${{ steps.get-contacts.outputs.mattermost-channels }}
       oci-img-name: ${{ steps.get-image-name.outputs.img-name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get image name
         id: get-image-name
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build release summary
         id: get-summary
@@ -79,7 +79,7 @@ jobs:
     needs: [get-contacts]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build package summary
         id: get-summary

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -104,7 +104,7 @@ jobs:
           git clone ${{ inputs.rock-repo }} .
       - run: git checkout ${{ inputs.rock-repo-commit }}
       - if: ${{ matrix.architecture != 'amd64' }}
-        run: snap install yq --channel=v4/stable
+        run: sudo snap install yq --channel=v4/stable
       - name: Validate image naming and base
         working-directory: ${{ inputs.rockfile-directory }}
         run: |

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -1,0 +1,68 @@
+name: Build rock
+
+on:
+  workflow_call:
+    inputs:
+      oci-archive-name:
+        description: "Final filename of the rock's OCI archive"
+        type: string
+        required: true
+      oci-factory-path:
+        description: "Path, in the OCI Factory, to this rock"
+        type: string
+        required: true
+      rock-name:
+        description: "Name of the rock"
+        type: string
+        required: true
+      rock-repo:
+        description: "Public Git repo where to build the rock from"
+        type: string
+        required: true
+      rock-repo-commit:
+        description: "Git ref from where to build the rock from"
+        type: string
+        required: true
+      rockfile-directory:
+        description: "Directory, in 'rock-repo', where to find the rockcraft.yaml file"
+        type: string
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone GitHub image repository
+        uses: actions/checkout@v3
+        id: clone-image-repo
+        continue-on-error: true
+        with:
+          repository: ${{ inputs.rock-repo }}
+          fetch-depth: 0
+      - name: Clone generic image repository
+        if: ${{ steps.clone-image-repo.outcome == 'failure' }}
+        run: |
+          git clone ${{ inputs.rock-repo }} .
+      - run: git checkout ${{ inputs.rock-repo-commit }}
+      - name: Validate image naming and base
+        working-directory: ${{ inputs.rockfile-directory }}
+        run: |
+          rock_name=`cat rockcraft.y*ml | yq -r .name`
+          if [[ "${{ inputs.oci-factory-path }}" != *"${rock_name}"* ]]
+          then
+            echo "ERROR: the ROCK's name '${rock_name}' must match the OCI folder name!"
+            exit 1
+          fi
+      - name: Build ROCK ${{ inputs.rock-name }}
+        id: rockcraft
+        uses: canonical/craft-actions/rockcraft-pack@main
+        with:
+          path: "${{ inputs.rockfile-directory }}"
+          verbosity: debug
+      - name: Rename ROCK OCI archive
+        run: |
+          mv ${{ steps.rockcraft.outputs.rock }} ${{ inputs.oci-archive-name }}
+      - uses: actions/cache/save@v3
+        with:
+          path: ${{ inputs.oci-archive-name }}
+          key: ${{ github.run_id }}-${{ inputs.oci-archive-name }}

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -27,6 +27,10 @@ on:
         description: "Directory, in 'rock-repo', where to find the rockcraft.yaml file"
         type: string
         required: true
+    outputs:
+      rock-cache-key:
+        description: "The cache key where other jobs can restore the assembled rock from"
+        value: ${{ jobs.assemble-rock.outputs.rock-cache-key }}
 
 jobs:
   prepare-multi-arch-matrix:
@@ -90,6 +94,8 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-multi-arch-matrix.outputs.build-for) }}
     runs-on: ${{ matrix.runner }}
     name: 'Build ${{ inputs.rock-name }} | ${{ matrix.architecture }}'
+    outputs:
+      multi-arch-cache-key: ${{ steps.multi-arch-cache-key.outputs.value }}
     steps:
       - name: Clone GitHub image repository
         uses: actions/checkout@v3
@@ -103,7 +109,7 @@ jobs:
         run: |
           git clone ${{ inputs.rock-repo }} .
       - run: git checkout ${{ inputs.rock-repo-commit }}
-      - if: ${{ matrix.architecture != 'amd64' }}
+      - if: matrix.architecture != 'amd64'
         run: sudo snap install yq --channel=v4/stable
       - name: Validate image naming and base
         working-directory: ${{ inputs.rockfile-directory }}
@@ -121,35 +127,49 @@ jobs:
           path: "${{ inputs.rockfile-directory }}"
           verbosity: debug
       - name: Rename ROCK OCI archive
+        id: rock
         run: |
-          mv ${{ steps.rockcraft.outputs.rock }} ${{ inputs.oci-archive-name }}
+          mv ${{ steps.rockcraft.outputs.rock }} $(basename ${{ steps.rockcraft.outputs.rock }})
+          echo "filename=$(basename ${{ steps.rockcraft.outputs.rock }})" >> $GITHUB_OUTPUT
       - name: Upload ${{ inputs.rock-name }} for ${{ matrix.architecture }}
         uses: actions/upload-artifact@v3
-        env:
-          NAME: ${{ needs.prepare-multi-arch-matrix.outputs.is-multi-arch == 1 && format('{0}-{1}', inputs.oci-archive-name, matrix.architecture) || inputs.oci-archive-name }}
         with:
-          name: ${{ env.NAME }}
-          path: ${{ inputs.oci-archive-name }}
+          name: ${{ steps.rock.outputs.filename }}
+          path: ${{ steps.rock.outputs.filename }}
           if-no-files-found: error
+      - id: multi-arch-cache-key
+        run: echo "value=${{ github.run_id }}-multi-arch" >> $GITHUB_OUTPUT
+      - uses: actions/cache/save@v3
+        with:
+          path: ${{ steps.rock.outputs.filename }}
+          key: ${{ steps.multi-arch-cache-key.outputs.value }}
 
-  create-multi-arch-rock:
+  assemble-rock:
     needs: [prepare-multi-arch-matrix, build]
     runs-on: ubuntu-22.04
-    if: needs.prepare-multi-arch-matrix.outputs.is-multi-arch == 1
     env:
       DOWNLOAD_PATH: rocks
+    outputs:
+      rock-cache-key: ${{ steps.rock-cache-key.outputs.value }}
     steps:
-      - run: apt update && apt install buildah
+      - run: sudo apt update && sudo apt install buildah -y
       - uses: actions/download-artifact@v4
         with:
           path: ${{ env.DOWNLOAD_PATH }}
-          pattern: ${{ inputs.oci-archive-name }}-*
           merge-multiple: true
+      - uses: actions/cache/restore@v3
+        with:
+          path: ${{ inputs.rock-name }}*rock
+          key: ${{ needs.build.outputs.multi-arch-cache-key }}
+          fail-on-cache-miss: true
       - name: Merge single-arch rocks into multi-arch OCI archive
         run: |
+          set -xe
+          ls ./*
           buildah manifest create multi-arch-rock
-          for rock in `find ${{ env.DOWNLOAD_PATH }}`
+          for rock in `find *.rock`
           do
+            test -f $rock
             buildah manifest add multi-arch-rock oci-archive:$rock
           done
           buildah manifest push --all multi-arch-rock oci-archive:${{ inputs.oci-archive-name }}
@@ -159,3 +179,9 @@ jobs:
           name: ${{ inputs.oci-archive-name }}
           path: ${{ inputs.oci-archive-name }}
           if-no-files-found: error
+      - id: rock-cache-key
+        run: echo "value=${{ github.run_id }}-${{ inputs.oci-archive-name }}" >> $GITHUB_OUTPUT
+      - uses: actions/cache/save@v3
+        with:
+          path: ${{ inputs.oci-archive-name }}
+          key: ${{ steps.rock-cache-key.outputs.value }}

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -32,6 +32,9 @@ on:
         description: "The cache key where other jobs can restore the assembled rock from"
         value: ${{ jobs.assemble-rock.outputs.rock-cache-key }}
 
+env:
+  ROCKS_CI_FOLDER: ci-rocks
+
 jobs:
   prepare-multi-arch-matrix:
     runs-on: ubuntu-22.04
@@ -129,19 +132,21 @@ jobs:
       - name: Rename ROCK OCI archive
         id: rock
         run: |
-          mv ${{ steps.rockcraft.outputs.rock }} $(basename ${{ steps.rockcraft.outputs.rock }})
+          mkdir ${{ env.ROCKS_CI_FOLDER }}
+          cp ${{ steps.rockcraft.outputs.rock }} ${{ env.ROCKS_CI_FOLDER }}/$(basename ${{ steps.rockcraft.outputs.rock }})
           echo "filename=$(basename ${{ steps.rockcraft.outputs.rock }})" >> $GITHUB_OUTPUT
+
       - name: Upload ${{ inputs.rock-name }} for ${{ matrix.architecture }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.rock.outputs.filename }}
-          path: ${{ steps.rock.outputs.filename }}
+          path: ${{ steps.rockcraft.outputs.rock }}
           if-no-files-found: error
       - id: multi-arch-cache-key
         run: echo "value=${{ github.run_id }}-multi-arch" >> $GITHUB_OUTPUT
       - uses: actions/cache/save@v4
         with:
-          path: ${{ steps.rock.outputs.filename }}
+          path: ${{ env.ROCKS_CI_FOLDER }}
           key: ${{ steps.multi-arch-cache-key.outputs.value }}
 
   assemble-rock:
@@ -152,18 +157,15 @@ jobs:
     outputs:
       rock-cache-key: ${{ steps.rock-cache-key.outputs.value }}
     steps:
-      - run: sudo apt update && sudo apt install buildah -y
       - uses: actions/download-artifact@v4
-        with:
-          path: ${{ env.DOWNLOAD_PATH }}
-          merge-multiple: true
       - uses: actions/cache/restore@v4
         with:
-          path: ${{ inputs.rock-name }}*rock
+          path: ${{ env.ROCKS_CI_FOLDER }}
           key: ${{ needs.build.outputs.multi-arch-cache-key }}
           fail-on-cache-miss: true
       - name: Merge single-arch rocks into multi-arch OCI archive
         run: |
+          sudo apt update && sudo apt install buildah -y
           set -xe
           ls ./*
           buildah manifest create multi-arch-rock

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -40,7 +40,7 @@ jobs:
       is-multi-arch: ${{ steps.rock-platforms.outputs.is-multi-arch }}
     steps:
       - name: Clone GitHub image repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         id: clone-image-repo
         continue-on-error: true
         with:
@@ -51,7 +51,7 @@ jobs:
         run: |
           git clone ${{ inputs.rock-repo }} .
       - run: git checkout ${{ inputs.rock-repo-commit }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - run: pip install pyyaml
@@ -98,7 +98,7 @@ jobs:
       multi-arch-cache-key: ${{ steps.multi-arch-cache-key.outputs.value }}
     steps:
       - name: Clone GitHub image repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         id: clone-image-repo
         continue-on-error: true
         with:
@@ -132,14 +132,14 @@ jobs:
           mv ${{ steps.rockcraft.outputs.rock }} $(basename ${{ steps.rockcraft.outputs.rock }})
           echo "filename=$(basename ${{ steps.rockcraft.outputs.rock }})" >> $GITHUB_OUTPUT
       - name: Upload ${{ inputs.rock-name }} for ${{ matrix.architecture }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.rock.outputs.filename }}
           path: ${{ steps.rock.outputs.filename }}
           if-no-files-found: error
       - id: multi-arch-cache-key
         run: echo "value=${{ github.run_id }}-multi-arch" >> $GITHUB_OUTPUT
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         with:
           path: ${{ steps.rock.outputs.filename }}
           key: ${{ steps.multi-arch-cache-key.outputs.value }}
@@ -157,7 +157,7 @@ jobs:
         with:
           path: ${{ env.DOWNLOAD_PATH }}
           merge-multiple: true
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ inputs.rock-name }}*rock
           key: ${{ needs.build.outputs.multi-arch-cache-key }}
@@ -174,14 +174,14 @@ jobs:
           done
           buildah manifest push --all multi-arch-rock oci-archive:${{ inputs.oci-archive-name }}
       - name: Upload multi-arch ${{ inputs.oci-archive-name }} OCI archive
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.oci-archive-name }}
           path: ${{ inputs.oci-archive-name }}
           if-no-files-found: error
       - id: rock-cache-key
         run: echo "value=${{ github.run_id }}-${{ inputs.oci-archive-name }}" >> $GITHUB_OUTPUT
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         with:
           path: ${{ inputs.oci-archive-name }}
           key: ${{ steps.rock-cache-key.outputs.value }}

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -152,24 +152,23 @@ jobs:
   assemble-rock:
     needs: [prepare-multi-arch-matrix, build]
     runs-on: ubuntu-22.04
-    env:
-      DOWNLOAD_PATH: rocks
     outputs:
       rock-cache-key: ${{ steps.rock-cache-key.outputs.value }}
     steps:
       - uses: actions/download-artifact@v4
+        id: download
       - uses: actions/cache/restore@v4
         with:
           path: ${{ env.ROCKS_CI_FOLDER }}
           key: ${{ needs.build.outputs.multi-arch-cache-key }}
           fail-on-cache-miss: true
+      - run: sudo apt update && sudo apt install buildah -y
       - name: Merge single-arch rocks into multi-arch OCI archive
         run: |
-          sudo apt update && sudo apt install buildah -y
           set -xe
           ls ./*
           buildah manifest create multi-arch-rock
-          for rock in `find *.rock`
+          for rock in `find ${{ steps.download.outputs.download-path }} -name *.rock`
           do
             test -f $rock
             buildah manifest add multi-arch-rock oci-archive:$rock

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -29,8 +29,11 @@ on:
         required: true
 
 jobs:
-  build:
+  prepare-multi-arch-matrix:
     runs-on: ubuntu-22.04
+    outputs:
+      build-for: ${{ steps.rock-platforms.outputs.build-for }}
+      is-multi-arch: ${{ steps.rock-platforms.outputs.is-multi-arch }}
     steps:
       - name: Clone GitHub image repository
         uses: actions/checkout@v3
@@ -44,6 +47,64 @@ jobs:
         run: |
           git clone ${{ inputs.rock-repo }} .
       - run: git checkout ${{ inputs.rock-repo-commit }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install pyyaml
+      - name: Get rock archs
+        uses: jannekem/run-python-script-action@v1
+        id: rock-platforms
+        with:
+          script: |
+            import yaml
+            import os
+            with open("${{ inputs.rockfile-directory }}/rockcraft.yaml") as rf:
+              rockcraft_yaml = yaml.safe_load(rf)
+
+            platforms = rockcraft_yaml["platforms"]
+
+            target_archs = ["amd64"]
+            for platf, values in platforms.items():
+                if isinstance(values, dict) and "build-for" in values:
+                    target_archs += list(values["build-for"])
+                target_archs.append(platf)
+            
+            matrix = {"include": []}
+            for supported_arch, runner in {"amd64": "ubuntu-22.04", "arm64": "Ubuntu_ARM64_4C_16G_01"}.items():
+              if supported_arch in target_archs:
+                matrix["include"].append(
+                  {"architecture": supported_arch, "runner": runner}
+                )
+            
+            with open(os.environ["GITHUB_OUTPUT"], "a") as gh_out:
+              print(f"build-for={matrix}", file=gh_out)
+              is_multi_arch = 0
+              if len(matrix["include"]) > 1:
+                is_multi_arch = 1
+              print(f"is-multi-arch={is_multi_arch}", file=gh_out)
+
+  build:
+    needs: [prepare-multi-arch-matrix]
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.prepare-multi-arch-matrix.outputs.build-for) }}
+    runs-on: ${{ matrix.runner }}
+    name: 'Build ${{ inputs.rock-name }} | ${{ matrix.architecture }}'
+    steps:
+      - name: Clone GitHub image repository
+        uses: actions/checkout@v3
+        id: clone-image-repo
+        continue-on-error: true
+        with:
+          repository: ${{ inputs.rock-repo }}
+          fetch-depth: 0
+      - name: Clone generic image repository
+        if: ${{ steps.clone-image-repo.outcome == 'failure' }}
+        run: |
+          git clone ${{ inputs.rock-repo }} .
+      - run: git checkout ${{ inputs.rock-repo-commit }}
+      - if: ${{ matrix.architecture != 'amd64' }}
+        run: snap install yq --channel=v4/stable
       - name: Validate image naming and base
         working-directory: ${{ inputs.rockfile-directory }}
         run: |
@@ -62,7 +123,39 @@ jobs:
       - name: Rename ROCK OCI archive
         run: |
           mv ${{ steps.rockcraft.outputs.rock }} ${{ inputs.oci-archive-name }}
-      - uses: actions/cache/save@v3
+      - name: Upload ${{ inputs.rock-name }} for ${{ matrix.architecture }}
+        uses: actions/upload-artifact@v3
+        env:
+          NAME: ${{ needs.prepare-multi-arch-matrix.outputs.is-multi-arch == 1 && format('{0}-{1}', inputs.oci-archive-name, matrix.architecture) || inputs.oci-archive-name }}
         with:
+          name: ${{ env.NAME }}
           path: ${{ inputs.oci-archive-name }}
-          key: ${{ github.run_id }}-${{ inputs.oci-archive-name }}
+          if-no-files-found: error
+
+  create-multi-arch-rock:
+    needs: [prepare-multi-arch-matrix, build]
+    runs-on: ubuntu-22.04
+    if: needs.prepare-multi-arch-matrix.outputs.is-multi-arch == 1
+    env:
+      DOWNLOAD_PATH: rocks
+    steps:
+      - run: apt update && apt install buildah
+      - uses: actions/download-artifact@v4
+        with:
+          path: ${{ env.DOWNLOAD_PATH }}
+          pattern: ${{ inputs.oci-archive-name }}-*
+          merge-multiple: true
+      - name: Merge single-arch rocks into multi-arch OCI archive
+        run: |
+          buildah manifest create multi-arch-rock
+          for rock in `find ${{ env.DOWNLOAD_PATH }}`
+          do
+            buildah manifest add multi-arch-rock oci-archive:$rock
+          done
+          buildah manifest push --all multi-arch-rock oci-archive:${{ inputs.oci-archive-name }}
+      - name: Upload multi-arch ${{ inputs.oci-archive-name }} OCI archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.oci-archive-name }}
+          path: ${{ inputs.oci-archive-name }}
+          if-no-files-found: error

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -97,8 +97,6 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-multi-arch-matrix.outputs.build-for) }}
     runs-on: ${{ matrix.runner }}
     name: 'Build ${{ inputs.rock-name }} | ${{ matrix.architecture }}'
-    outputs:
-      multi-arch-cache-key: ${{ steps.multi-arch-cache-key.outputs.value }}
     steps:
       - name: Clone GitHub image repository
         uses: actions/checkout@v4
@@ -135,19 +133,12 @@ jobs:
           mkdir ${{ env.ROCKS_CI_FOLDER }}
           cp ${{ steps.rockcraft.outputs.rock }} ${{ env.ROCKS_CI_FOLDER }}/$(basename ${{ steps.rockcraft.outputs.rock }})
           echo "filename=$(basename ${{ steps.rockcraft.outputs.rock }})" >> $GITHUB_OUTPUT
-
       - name: Upload ${{ inputs.rock-name }} for ${{ matrix.architecture }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.rock.outputs.filename }}
           path: ${{ steps.rockcraft.outputs.rock }}
           if-no-files-found: error
-      - id: multi-arch-cache-key
-        run: echo "value=${{ github.run_id }}-multi-arch" >> $GITHUB_OUTPUT
-      - uses: actions/cache/save@v4
-        with:
-          path: ${{ env.ROCKS_CI_FOLDER }}
-          key: ${{ steps.multi-arch-cache-key.outputs.value }}
 
   assemble-rock:
     needs: [prepare-multi-arch-matrix, build]
@@ -157,18 +148,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         id: download
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.ROCKS_CI_FOLDER }}
-          key: ${{ needs.build.outputs.multi-arch-cache-key }}
-          fail-on-cache-miss: true
       - run: sudo apt update && sudo apt install buildah -y
       - name: Merge single-arch rocks into multi-arch OCI archive
         run: |
           set -xe
           ls ./*
           buildah manifest create multi-arch-rock
-          for rock in `find ${{ steps.download.outputs.download-path }} -name *.rock`
+          for rock in `find *.rock/*`
           do
             test -f $rock
             buildah manifest add multi-arch-rock oci-archive:$rock

--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -12,8 +12,8 @@ jobs:
       released-revisions-matrix: ${{ steps.prepare-test-matrix.outputs.released-revisions-matrix }}
       last-scan: ${{ steps.last-scan.outputs.date }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - run: pip install -r src/tests/requirements.txt

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -34,7 +34,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Infer images to document
         uses: tj-actions/changed-files@v35
@@ -77,9 +77,9 @@ jobs:
     env:
       IS_PROD: ${{ ! startsWith(needs.validate-documentation-request.outputs.oci-img-name, 'mock-') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -116,7 +116,7 @@ jobs:
             --doc-data-dir data
       
       - name: Upload documentation data YAML
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: '${{ needs.validate-documentation-request.outputs.oci-img-name }}.doc.yaml'
           path: "${{ steps.generate-documentation.outputs.image_doc_folder }}/*.y*ml"
@@ -145,9 +145,9 @@ jobs:
     needs: [validate-documentation-request, do-documentation]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name != 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -1,5 +1,5 @@
 name: Image
-run-name: 'Image - ${{ inputs.oci-image-name }} - ${{ github.ref }}'
+run-name: 'Image - ${{ inputs.oci-image-name || github.triggering_actor }} - ${{ github.ref }}'
 
 on:
   push:
@@ -135,55 +135,19 @@ jobs:
           key: ${{ steps.prepare-matrix.outputs.revision-data-cache-key }}
 
   run-build:
-    runs-on: ubuntu-22.04
     needs: [prepare-build]
-    name: Build
     strategy:
       fail-fast: true
       matrix: ${{ fromJSON(needs.prepare-build.outputs.build-matrix) }}
-    env:
-      OCI_ARCHIVE_NAME: ${{ matrix.name }}_${{ matrix.commit }}_${{ matrix.revision }}
-    steps:
-      - name: Clone GitHub image repository
-        uses: actions/checkout@v3
-        id: clone-image-repo
-        continue-on-error: true
-        with:
-          repository: ${{ matrix.source }}
-          fetch-depth: 0
-
-      - name: Clone generic image repository
-        if: ${{ steps.clone-image-repo.outcome == 'failure' }}
-        run: |
-          git clone ${{ matrix.source }} .
-
-      - run: git checkout ${{ matrix.commit }}
-
-      - name: Validate image naming and base
-        working-directory: ${{ matrix.directory }}
-        run: |
-          rock_name=`cat rockcraft.y*ml | yq -r .name`
-          if [[ "${{ matrix.path }}" != *"${rock_name}"* ]]
-          then
-            echo "ERROR: the ROCK's name '${rock_name}' must match the OCI folder name!"
-            exit 1
-          fi
-
-      - name: Build ROCK ${{ matrix.name }}
-        id: rockcraft
-        uses: canonical/craft-actions/rockcraft-pack@main
-        with:
-          path: "${{ matrix.directory }}"
-          verbosity: debug
-
-      - name: Rename ROCK OCI archive
-        run: |
-          mv ${{ steps.rockcraft.outputs.rock }} ${{ env.OCI_ARCHIVE_NAME }}
-
-      - uses: actions/cache/save@v3
-        with:
-          path: ${{ env.OCI_ARCHIVE_NAME }}
-          key: ${{ github.run_id }}-${{ env.OCI_ARCHIVE_NAME }}
+    uses: ./.github/workflows/Build-Rock.yaml
+    with:
+      oci-archive-name: ${{ matrix.name }}_${{ matrix.commit }}_${{ matrix.revision }}
+      oci-factory-path: ${{ matrix.path }}
+      rock-name: ${{ matrix.name }}
+      rock-repo: ${{ matrix.source }}
+      rock-repo-commit: ${{ matrix.commit }}
+      rockfile-directory: ${{ matrix.directory }}
+    secrets: inherit
 
   test:
     needs: [prepare-build, run-build]

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -160,7 +160,7 @@ jobs:
       oci-image-name: "${{ matrix.name }}_${{ matrix.commit }}_${{ matrix.revision }}"
       oci-image-path: "oci/${{ matrix.name }}"
       test-from: "cache"
-      cache-key: "${{ github.run_id }}-${{ matrix.name }}_${{ matrix.commit }}_${{ matrix.revision }}"
+      cache-key: ${{ needs.run-build.outputs.rock-cache-key }}
     secrets: inherit
 
   upload:
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/cache/restore@v3
         with:
           path: ${{ env.OCI_ARCHIVE_NAME }}
-          key: ${{ github.run_id }}-${{ env.OCI_ARCHIVE_NAME }}
+          key: ${{ needs.run-build.outputs.rock-cache-key }}
           fail-on-cache-miss: true
 
       - name: Infer track name

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Infer number of image triggers
         uses: tj-actions/changed-files@v35
@@ -97,7 +97,7 @@ jobs:
         if: ${{ inputs.b64-image-trigger != '' }}
         run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ steps.validate-image.outputs.img-path }}/image.yaml
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -129,7 +129,7 @@ jobs:
 
           echo "revision-data-cache-key=${{ github.run_id }}-${{ env.DATA_DIR }}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         with:
           path: ${{ steps.prepare-matrix.outputs.revision-data-dir }}
           key: ${{ steps.prepare-matrix.outputs.revision-data-cache-key }}
@@ -176,9 +176,9 @@ jobs:
     outputs:
       artefacts-hashes: ${{ steps.artefacts-hashes.outputs.hashes }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -196,7 +196,7 @@ jobs:
           pip install -r src/uploads/requirements.txt -r src/image/requirements.txt
 
       - name: Clone GitHub image repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         id: clone-image-repo
         continue-on-error: true
         with:
@@ -211,7 +211,7 @@ jobs:
 
       - run: cd source && git checkout ${{ matrix.commit }}
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ env.OCI_ARCHIVE_NAME }}
           key: ${{ needs.run-build.outputs.rock-cache-key }}
@@ -233,7 +233,7 @@ jobs:
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "canonical-tag=${canonical_tag}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         with:
           path: ${{ steps.rename-oci-archive.outputs.name }}
           key: ${{ github.run_id }}-${{ steps.rename-oci-archive.outputs.name }}
@@ -284,7 +284,7 @@ jobs:
           echo "sboms=${all_sboms_zip}" >> "$GITHUB_OUTPUT"
 
       - name: Fetch vulnerability artifacts for hashing
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.OCI_ARCHIVE_NAME }}${{ env.VULNERABILITY_REPORT_SUFFIX }}
           key: ${{ github.run_id }}-${{ env.OCI_ARCHIVE_NAME }}${{ env.VULNERABILITY_REPORT_SUFFIX }}
@@ -309,14 +309,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.generate-sboms.outputs.sboms }}
           path: ${{ steps.generate-sboms.outputs.sboms }}
           if-no-files-found: error
 
       - name: Upload image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.rename-oci-archive.outputs.name }}
           path: ${{ steps.rename-oci-archive.outputs.name }}
@@ -387,11 +387,11 @@ jobs:
     env:
       REVISION_DATA_DIR: revision-data
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -399,7 +399,7 @@ jobs:
         if: ${{ inputs.b64-image-trigger != '' }}
         run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ env.REVISION_DATA_DIR }}
           key: ${{ needs.prepare-build.outputs.revision-data-cache-key }}
@@ -431,7 +431,7 @@ jobs:
               --revision-data-file "${{ env.REVISION_DATA_DIR }}/${revision_file}"
           done
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         with:
           path: ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
           key: ${{ github.run_id }}-image-trigger
@@ -477,7 +477,7 @@ jobs:
       #     cosign sign-blob --key cosign.key --output-signature provenance.json.sig provenance.json
 
       # - name: Upload verification keys
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: verify
       #     path: |
@@ -490,14 +490,14 @@ jobs:
       #   run: sha256sum * > SHA256SUMS || true
 
       # - name: Upload SHA256SUMS file
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: SHA256SUMS
       #     path: SHA256SUMS
       #     if-no-files-found: error
 
       - name: Upload provenance file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: provenance
           path: provenance.json
@@ -520,9 +520,9 @@ jobs:
     needs: [prepare-build, run-build, upload, prepare-releases, generate-provenance]
     if: ${{ always() && contains(needs.*.result, 'failure') && github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -12,7 +12,7 @@ jobs:
       changed-files-matrix: ${{ steps.changed-files-matrix.outputs.matrix }}
       image-name: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get changed files
         id: changed-files
@@ -50,7 +50,7 @@ jobs:
     # temporarily continue on error, until the Notification and Doc update jobs are set
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check if documentation.yaml exists
         uses: andstor/file-existence-action@v2
@@ -72,9 +72,9 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.get-submitted-files.outputs.changed-files-matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: ${{ inputs.external_ref_id }} #(2)
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
         
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Infer number of image triggers
         uses: tj-actions/changed-files@v35
@@ -70,16 +70,16 @@ jobs:
     env:
       IS_PROD: ${{ ! startsWith(inputs.oci-image-name, 'mock-') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         if: ${{ inputs.image-trigger-cache-key != '' }}
         with:
           path: oci/${{ inputs.oci-image-name }}/image.yaml
           key: ${{ inputs.image-trigger-cache-key }}
           fail-on-cache-miss: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -164,7 +164,7 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.do-releases.outputs.gh-releases-matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
             fetch-depth: 0
             ref: ${{ matrix.canonical-tag }}

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: ${{ inputs.external_ref_id }} #(2)
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
         
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         if: ${{ inputs.test-from == 'cache' }}
         with:
           path: ${{ inputs.oci-image-name }}
@@ -100,7 +100,7 @@ jobs:
             copy docker://${{ inputs.oci-image-name }} \
             oci:${{ env.TEST_IMAGE_NAME}}:${{ env.TEST_IMAGE_TAG }}
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         with:
           path: ${{ env.TEST_IMAGE_NAME}}
           key: ${{ github.run_id }}-${{ inputs.oci-image-name }}-${{ env.TEST_IMAGE_NAME }}
@@ -115,7 +115,7 @@ jobs:
     name: Test OCI compliance
     needs: [fetch-oci-image]
     steps:
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ env.TEST_IMAGE_NAME}}
           key: ${{ needs.fetch-oci-image.outputs.test-cache-key }}
@@ -143,7 +143,7 @@ jobs:
     name: Black-box and portability tests
     needs: [fetch-oci-image]
     steps:
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ env.TEST_IMAGE_NAME}}
           key: ${{ needs.fetch-oci-image.outputs.test-cache-key }}
@@ -174,9 +174,9 @@ jobs:
     # TODO: remove once https://chat.charmhub.io/charmhub/pl/o5wxpb65ffbfzy7bcmi8kzftzy is fixed
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ env.TEST_IMAGE_NAME}}
           key: ${{ needs.fetch-oci-image.outputs.test-cache-key }}
@@ -218,9 +218,9 @@ jobs:
     name: Malware scan
     needs: [fetch-oci-image]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: ${{ env.TEST_IMAGE_NAME}}
           key: ${{ github.run_id }}-${{ inputs.oci-image-name }}-${{ env.TEST_IMAGE_NAME }}
@@ -238,7 +238,7 @@ jobs:
             --image ${{ env.TEST_IMAGE_NAME}}:${{ env.TEST_IMAGE_TAG }} \
             --rootless raw
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -41,7 +41,7 @@ jobs:
       vulnerability-report: ${{ steps.vulnerability-report.outputs.name }}
       notify: ${{ steps.check-report.outputs.notify }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: vulnerability-report
         run: |
@@ -49,7 +49,7 @@ jobs:
           final_name="$(echo ${full_name} | sed 's/ghcr.io\/canonical\/oci-factory\///g' | tr ':' '_')"
           echo "name=$final_name" >> "$GITHUB_OUTPUT" 
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         if: ${{ inputs.cache-key != '' }}
         with:
           path: ${{ env.TEST_IMAGE_NAME}}
@@ -126,13 +126,13 @@ jobs:
             fi
           done
 
-      - uses: actions/cache/save@v3
+      - uses: actions/cache/save@v4
         if: ${{ always() }}
         with:
           path: ${{ steps.vulnerability-report.outputs.name }}
           key: ${{ github.run_id }}-${{ steps.vulnerability-report.outputs.name }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: ${{ steps.vulnerability-report.outputs.name }}
@@ -148,9 +148,9 @@ jobs:
       - test-vulnerabilities
     if: ${{ always() && needs.test-vulnerabilities.outputs.notify == 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/_Auto-updates.yaml
+++ b/.github/workflows/_Auto-updates.yaml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get updated filenames
         uses: tj-actions/changed-files@v35
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -1,10 +1,15 @@
-name: _Test OCI Factory
+name: _Test OCI Factory | mock-rock
 on:
-  push:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
     paths:
       - ".github/workflows/*"
       - "!.github/workflows/CLA-Check.yaml"
       - "!.github/workflows/PR-Validator.yaml"
+      - "!.github/workflows/_Auto-updates.yaml"
+      - "!.github/workflows/Continuous-Testing.yaml"
       - "oci/mock-*"
       - "examples/**"
       - "src/**"
@@ -12,12 +17,9 @@ on:
 
 jobs:
   test-workflows:
-    name: Trigger image workflows for ${{ matrix.oci-image }}
-    strategy:
-      matrix:
-        oci-image: [mock-rock]
+    name: Trigger internal tests for mock-rock
     uses: ./.github/workflows/Image.yaml
     with:
-      oci-image-name: "${{ matrix.oci-image }}"
+      oci-image-name: "mock-rock"
       upload: true
     secrets: inherit

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -8,6 +8,7 @@ on:
       - "oci/mock-*"
       - "examples/**"
       - "src/**"
+      - "!src/workflow-engine/**"
 
 jobs:
   test-workflows:

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -10,7 +10,6 @@ on:
       - "!.github/workflows/PR-Validator.yaml"
       - "!.github/workflows/_Auto-updates.yaml"
       - "!.github/workflows/Continuous-Testing.yaml"
-      - "oci/mock-*"
       - "examples/**"
       - "src/**"
       - "!src/workflow-engine/**"

--- a/examples/mock-rock/rockcraft.yaml
+++ b/examples/mock-rock/rockcraft.yaml
@@ -7,6 +7,7 @@ build-base: ubuntu:22.04
 license: Apache-2.0
 platforms:
   amd64:
+  arm64:
 
 parts:
   hello:

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -1,34 +1,34 @@
 {
     "latest": {
         "candidate": {
-            "target": "188"
+            "target": "1.0-22.04_candidate"
         },
         "beta": {
-            "target": "188"
+            "target": "latest_candidate"
         },
         "edge": {
-            "target": "188"
+            "target": "latest_beta"
         },
         "end-of-life": "2024-05-01T00:00:00Z"
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "188"
+            "target": "191"
         },
         "beta": {
-            "target": "188"
+            "target": "191"
         },
         "edge": {
-            "target": "188"
+            "target": "191"
         },
         "end-of-life": "2024-05-01T00:00:00Z"
     },
     "test": {
         "beta": {
-            "target": "188"
+            "target": "1.0-22.04_beta"
         },
         "edge": {
-            "target": "188"
+            "target": "test_beta"
         },
         "end-of-life": "2026-05-01T00:00:00Z"
     }

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -10,7 +10,7 @@ release:
     
 upload:  
   - source: "canonical/oci-factory"
-    commit: f661770134f29bd21541a465a47a859529e09877
+    commit: a7361a0cf634d726287026a0690fd9e644d05959
     directory: examples/mock-rock
     release:
       1.0-22.04:

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -10,7 +10,7 @@ release:
     
 upload:  
   - source: "canonical/oci-factory"
-    commit: a7361a0cf634d726287026a0690fd9e644d05959
+    commit: 30e73ac0dc4705c12baacbcba74106c8eda2cf9a
     directory: examples/mock-rock
     release:
       1.0-22.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
There are many commits in this PR, but they all contribute to the same:
 - finer control over when our internal tests run
 - get rid of nodejs warnings by bumping many 3rd party actions
 - make the build of rocks a reusable workflow
 - add support for our self-hosted ARM64 runners
 - use arm64 runners whenever the rock recipe asks for it
