### PR TITLE
Remove Launchpad CI dependency from Mock Rocks

### DIFF
--- a/examples/mock-rock/1.2/rockcraft.yaml
+++ b/examples/mock-rock/1.2/rockcraft.yaml
@@ -6,7 +6,6 @@ base: bare
 build-base: ubuntu@22.04
 license: Apache-2.0
 platforms:
-  ppc64el:
   amd64:
 
 parts:

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -36,7 +36,7 @@ upload:
           - edge
           - beta
   - source: "canonical/oci-factory"
-    commit: 486799e24328410678c3534381a5473a46b07d06
+    commit: 61abcfee95f248302a41b26dfeb40f6539fd6ec1
     directory: examples/mock-rock/1.2
     release:
       1.2-22.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

This PR is to remove Launchpad CI as a requirement to build the mock rocks.

Currently Launchpad is used to build a ppc64el arch rock. When test builds of mock-rock are triggered, lpci jobs builds take a long time to complete, and seem to fail (timeout) more often than they succeed. This makes testing changes more difficult. 

We mitigate this issue by removing ppc64el arch support form mock-rock 1.2.