### PR TITLE
fix: add canonical-iam as maintainer to use oci-factory cli on hydra

### DIFF
--- a/oci/hydra/contacts.yaml
+++ b/oci/hydra/contacts.yaml
@@ -3,3 +3,5 @@ notify:
     - identity.charmers@lists.launchpad.net
   mattermost-channels:
     - ofi4for9obfq8m978h318x56ar
+maintainers:
+  - canonical-iam


### PR DESCRIPTION
adding canonical-iam as maintainer for hydra

split from https://github.com/canonical/oci-factory/pull/274