### PR TITLE
Create issues only for continuous testing

### DIFF
--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -31,8 +31,6 @@ jobs:
           last_scan="$(date --date='26 hours ago' +'%Y-%m-%dT%H:%M:00Z')"
           echo "date=$last_scan" >> "$GITHUB_OUTPUT"
 
-
-
   run-tests:
     name: Run tests for released images
     needs: [prepare-test-matrix]
@@ -46,9 +44,6 @@ jobs:
       date-last-scan: ${{ needs.prepare-test-matrix.outputs.last-scan }}
     secrets: inherit
 
-
-
-
   issue:
     runs-on: ubuntu-22.04
     name: Create issue
@@ -57,7 +52,6 @@ jobs:
       - run-tests
     env:
       GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
-    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -127,7 +121,6 @@ jobs:
           fi
 
       - name: Close issue
-        if: ${{ needs.run-tests.result == 'success' && steps.issue-exists.outputs.issue-exists == 'true' && steps.create-markdown.outputs.vulnerability-exists == 'false' }}
+        if: ${{ steps.create-markdown.outputs.vulnerability-exists == 'false' && steps.issue-exists.outputs.issue-exists == 'true' && steps.create-markdown.outputs.vulnerability-exists == 'false' }}
         run: |
           gh issue close ${{ steps.issue-exists.outputs.issue-number }} --repo ${{ steps.get-image-repo.outputs.img-repo }}
-

--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -31,6 +31,8 @@ jobs:
           last_scan="$(date --date='26 hours ago' +'%Y-%m-%dT%H:%M:00Z')"
           echo "date=$last_scan" >> "$GITHUB_OUTPUT"
 
+
+
   run-tests:
     name: Run tests for released images
     needs: [prepare-test-matrix]
@@ -43,3 +45,89 @@ jobs:
       oci-image-path: "oci/${{ matrix.name }}"
       date-last-scan: ${{ needs.prepare-test-matrix.outputs.last-scan }}
     secrets: inherit
+
+
+
+
+  issue:
+    runs-on: ubuntu-22.04
+    name: Create issue
+    if: ${{ !cancelled() }}
+    needs:
+      - run-tests
+    env:
+      GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: simplify-image-name
+        run: |
+          img_name=$(echo "${{ inputs.oci-image-name }}" | sed -r 's|.*/([a-zA-Z0-9-]+:[0-9.-]+)_[0-9]+|\1|')
+          echo "img_name=$img_name" >> "$GITHUB_OUTPUT"
+
+      # We assume that the sources within image.yaml are the same
+      - name: Get image repo
+        id: get-image-repo
+        run: |
+          img_repo=$(yq -r '.upload.[].source' ${{ github.workspace }}/${{ inputs.oci-image-path }}/image.yaml | head -n 1)
+          echo "img-repo=$img_repo" >> "$GITHUB_OUTPUT"
+
+      # We have to walk through the vulnerabilities since trivy does not support outputting the results as Markdown
+      - name: Create Markdown Content
+        id: create-markdown
+        run: |
+          set -x
+          title="Vulnerabilities found for ${{ steps.simplify-image-name.outputs.img_name }}"
+          echo "## $title" > issue.md
+          echo "| ID | Target | Severity | Package |" >> issue.md
+          echo "| -- | ----- | -------- | ------- |" >> issue.md
+          echo '${{ needs.run-tests.outputs.vulnerabilities }}' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> issue.md
+          echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md
+          num_vulns=$(echo '${{ needs.run-tests.outputs.vulnerabilities }}' | jq -r 'length')
+          echo "issue-title=$title" >> "$GITHUB_OUTPUT"
+          echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
+          echo "vulnerability-exists=$([[ $num_vulns -gt 0 ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+
+      - id: issue-exists
+        run: |
+          issue_number=$(gh issue list --repo ${{ steps.get-image-repo.outputs.img-repo }} --json "number,title" \
+                  | jq -r '.[] | select(.title == "${{ steps.create-markdown.outputs.issue-title }}") | .number')
+          echo "issue-exists=$([[ -n "$issue_number" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+          echo "issue-number=$issue_number" >> "$GITHUB_OUTPUT"
+
+
+      # Truth table for issue creation
+      # | issue-exists | notify | vulnerability-exists |   op   |
+      # |--------------|--------|----------------------|--------|
+      # |      T       |   T    |          T           | update |
+      # |      T       |   T    |          F           |  never |
+      # |      T       |   F    |          T           |   nop  |
+      # |      T       |   F    |          F           |  close |
+      # |      F       |   T    |          T           | create |
+      # |      F       |   T    |          F           |  never |
+      # |      F       |   F    |          T           | create |
+      # |      F       |   F    |          F           |   nop  |
+      
+      - name: Notify via GitHub issue
+        if: ${{ steps.create-markdown.outputs.vulnerability-exists == 'true' }}
+        run: |
+          set -x
+          op=nop
+          if [[ ${{ steps.issue-exists.outputs.issue-exists }}  == 'false' ]]; then
+            op="create"
+          elif [[ ${{ steps.issue-exists.outputs.issue-exists }} == 'true' \
+                  && ${{ needs.test-vulnerabilities.outputs.notify }} == 'true' ]]; then
+            op="edit ${{ steps.issue-exists.outputs.issue-number }}"
+          fi
+          if [[ $op != 'nop' ]]; then
+            gh issue $op --repo ${{ steps.get-image-repo.outputs.img-repo }} \
+              --title "Vulnerabilities found for ${{ steps.simplify-image-name.outputs.img_name }}" \
+              --body-file "${{ steps.create-markdown.outputs.issue-body-file }}"
+          fi
+
+      - name: Close issue
+        if: ${{ needs.run-tests.result == 'success' && steps.issue-exists.outputs.issue-exists == 'true' && steps.create-markdown.outputs.vulnerability-exists == 'false' }}
+        run: |
+          gh issue close ${{ steps.issue-exists.outputs.issue-number }} --repo ${{ steps.get-image-repo.outputs.img-repo }}
+

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -199,4 +199,3 @@ jobs:
           do
             MM_CHANNEL_ID="${channel}" ./src/notifications/send_to_mattermost.sh
           done
