### PR TITLE
fix: race condition between Image and _Test

### DIFF
--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -450,7 +450,7 @@ jobs:
     needs: [upload]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           path: artifacts

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -5,9 +5,11 @@ on:
   push:
     paths:
       - "oci/*/image.y*ml"
+      - "!oci/mock*"
   pull_request:
     paths:
       - "oci/*/image.y*ml"
+      - "!oci/mock*"
   workflow_dispatch:
     inputs:
       oci-image-name:

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -9,6 +9,7 @@ on:
       - "!.github/workflows/_Auto-updates.yaml"
       - "!.github/workflows/Continuous-Testing.yaml"
       - "examples/**"
+      - "oci/mock*"
       - "src/**"
       - "!src/workflow-engine/**"
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "195"
+            "target": "196"
         },
         "beta": {
-            "target": "195"
+            "target": "196"
         },
         "edge": {
-            "target": "195"
+            "target": "196"
         },
         "end-of-life": "2024-05-01T00:00:00Z"
     },


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
 - bumped the download-artifact action in the provenance job (which was failing to fetch the workflow's artifacts)
 - fixed a race condition: in the previous PR, the Image.yaml and _Test workflows would be triggered at the same time, which would cause a race condition to the `_release.json` file. This PR makes sure the Image.yaml doesn't run for the mock-rock, cause it should be called by the _Test workflow anyway

### Related issues
https://github.com/canonical/oci-factory/actions/runs/8187580397/job/22390383561

