### PR TITLE
Fix CLI Client Handling Non-Interactive Terminal and Error Message for Non-Canonical Repo

### DIFF
--- a/tools/cli-client/internals/cli/cli_main.go
+++ b/tools/cli-client/internals/cli/cli_main.go
@@ -55,7 +55,7 @@ func addHelp(p *flags.Parser) {
 func blockForConfirm(s string) error {
 	// check if is a tty
 	fi, err := os.Stdin.Stat()
-	if err != nil && fi.Mode()&os.ModeNamedPipe == 1 {
+	if err != nil && fi.Mode()&os.ModeNamedPipe != 0 {
 		return fmt.Errorf("non-interactive terminal detected, run with -y option")
 	} else if err != nil {
 		return err

--- a/tools/cli-client/internals/cli/cli_main.go
+++ b/tools/cli-client/internals/cli/cli_main.go
@@ -55,7 +55,7 @@ func addHelp(p *flags.Parser) {
 func blockForConfirm(s string) error {
 	// check if is a tty
 	fi, err := os.Stdin.Stat()
-	if err != nil || fi.Mode()&os.ModeNamedPipe == 0 {
+	if err != nil && fi.Mode()&os.ModeNamedPipe == 1 {
 		return fmt.Errorf("non-interactive terminal detected, run with -y option")
 	} else if err != nil {
 		return err

--- a/tools/cli-client/internals/trigger/build_metadata.go
+++ b/tools/cli-client/internals/trigger/build_metadata.go
@@ -29,18 +29,18 @@ func InferBuildMetadata() BuildMetadata {
 	repo, err := git.PlainOpenWithOptions(".",
 		&git.PlainOpenOptions{DetectDotGit: true, EnableDotGitCommonDir: false})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to open repository: %v", err)
+		fmt.Fprintf(os.Stderr, "Unable to open repository: %v\n", err)
 		os.Exit(1)
 	}
 
 	// find the source URL
 	remotes, err := repo.Remotes()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to obtain remotes: %v", err)
+		fmt.Fprintf(os.Stderr, "Unable to obtain remotes: %v\n", err)
 		os.Exit(1)
 	}
 	if len(remotes) < 1 || len(remotes[0].Config().URLs) < 1 {
-		fmt.Fprintf(os.Stderr, "No valid remote exists for this repo")
+		fmt.Fprintf(os.Stderr, "No valid remote exists for this repo\n")
 		os.Exit(1)
 	}
 	remoteURL := remotes[0].Config().URLs[0]
@@ -49,12 +49,16 @@ func InferBuildMetadata() BuildMetadata {
 	// use regex to match the repo location
 	regex := regexp.MustCompile("github.com[:/](canonical/.*).git")
 	matches := regex.FindStringSubmatch(remoteURL)
+	if len(matches) < 2 {
+		fmt.Fprintf(os.Stderr, "oci-factory must be called in a git local repository under organization [canonical]\n")
+		os.Exit(1)
+	}
 	source := matches[1]
 	logger.Debugf("Source: %s", source)
 
 	headSha256, err := repo.ResolveRevision("HEAD")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to resolve HEAD: %v", err)
+		fmt.Fprintf(os.Stderr, "Unable to resolve HEAD: %v\n", err)
 		os.Exit(1)
 	}
 	logger.Debugf("HEAD SHA-256: %s", headSha256)

--- a/tools/cli-client/internals/trigger/build_metadata.go
+++ b/tools/cli-client/internals/trigger/build_metadata.go
@@ -47,9 +47,9 @@ func InferBuildMetadata() BuildMetadata {
 	logger.Debugf("Remote URL: %s", remoteURL)
 
 	// use regex to match the repo location
-	regex := regexp.MustCompile("github.com[:/](canonical/.*)")
+	regex := regexp.MustCompile(`github.com[:\/](canonical\/[A-Za-z0-9_-]*)(\.git)?`)
 	matches := regex.FindStringSubmatch(remoteURL)
-	if len(matches) != 2 {
+	if len(matches) < 3 {
 		fmt.Fprintf(os.Stderr, "oci-factory must be called in a git local repository belongs to the organization [canonical]\n")
 		os.Exit(1)
 	}

--- a/tools/cli-client/internals/trigger/build_metadata.go
+++ b/tools/cli-client/internals/trigger/build_metadata.go
@@ -47,10 +47,10 @@ func InferBuildMetadata() BuildMetadata {
 	logger.Debugf("Remote URL: %s", remoteURL)
 
 	// use regex to match the repo location
-	regex := regexp.MustCompile("github.com[:/](canonical/.*).git")
+	regex := regexp.MustCompile("github.com[:/](canonical/.*)")
 	matches := regex.FindStringSubmatch(remoteURL)
-	if len(matches) < 2 {
-		fmt.Fprintf(os.Stderr, "oci-factory must be called in a git local repository under organization [canonical]\n")
+	if len(matches) != 2 {
+		fmt.Fprintf(os.Stderr, "oci-factory must be called in a git local repository belongs to the organization [canonical]\n")
 		os.Exit(1)
 	}
 	source := matches[1]

--- a/tools/cli-client/internals/trigger/build_metadata.go
+++ b/tools/cli-client/internals/trigger/build_metadata.go
@@ -50,7 +50,7 @@ func InferBuildMetadata() BuildMetadata {
 	regex := regexp.MustCompile(`github.com[:\/](canonical\/[A-Za-z0-9_-]*)(\.git)?`)
 	matches := regex.FindStringSubmatch(remoteURL)
 	if len(matches) < 3 {
-		fmt.Fprintf(os.Stderr, "oci-factory must be called in a git local repository belongs to the organization [canonical]\n")
+		fmt.Fprintf(os.Stderr, "oci-factory must be called in a git local repository belonging to the organization [canonical]\n")
 		os.Exit(1)
 	}
 	source := matches[1]

--- a/tools/cli-client/internals/trigger/build_metadata_test.go
+++ b/tools/cli-client/internals/trigger/build_metadata_test.go
@@ -39,7 +39,7 @@ func (s *BuildMetadataSuite) TestGetBuildMetadataCustomDirector(c *C) {
 		c.Fatal("git not installed")
 	}
 	repoPath := filepath.Join(s.dir, "tester-path")
-	cmd = exec.Command("git", "clone", "https://github.com/canonical/oci-factory.git", repoPath)
+	cmd = exec.Command("git", "clone", "https://github.com/canonical/rocks-toolbox.git", repoPath)
 	var errBuf bytes.Buffer
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
@@ -47,16 +47,16 @@ func (s *BuildMetadataSuite) TestGetBuildMetadataCustomDirector(c *C) {
 		c.Fatal(err)
 	}
 
-	err := os.Chdir(filepath.Join(repoPath, "examples", "mock-rock", "1.0"))
+	err := os.Chdir(filepath.Join(repoPath, "mock_rock", "1.0"))
 	c.Assert(err, IsNil)
 
 	result := trigger.InferBuildMetadata()
 
-	prefix := filepath.Join("examples", "mock-rock", "1.0") + "/"
+	prefix := filepath.Join("mock_rock", "1.0") + "/"
 	head, err := exec.Command("git", "rev-parse", "HEAD").Output()
 	headStr := strings.TrimSpace(string(head))
 	c.Assert(err, IsNil)
-	source := "canonical/oci-factory"
+	source := "canonical/rocks-toolbox"
 	expected := trigger.BuildMetadata{
 		Source:    source,
 		Directory: prefix,


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR fixes the following issues:
1. The CLI client is giving false positive results detecting non-interactive terminals.
2. The CLI client dumps stack traceback when the regex fails to match a repo remote URL that does not belong to Canonical.