### PR TITLE
feat: add EOL to doc generation

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "247"
+            "target": "253"
         },
         "beta": {
-            "target": "247"
+            "target": "253"
         },
         "edge": {
-            "target": "247"
+            "target": "253"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "248"
+            "target": "254"
         },
         "beta": {
-            "target": "248"
+            "target": "254"
         },
         "edge": {
-            "target": "248"
+            "target": "254"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "248"
+            "target": "254"
         },
         "beta": {
-            "target": "248"
+            "target": "254"
         },
         "edge": {
-            "target": "248"
+            "target": "254"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "249"
+            "target": "255"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
If a channel has an associated EOL, make sure it is reflected in the registry docs.

Here's a successful run: https://hub.docker.com/r/rocksdev/mock-rock, from https://github.com/canonical/oci-factory/actions/runs/9303807030/job/25606973889

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---
