### PR TITLE
fix(ci): pass commit sha to force doc wf checkout to newest main

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release-commit-sha}}
+          ref: ${{ inputs.release-commit-sha }}
       
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -21,6 +21,10 @@ on:
         description: 'OCI image to generate the documentation for'
         required: true
         type: string
+      release-commit-sha:
+        description: 'Commit SHA containing the updated _releases.json'
+        required: true
+        type: string
 
 jobs:
   validate-documentation-request:
@@ -78,6 +82,8 @@ jobs:
       IS_PROD: ${{ ! startsWith(needs.validate-documentation-request.outputs.oci-img-name, 'mock-') }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release-commit-sha}}
       
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -67,6 +67,7 @@ jobs:
     needs: [validate-push-release-request]
     outputs:
       gh-releases-matrix: ${{ steps.release-image.outputs.gh-releases-matrix }}
+      release-commit-sha: ${{ steps.release-commit-sha.outputs.release-commit-sha }}
     env:
       IS_PROD: ${{ ! startsWith(inputs.oci-image-name, 'mock-') }}
     steps:
@@ -146,6 +147,12 @@ jobs:
           message: 'ci: automatically update oci/${{ inputs.oci-image-name }}/_releases.json, from ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           files: oci/${{ inputs.oci-image-name }}/_releases.json
 
+      - name: Get commit SHA of _release.json update
+        id: release-commit-sha
+        run: |
+          set -ex
+          echo "release-commit-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
 
   update-documentation:
     name: Update documentation
@@ -153,6 +160,7 @@ jobs:
     uses: ./.github/workflows/Documentation.yaml
     with:
       oci-image-name: "${{ inputs.oci-image-name }}"
+      release-commit-sha: "${{ needs.do-releases.outputs.release-commit-sha }}"
     secrets: inherit
 
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "391"
+            "target": "394"
         },
         "beta": {
-            "target": "391"
+            "target": "394"
         },
         "edge": {
-            "target": "391"
+            "target": "394"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "392"
+            "target": "395"
         },
         "beta": {
-            "target": "392"
+            "target": "395"
         },
         "edge": {
-            "target": "392"
+            "target": "395"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "392"
+            "target": "395"
         },
         "beta": {
-            "target": "392"
+            "target": "395"
         },
         "edge": {
-            "target": "392"
+            "target": "395"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "393"
+            "target": "396"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

This PR fixes the issue when a new track is released with the OCI Factory, the EOL field is not properly set after the first run of the `Image.yaml` workflow. The cause of the problem is the default checkout refs in the called workflow `Documentation.yaml` is the HEAD of main when the `Image.yaml` workflow is dispatched, in which the updates to `_releases.json` in the `Release.yaml` workflow is not included yet. The PR passes the commit SHA that contains the updates to `_releases.json` from the `Release.yaml` workflow, and forces the `Documentation.yaml` workflow to checkout to this commit when generating the document yaml.

### Temporary solution for the issue

Manually trigger the `Documentation.yaml` workflow one more time after the `Image.yaml` workflow completes with success. 

### Related issues
ROCKS-1354
The [checked commit in Documentation](https://github.com/canonical/oci-factory/actions/runs/10080015719/job/27869397538#step:2:69) is the one prior to the [commit contains _releases.json updates](https://github.com/canonical/oci-factory/actions/runs/10080015719/job/27869295243#step:10:34)