### PR TITLE
fix(ci): add escapes for [ and ] to allow renovatebot trigger mock-rock

### DIFF
--- a/.github/actions/validate-actor/validate-actor.sh
+++ b/.github/actions/validate-actor/validate-actor.sh
@@ -6,22 +6,23 @@ workspace=$3
 image_path=$4
 
 echo "github.actor: ${actor}"
+actor=$(echo "$actor" | sed 's/\[/\\[/g;s/\]/\\]/g') # Escape square brackets for actors like renovate[bot]
 echo "admin-only: ${admin_only}"
 if [[ ${admin_only} == true ]]; then
     exit_status=0
     echo "Expanding team mentions in the CODEOWNERS file"
-    cp ${workspace}/CODEOWNERS ${workspace}/CODEOWNERS.bak
-    teams=$(grep -oE '@[[:alnum:]_.-]+\/[[:alnum:]_.-]+' ${workspace}/CODEOWNERS || true | sort | uniq)
+    cp ${workspace}/CODEOWNERS ${workspace}/CODEOWNERS.chk
+    teams=$(grep -oE '@[[:alnum:]_.-]+\/[[:alnum:]_.-]+' ${workspace}/CODEOWNERS.chk || true | sort | uniq)
 
     for team in ${teams}; do
         org=$(echo ${team} | cut -d'/' -f1 | sed 's/@//')
         team_name=$(echo ${team} | cut -d'/' -f2)
         members=$(gh api "/orgs/${org}/teams/${team_name}/members" | jq -r '.[].login')
         replacement=$(echo "${members}" | xargs -I {} echo -n "@{} " | awk '{$1=$1};1')
-        sed -i "s|${team}|${replacement}|g" ${workspace}/CODEOWNERS
+        sed -i "s|${team}|${replacement}|g" ${workspace}/CODEOWNERS.chk
     done
 
-    if grep -wq "@${actor}" ${workspace}/CODEOWNERS; then
+    if grep -wq "@${actor}" ${workspace}/CODEOWNERS.chk; then
         echo "The workflow is triggered by ${actor} as the code owner"
     elif cat ${workspace}/${image_path}/contacts.yaml | yq ".maintainers" | grep "\- " | grep -wq "${actor}"; then
         echo "The workflow is triggered by ${actor} as a maintainer of the image ${image_path}"
@@ -29,7 +30,7 @@ if [[ ${admin_only} == true ]]; then
         echo "The workflow is triggered by a user neither as a code owner nor a maintainer of the image ${image_path}"
         exit_status=1
     fi
-    mv ${workspace}/CODEOWNERS.bak ${workspace}/CODEOWNERS
+    rm ${workspace}/CODEOWNERS.chk
     exit ${exit_status}
 else
     echo "The workflow is not restricted to non-code-owner or non-maintainer users"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "921"
+            "target": "945"
         },
         "beta": {
-            "target": "921"
+            "target": "945"
         },
         "edge": {
-            "target": "921"
+            "target": "945"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "921"
+            "target": "945"
         },
         "beta": {
-            "target": "921"
+            "target": "945"
         },
         "edge": {
-            "target": "921"
+            "target": "945"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "922"
+            "target": "946"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "945"
+            "target": "948"
         },
         "beta": {
-            "target": "945"
+            "target": "948"
         },
         "edge": {
-            "target": "945"
+            "target": "948"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "945"
+            "target": "948"
         },
         "beta": {
-            "target": "945"
+            "target": "948"
         },
         "edge": {
-            "target": "945"
+            "target": "948"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "946"
+            "target": "949"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/contacts.yaml
+++ b/oci/mock-rock/contacts.yaml
@@ -11,7 +11,7 @@ notify:
     - fbdezwkcxpfofpysjore1wpfoc
 
 maintainers:
-  - cjdc
+  - cjdcordeiro
   - clay-lake
   - linostar
   - rebornplusplus


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This follows the PR #298 to resolve the failed workflows caused by renovatebot's not being authorised to trigger the `_Test-OCI-Factory` workflow when renovating dependencies of the workflow itself.
