### PR TITLE
fix: move upload trigger condition to prepare-upload

### DIFF
--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -149,6 +149,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [prepare-build, run-build, test]
     name: Prepare upload
+    if: ${{ inputs.upload || (github.ref_name == 'main' && github.event_name == 'push') }}
     env:
       OS_USERNAME: ${{ secrets.SWIFT_OS_USERNAME }}
       OS_TENANT_NAME: ${{ secrets.SWIFT_OS_TENANT_NAME }}
@@ -238,7 +239,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [prepare-build, prepare-upload]
     name: Upload
-    if: ${{ inputs.upload || (github.ref_name == 'main' && github.event_name == 'push') }}
     strategy:
       fail-fast: true
       matrix: ${{ fromJSON(needs.prepare-upload.outputs.build-matrix) }}

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "385"
+            "target": "388"
         },
         "beta": {
-            "target": "385"
+            "target": "388"
         },
         "edge": {
-            "target": "385"
+            "target": "388"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "386"
+            "target": "389"
         },
         "beta": {
-            "target": "386"
+            "target": "389"
         },
         "edge": {
-            "target": "386"
+            "target": "389"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "386"
+            "target": "389"
         },
         "beta": {
-            "target": "386"
+            "target": "389"
         },
         "edge": {
-            "target": "386"
+            "target": "389"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "387"
+            "target": "390"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR fix the issue that the `prepare-upload` job is not protected by the triggering condition, causing unnecessary increments of revision numbers if the workflow is not expected to run the `upload` job.