### PR TITLE
chore: add renovatebot to maintainers of mock-rock

### DIFF
--- a/oci/mock-rock/contacts.yaml
+++ b/oci/mock-rock/contacts.yaml
@@ -16,3 +16,4 @@ maintainers:
   - linostar
   - rebornplusplus
   - zhijie-yang
+  - renovate[bot]


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
`renovate[bot]` is added to the `maintainers` list of the `mock-rock` to enable the renovation of dependencies of the OCI Factory itself.

### Related issues
https://github.com/canonical/oci-factory/actions/runs/12105641691/job/33775903985?pr=297
