### PR TITLE
Repair OCI Factory Mock Rock Builds

### DIFF
--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -36,7 +36,7 @@ upload:
           - edge
           - beta
   - source: "canonical/oci-factory"
-    commit: 61abcfee95f248302a41b26dfeb40f6539fd6ec1
+    commit: 6829e479d71da94ffd46c18744e131a9693bc1b6
     directory: examples/mock-rock/1.2
     release:
       1.2-22.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

When #234 was merged, the subsequent squash removed the githash that was required for to build Mock Rock 1.2.  
Here we are updating that githash again, to a commit already in main to fix the mock-rock build.