### PR TITLE
fix: do not close issue upon vulnerability scan errors

### DIFF
--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -268,6 +268,6 @@ jobs:
           fi
 
       - name: Close issue
-        if: ${{ steps.issue-exists.outputs.issue-exists == 'true' && steps.create-markdown.outputs.vulnerability-exists == 'false' }}
+        if: ${{ needs.test-vulnerabilities.result == 'success' && steps.issue-exists.outputs.issue-exists == 'true' && steps.create-markdown.outputs.vulnerability-exists == 'false' }}
         run: |
           gh issue close ${{ steps.issue-exists.outputs.issue-number }} --repo ${{ steps.get-image-repo.outputs.img-repo }}


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR fixes the issue that the GitHub issue reporting the vulnerability scanning results will be accidentally closed when the vulnerability scanning job exits with errors and an empty report. The solution is to screen the "close issue" operation with the constraint that the scanning job exits with the result "success".

### Related issues
https://github.com/canonical/oci-factory/actions/runs/11024690355/job/30618459568

---

