### PR TITLE
Do not create issues on vul scan failures when triggered by pull requests

### DIFF
--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -198,7 +198,7 @@ jobs:
       - test-vulnerabilities
     env:
       GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "625"
+            "target": "639"
         },
         "beta": {
-            "target": "625"
+            "target": "639"
         },
         "edge": {
-            "target": "625"
+            "target": "639"
         }
     },
     "1-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "candidate": {
-            "target": "625"
+            "target": "639"
         },
         "beta": {
-            "target": "625"
+            "target": "639"
         },
         "edge": {
-            "target": "625"
+            "target": "639"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2025-05-01T00:00:00Z",
         "beta": {
-            "target": "626"
+            "target": "640"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This change fixes the issue that vulnerability GH issues are created when the PR to add new images are not merged into `main` yet. We should create issues for the oci images only when they are already in the `main` branch since the new images with failing vulnerability scanning results should not be merged into `main`.

### Related issues
Workflow run: https://github.com/canonical/oci-factory/actions/runs/11342692546/job/31546152898?pr=262

---
