### PR TITLE
fix: checkout oci-factory repo before actor validation

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -38,6 +38,20 @@ jobs:
       build-for: ${{ steps.rock-platforms.outputs.build-for }}
       build-with-lpci: ${{ steps.rock-platforms.outputs.build-with-lpci }}
     steps:
+      # Checkout the OCI Factory repo for the actor validation
+      - uses: actions/checkout@v4
+        if: ${{ github.repository == 'canonical/oci-factory' }}
+
+      - name: Validate access to triggered image
+        uses: ./.github/actions/validate-actor
+        if: ${{ github.repository == 'canonical/oci-factory' }}
+        with:
+          admin-only: true
+          image-path: ${{ inputs.oci-factory-path }}
+          github-token: ${{ secrets.ROCKSBOT_TOKEN }}
+
+      - run: rm -rf ./*
+
       - name: Clone GitHub image repository
         uses: actions/checkout@v4
         id: clone-image-repo
@@ -49,14 +63,6 @@ jobs:
         if: ${{ steps.clone-image-repo.outcome == 'failure' }}
         run: |
           git clone ${{ inputs.rock-repo }} .
-
-      - name: Validate access to triggered image
-        uses: ./.github/actions/validate-actor
-        if: ${{ github.repository == 'canonical/oci-factory' }}
-        with:
-          admin-only: true
-          image-path: ${{ inputs.oci-factory-path }}
-          github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
       - run: git checkout ${{ inputs.rock-repo-commit }}
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "533"
+            "target": "547"
         },
         "beta": {
-            "target": "533"
+            "target": "547"
         },
         "edge": {
-            "target": "533"
+            "target": "547"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "534"
+            "target": "548"
         },
         "beta": {
-            "target": "534"
+            "target": "548"
         },
         "edge": {
-            "target": "534"
+            "target": "548"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "534"
+            "target": "548"
         },
         "beta": {
-            "target": "534"
+            "target": "548"
         },
         "edge": {
-            "target": "534"
+            "target": "548"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "535"
+            "target": "549"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR fixes the missing "checkout" in the Build Rock workflow, which causes the workflow to fail unexpectedly. This but is not captured by the testing workflow either, as the `mock-rock` lives inside the `oci-factory` repo, which conceals this bug under the water.

### Related issues
https://github.com/canonical/oci-factory/actions/runs/10920792896/job/30311462832

### Additional tests
https://github.com/canonical/oci-factory/actions/runs/10945495302/job/30389858407#step:3:1
