### PR TITLE
Bypass actor validation for Image, Build, Test, Vul-Scan workflow triggered by forked PRs

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       # Checkout the OCI Factory repo for the actor validation
       - uses: actions/checkout@v4
-        if: ${{ github.repository == 'canonical/oci-factory' }}
+        if: ${{ github.repository == 'canonical/oci-factory'  && !github.event.pull_request.head.repo.fork }}
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -50,7 +50,9 @@ jobs:
           image-path: ${{ inputs.oci-factory-path }}
           github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
+      # We clear the working directory to make space for the rock repo
       - run: rm -rf ./*
+        if: ${{ github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork }}
 
       - name: Clone GitHub image repository
         uses: actions/checkout@v4

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
-        if: ${{ github.repository == 'canonical/oci-factory' }}
+        if: ${{ github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork }}
         with:
           admin-only: true
           image-path: ${{ inputs.oci-factory-path }}

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
-        if: ${{ github.repository == 'canonical/oci-factory' }}
+        if: ${{ github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork }}
         with:
           admin-only: true
           image-path: ${{ steps.validate-image.outputs.img-path }}

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -72,7 +72,7 @@ jobs:
     - uses: actions/checkout@v4 
     - name: Validate access to triggered image
       uses: ./.github/actions/validate-actor
-      if: ${{ github.repository == 'canonical/oci-factory' }}
+      if: ${{ github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork }}
       with:
         admin-only: true
         image-path: ${{ inputs.oci-image-path }}

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
-        if: ${{ github.repository == 'canonical/oci-factory' }}
+        if: ${{ github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork }}
         with:
           admin-only: true
           image-path: ${{ inputs.oci-image-path }}

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "571"
+            "target": "577"
         },
         "beta": {
-            "target": "571"
+            "target": "577"
         },
         "edge": {
-            "target": "571"
+            "target": "577"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "572"
+            "target": "578"
         },
         "beta": {
-            "target": "572"
+            "target": "578"
         },
         "edge": {
-            "target": "572"
+            "target": "578"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "572"
+            "target": "578"
         },
         "beta": {
-            "target": "572"
+            "target": "578"
         },
         "edge": {
-            "target": "572"
+            "target": "578"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "573"
+            "target": "579"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "565"
+            "target": "571"
         },
         "beta": {
-            "target": "565"
+            "target": "571"
         },
         "edge": {
-            "target": "565"
+            "target": "571"
         },
         "end-of-life": "2025-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "566"
+            "target": "572"
         },
         "beta": {
-            "target": "566"
+            "target": "572"
         },
         "edge": {
-            "target": "566"
+            "target": "572"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "566"
+            "target": "572"
         },
         "beta": {
-            "target": "566"
+            "target": "572"
         },
         "edge": {
-            "target": "566"
+            "target": "572"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "567"
+            "target": "573"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
According to the GitHub [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflows-in-forked-repositories), secrets are not passed to the runner when a workflow is triggered from a forked repository. Therefore, for forked PR, the actor validation will always fail. To cope with this issue, we allow the bypassing of actor validation for the Image, Build-Rock, Tests and Vulnerability-Scan workflows triggered with a forked pull request. 

More security thought: The external user's PR workflow will only run upon approval by the repo's maintainer, so the chance of exploiting is considered low. The external user's PR will neither trigger Upload and Release workflows nor have the secrets in the main repo, so the secrets are safe from stealing.

### Related issues
Failed Image workflow run: https://github.com/canonical/oci-factory/actions/runs/11048142134/job/30691724573

### Tests
1. Actor validation is bypassed when a PR from a forked repo triggers the workflow. https://github.com/canonical/oci-factory/actions/runs/11069540851/job/30757337773?pr=252
