### PR TITLE
Parse numerical strings in yaml files as strings

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -1,68 +1,68 @@
 {
     "latest": {
         "candidate": {
-            "target": "226"
+            "target": "1.0-22.04_candidate"
         },
         "beta": {
-            "target": "226"
+            "target": "latest_candidate"
         },
         "edge": {
-            "target": "226"
+            "target": "latest_beta"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "226"
+            "target": "247"
         },
         "beta": {
-            "target": "226"
+            "target": "247"
         },
         "edge": {
-            "target": "226"
+            "target": "247"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
     "test": {
         "beta": {
-            "target": "226"
+            "target": "1.0-22.04_beta"
         },
         "edge": {
-            "target": "226"
+            "target": "test_beta"
         },
         "end-of-life": "2026-05-01T00:00:00Z"
     },
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "227"
+            "target": "248"
         },
         "beta": {
-            "target": "227"
+            "target": "248"
         },
         "edge": {
-            "target": "227"
+            "target": "248"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "227"
+            "target": "248"
         },
         "beta": {
-            "target": "227"
+            "target": "248"
         },
         "edge": {
-            "target": "227"
+            "target": "248"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "228"
+            "target": "249"
         },
         "edge": {
-            "target": "228"
+            "target": "1.2-22.04_beta"
         }
     }
 }

--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -273,9 +273,9 @@ class OCIDocumentationData:
         logging.info("Opening file %s", doc_file)
         with open(doc_file, "r", encoding="UTF-8") as file:
             try:
-                base_doc_data = DocSchema(**yaml.safe_load(file) or {}).dict(
-                    exclude_none=True
-                )
+                base_doc_data = DocSchema(
+                    **yaml.load(file, Loader=yaml.BaseLoader) or {}
+                ).dict(exclude_none=True)
             except (yaml.YAMLError, pydantic.ValidationError) as exc:
                 msg = f"Error loading the {doc_file} file"
                 raise Exception(msg) from exc

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
 
     print(f"Getting existing image trigger from {args.image_trigger}")
     with open(args.image_trigger, encoding="UTF-8") as trigger:
-        image_trigger = yaml.safe_load(trigger)
+        image_trigger = yaml.load(trigger, Loader=yaml.BaseLoader)
 
     _ = ImageSchema(**image_trigger)
 

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     print(f"Generating build matrix for {image_trigger_file}")
     with open(image_trigger_file, encoding="UTF-8") as bf:
-        image_trigger = yaml.safe_load(bf)
+        image_trigger = yaml.load(bf, Loader=yaml.BaseLoader)
         try:
             validate_image_trigger(image_trigger)
         except pydantic.error_wrappers.ValidationError as err:

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -67,7 +67,7 @@ tag_mapping_from_all_releases = shared.get_tag_mapping_from_all_releases(all_rel
 
 print(f"Parsing image trigger {args.image_trigger}")
 with open(args.image_trigger, encoding="UTF-8") as trigger:
-    image_trigger = ImageSchema(**yaml.safe_load(trigger))
+    image_trigger = ImageSchema(**yaml.load(trigger, Loader=yaml.BaseLoader))
 
 tag_mapping_from_trigger = {}
 for track, risks in image_trigger.release.items():

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -1,2 +1,3 @@
 docker
 pydantic==1.9.0
+requests==2.31

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 import yaml
 
+
 logging.basicConfig()
 
 
@@ -31,7 +32,7 @@ args = parser.parse_args()
 with open(
     f"{args.recipe_dirname.rstrip('/')}/rockcraft.yaml", encoding="UTF-8"
 ) as rockcraft_file:
-    rockcraft_yaml = yaml.safe_load(rockcraft_file)
+    rockcraft_yaml = yaml.load(rockcraft_file, Loader=yaml.BaseLoader)
 
 rock_base = (
     rockcraft_yaml["base"]
@@ -43,7 +44,7 @@ try:
     base_release = float(rock_base.replace(":", "@").split("@")[-1])
 except ValueError:
     logging.warning(
-        f"Could not infer rock's base release from {rock_base}. Trying with codename."
+        f"Could not infer ROCK's base release from {rock_base}. Trying with codename."
     )
     base_release = float(
         get_release_from_codename(rock_base.replace(":", "@").split("@")[-1])


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
The default python YAML parser that we uses to parse various yaml files consider all numeric values in the yaml values as integers or float as long as they are not enclosed by quotes.
That means that a field like `version: 2.3` would get the value of `2.3` as a float and not as string.
However, our python classes are expecting all values to be strings, because those values are not guaranteed to be numerical in all cases (i.e. `version` value can contain letters too).

## Action taken
The implemented solution in this PR was:
- add a common module and import it in all other modules that uses the yaml parser
- in the common module, make the default parsing behavior of numerical values construct them as strings

