### PR TITLE
fix: add canonical-iam as maintainer to use oci-factory cli on login-ui

### DIFF
--- a/oci/identity-platform-login-ui/contacts.yaml
+++ b/oci/identity-platform-login-ui/contacts.yaml
@@ -3,3 +3,5 @@ notify:
     - identity.charmers@lists.launchpad.net
   mattermost-channels:
     - ofi4for9obfq8m978h318x56ar
+maintainers:
+  - canonical-iam


### PR DESCRIPTION
adding canonical-iam as maintainer for login-ui

split from https://github.com/canonical/oci-factory/pull/274