### PR TITLE
feat: add 24.04 to Renovate's radar

### DIFF
--- a/.github/base_digests/24.04
+++ b/.github/base_digests/24.04
@@ -1,0 +1,2 @@
+public.ecr.aws/ubuntu/ubuntu:noble@sha256:5b2fc4131b3c134a019c3ea815811de70e6ad9ee1626f59bf302558a95b436e5
+


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Since now we have at least on Noble-based rock here, let's get that under Renovate's radar as well.