### PR TITLE
Add CI-Level trivyignore

### DIFF
--- a/.github/.trivyignore
+++ b/.github/.trivyignore
@@ -1,0 +1,3 @@
+# False positive for encoding/gob that not used by pebble
+# encoding/gob: cover missed cases when checking ignore depth
+CVE-2024-34156

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -87,13 +87,10 @@ jobs:
       - name: Check for .trivyignore
         id: trivyignore
         run: |
+          file="./.github/.trivyignore"
           if [ -f ${{ inputs.oci-image-path }}/.trivyignore ]
           then
-            file=${{ inputs.oci-image-path }}/.trivyignore
-          else
-            # dummy .trivyignore file
-            file=.trivyignore
-            touch $file
+            file="$file,${{ inputs.oci-image-path }}/.trivyignore"
           fi
           echo "file=$file" >> "$GITHUB_OUTPUT"
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -13,13 +13,13 @@
     },
     "1.0-22.04": {
         "candidate": {
-            "target": "775"
+            "target": "784"
         },
         "beta": {
-            "target": "775"
+            "target": "784"
         },
         "edge": {
-            "target": "775"
+            "target": "784"
         },
         "end-of-life": "2030-05-01T00:00:00Z"
     },
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "776"
+            "target": "785"
         },
         "beta": {
-            "target": "776"
+            "target": "785"
         },
         "edge": {
-            "target": "776"
+            "target": "785"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "776"
+            "target": "785"
         },
         "beta": {
-            "target": "776"
+            "target": "785"
         },
         "edge": {
-            "target": "776"
+            "target": "785"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "777"
+            "target": "786"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR adds a CI-level trivyignore to bypass the false positive vulnerability findings for the pebble binary in the bare-based rocks using the feature that `trivyignores` can be a comma-separated string to contain multiple bypass lists.

### Related issues
https://github.com/canonical/chiselled-python/issues/26
