### PR TITLE
fix(ci): uniquely identify rocks from parallel builds

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -121,13 +121,13 @@ jobs:
       - name: Rename ROCK OCI archive
         id: rock
         run: |
-          mkdir ${{ env.ROCKS_CI_FOLDER }}
-          cp ${{ steps.rockcraft.outputs.rock }} ${{ env.ROCKS_CI_FOLDER }}/$(basename ${{ steps.rockcraft.outputs.rock }})
+          # mkdir ${{ env.ROCKS_CI_FOLDER }}
+          # cp ${{ steps.rockcraft.outputs.rock }} ${{ env.ROCKS_CI_FOLDER }}/$(basename ${{ steps.rockcraft.outputs.rock }})
           echo "filename=$(basename ${{ steps.rockcraft.outputs.rock }})" >> $GITHUB_OUTPUT
       - name: Upload ${{ inputs.rock-name }} for ${{ matrix.architecture }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.rock.outputs.filename }}
+          name: ${{ inputs.oci-archive-name }}-${{ steps.rock.outputs.filename }}
           path: ${{ steps.rockcraft.outputs.rock }}
           if-no-files-found: error
 
@@ -141,9 +141,9 @@ jobs:
       - name: Merge single-arch rocks into multi-arch OCI archive
         run: |
           set -xe
-          ls ./*
+          ls ./${{ inputs.oci-archive-name }}*
           buildah manifest create multi-arch-rock
-          for rock in `find *.rock/*`
+          for rock in `find ${{ inputs.oci-archive-name }}*.rock/*`
           do
             test -f $rock
             buildah manifest add multi-arch-rock oci-archive:$rock

--- a/examples/mock-rock/1.0/rockcraft.yaml
+++ b/examples/mock-rock/1.0/rockcraft.yaml
@@ -3,7 +3,7 @@ summary: Hello World
 description: The most basic example of a rock.
 version: "1.0"
 base: bare
-build-base: ubuntu:22.04
+build-base: ubuntu@22.04
 license: Apache-2.0
 platforms:
   amd64:

--- a/examples/mock-rock/1.1/rockcraft.yaml
+++ b/examples/mock-rock/1.1/rockcraft.yaml
@@ -1,0 +1,15 @@
+name: mock-rock
+summary: Hello World
+description: The most basic example of a rock.
+version: "1.1"
+base: bare
+build-base: ubuntu@22.04
+license: Apache-2.0
+platforms:
+  amd64:
+
+parts:
+  hello:
+    plugin: nil
+    stage-packages:
+      - hello

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -9,20 +9,19 @@
         "edge": {
             "target": "latest_beta"
         },
-        "end-of-life": "2024-05-01T00:00:00Z"
+        "end-of-life": "2025-05-01T00:00:00Z"
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "199"
+            "target": "205"
         },
         "beta": {
-            "target": "199"
+            "target": "205"
         },
         "edge": {
-            "target": "199"
-
+            "target": "205"
         },
-        "end-of-life": "2024-05-01T00:00:00Z"
+        "end-of-life": "2025-05-01T00:00:00Z"
     },
     "test": {
         "beta": {
@@ -32,5 +31,29 @@
             "target": "test_beta"
         },
         "end-of-life": "2026-05-01T00:00:00Z"
+    },
+    "1.1-22.04": {
+        "end-of-life": "2025-05-01T00:00:00Z",
+        "candidate": {
+            "target": "206"
+        },
+        "beta": {
+            "target": "206"
+        },
+        "edge": {
+            "target": "206"
+        }
+    },
+    "1-22.04": {
+        "end-of-life": "2025-05-01T00:00:00Z",
+        "candidate": {
+            "target": "206"
+        },
+        "beta": {
+            "target": "206"
+        },
+        "edge": {
+            "target": "206"
+        }
     }
 }

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -2,20 +2,36 @@ version: 1
 
 release:
   latest:
-    end-of-life: "2024-05-01T00:00:00Z"
+    end-of-life: "2025-05-01T00:00:00Z"
     candidate: 1.0-22.04_candidate
   test:
     end-of-life: "2026-05-01T00:00:00Z"
     beta: 1.0-22.04_beta
-    
-upload:  
+
+upload:
   - source: "canonical/oci-factory"
-    commit: 30e73ac0dc4705c12baacbcba74106c8eda2cf9a
-    directory: examples/mock-rock
+    commit: 7f080b50ba656538aee3819889090c173f06debd
+    directory: examples/mock-rock/1.0
     release:
       1.0-22.04:
-        end-of-life: "2024-05-01T00:00:00Z"
-        risks: 
+        end-of-life: "2025-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/oci-factory"
+    commit: 7f080b50ba656538aee3819889090c173f06debd
+    directory: examples/mock-rock/1.1
+    release:
+      1.1-22.04:
+        end-of-life: "2025-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+      1-22.04:
+        end-of-life: "2025-05-01T00:00:00Z"
+        risks:
           - candidate
           - edge
           - beta


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

With the recent introduction of arm64 support, the rocks are being built in a matrix and then assembled into a multi-arch rock. The assembling relies on the existing artifacts uploaded during the matrix build, but it is currently downloading all of them and not filtering them correctly - the result is a multi-arch roch with multiple manifests for the same arch.

This PR fixes that by pretending a unique identifier to each single-arch rock artifact.


