### PR TITLE
fix temporal charm deployment issues

### DIFF
--- a/src/workflow-engine/charms/temporal-worker/variables.tf
+++ b/src/workflow-engine/charms/temporal-worker/variables.tf
@@ -111,7 +111,7 @@ variable "config_temporal_queue" {
 variable "config_temporal_proxy" {
   description = "HTTP/HTTPS proxy URL"
   type        = string
-  default     = ""
+  default     = "http://squid.internal:3128"
 }
 
 variable "config_temporal_workflows_file_path" {


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Fix the temporal charm deployment issues by using a proxy to access temporal.staging.canonical.com.