### PR TITLE
Use wildcard in renovate.json to include 24.04

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,7 @@
         {
             "customType": "regex",
             "fileMatch": [
-                "\\.github/base_digests/22.04$",
-                "\\.github/base_digests/20.04$"
+                "\\.github/base_digests/\\d{2}.\\d{2}$"
             ],
             "matchStringsStrategy": "any",
             "matchStrings": [


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Wildcard is used in the `renovate.json` to include 24.04 into the renovatebot. This also allows the scalability of future releases added to `.github/base_digests`.