-

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -27,6 +27,13 @@ on:
         required: false
         type: string
         default: '9999-12-31T23:59:59'
+    outputs:
+      vulnerabilities:
+        description: "Result of the vulnerability analysis."
+        value: ${{ jobs.test-vulnerabilities.outputs.vulnerabilities }}
+      notify:
+        description: "Should we report result to issue tracker?"
+        value: ${{ jobs.test-vulnerabilities.outputs.notify }}
 
 env:
   TEST_IMAGE_NAME: 'test-img'
@@ -193,83 +200,3 @@ jobs:
             MM_CHANNEL_ID="${channel}" ./src/notifications/send_to_mattermost.sh
           done
 
-  issue:
-    runs-on: ubuntu-22.04
-    name: Create issue
-    needs:
-      - test-vulnerabilities
-    env:
-      GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
-    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: simplify-image-name
-        run: |
-          img_name=$(echo "${{ inputs.oci-image-name }}" | sed -r 's|.*/([a-zA-Z0-9-]+:[0-9.-]+)_[0-9]+|\1|')
-          echo "img_name=$img_name" >> "$GITHUB_OUTPUT"
-
-      # We assume that the sources within image.yaml are the same
-      - name: Get image repo
-        id: get-image-repo
-        run: |
-          img_repo=$(yq -r '.upload.[].source' ${{ github.workspace }}/${{ inputs.oci-image-path }}/image.yaml | head -n 1)
-          echo "img-repo=$img_repo" >> "$GITHUB_OUTPUT"
-
-      # We have to walk through the vulnerabilities since trivy does not support outputting the results as Markdown
-      - name: Create Markdown Content
-        id: create-markdown
-        run: |
-          set -x
-          title="Vulnerabilities found for ${{ steps.simplify-image-name.outputs.img_name }}"
-          echo "## $title" > issue.md
-          echo "| ID | Target | Severity | Package |" >> issue.md
-          echo "| -- | ----- | -------- | ------- |" >> issue.md
-          echo '${{ needs.test-vulnerabilities.outputs.vulnerabilities }}' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> issue.md
-          echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md
-          num_vulns=$(echo '${{ needs.test-vulnerabilities.outputs.vulnerabilities }}' | jq -r 'length')
-          echo "issue-title=$title" >> "$GITHUB_OUTPUT"
-          echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
-          echo "vulnerability-exists=$([[ $num_vulns -gt 0 ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
-
-      - id: issue-exists
-        run: |
-          issue_number=$(gh issue list --repo ${{ steps.get-image-repo.outputs.img-repo }} --json "number,title" \
-                  | jq -r '.[] | select(.title == "${{ steps.create-markdown.outputs.issue-title }}") | .number')
-          echo "issue-exists=$([[ -n "$issue_number" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
-          echo "issue-number=$issue_number" >> "$GITHUB_OUTPUT"
-
-
-      # Truth table for issue creation
-      # | issue-exists | notify | vulnerability-exists |   op   |
-      # |--------------|--------|----------------------|--------|
-      # |      T       |   T    |          T           | update |
-      # |      T       |   T    |          F           |  never |
-      # |      T       |   F    |          T           |   nop  |
-      # |      T       |   F    |          F           |  close |
-      # |      F       |   T    |          T           | create |
-      # |      F       |   T    |          F           |  never |
-      # |      F       |   F    |          T           | create |
-      # |      F       |   F    |          F           |   nop  |
-      
-      - name: Notify via GitHub issue
-        if: ${{ steps.create-markdown.outputs.vulnerability-exists == 'true' }}
-        run: |
-          set -x
-          op=nop
-          if [[ ${{ steps.issue-exists.outputs.issue-exists }}  == 'false' ]]; then
-            op="create"
-          elif [[ ${{ steps.issue-exists.outputs.issue-exists }} == 'true' \
-                  && ${{ needs.test-vulnerabilities.outputs.notify }} == 'true' ]]; then
-            op="edit ${{ steps.issue-exists.outputs.issue-number }}"
-          fi
-          if [[ $op != 'nop' ]]; then
-            gh issue $op --repo ${{ steps.get-image-repo.outputs.img-repo }} \
-              --title "Vulnerabilities found for ${{ steps.simplify-image-name.outputs.img_name }}" \
-              --body-file "${{ steps.create-markdown.outputs.issue-body-file }}"
-          fi
-
-      - name: Close issue
-        if: ${{ needs.test-vulnerabilities.result == 'success' && steps.issue-exists.outputs.issue-exists == 'true' && steps.create-markdown.outputs.vulnerability-exists == 'false' }}
-        run: |
-          gh issue close ${{ steps.issue-exists.outputs.issue-number }} --repo ${{ steps.get-image-repo.outputs.img-repo }}

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "803"
+            "target": "806"
         },
         "beta": {
-            "target": "803"
+            "target": "806"
         },
         "edge": {
-            "target": "803"
+            "target": "806"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "803"
+            "target": "806"
         },
         "beta": {
-            "target": "803"
+            "target": "806"
         },
         "edge": {
-            "target": "803"
+            "target": "806"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "804"
+            "target": "807"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "814"
+            "target": "817"
         },
         "beta": {
-            "target": "814"
+            "target": "817"
         },
         "edge": {
-            "target": "814"
+            "target": "817"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "814"
+            "target": "817"
         },
         "beta": {
-            "target": "814"
+            "target": "817"
         },
         "edge": {
-            "target": "814"
+            "target": "817"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "815"
+            "target": "818"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "806"
+            "target": "814"
         },
         "beta": {
-            "target": "806"
+            "target": "814"
         },
         "edge": {
-            "target": "806"
+            "target": "814"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "806"
+            "target": "814"
         },
         "beta": {
-            "target": "806"
+            "target": "814"
         },
         "edge": {
-            "target": "806"
+            "target": "814"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "807"
+            "target": "815"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR moves the creation of issues to the continuous testing workflow, since creating issues for failed vulnerability scanning in the Image workflow is not necessary (for image onboarding and rebuilds), and for that, the images are not named by tracks, but commit SHAs instead.
