### PR TITLE
fix: commit to protected branch with ROCKSBOT_TOKEN

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Commit oci/${{ inputs.oci-image-name }}/_releases.json
         uses: actions-x/commit@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ROCKSBOT_TOKEN }}
           branch: ${{ github.ref }}
           message: 'ci: automatically update oci/${{ inputs.oci-image-name }}/_releases.json, from ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           files: oci/${{ inputs.oci-image-name }}/_releases.json

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "397"
+            "target": "439"
         },
         "beta": {
-            "target": "397"
+            "target": "439"
         },
         "edge": {
-            "target": "397"
+            "target": "439"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "398"
+            "target": "440"
         },
         "beta": {
-            "target": "398"
+            "target": "440"
         },
         "edge": {
-            "target": "398"
+            "target": "440"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "398"
+            "target": "440"
         },
         "beta": {
-            "target": "398"
+            "target": "440"
         },
         "edge": {
-            "target": "398"
+            "target": "440"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "399"
+            "target": "441"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR changes the use of the token passed to the `actions-x/commit` action to allow the changes of `_releases.json` files to the protected branches to be commited.

### Related issues
[Workflow run](https://github.com/canonical/oci-factory/actions/runs/10503841228/job/29099351534)
