### PR TITLE
fix: remove trigger for img w/o release within eol

### DIFF
--- a/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/src/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -221,10 +221,12 @@ if __name__ == "__main__":
                             f"Track {to_track} is missing its end-of-" "life field"
                         )
 
+                # filter out the tracks with releases out of EOL
+                release_to = {k : v for k, v in release_to.items() if "end-of-life" in v}
+
                 if release_to:
                     build_and_upload_data["release"] = release_to
-
-                uber_img_trigger["upload"].append(build_and_upload_data)
+                    uber_img_trigger["upload"].append(build_and_upload_data)
 
             if not uber_img_trigger["upload"]:
                 # Nothing to rebuild here


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Fix the problem of an image with all releases EOL having a trigger with no `end-of-life` field. 

E.g., https://github.com/canonical/oci-factory/actions/runs/9415158556 and https://github.com/canonical/oci-factory/actions/runs/9415158867.

Such images will not be triggered to build since this commit.
