### PR TITLE
fix(ci): correct prepare-build release-to logic

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "966"
+            "target": "969"
         },
         "beta": {
-            "target": "966"
+            "target": "969"
         },
         "edge": {
-            "target": "966"
+            "target": "969"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "966"
+            "target": "969"
         },
         "beta": {
-            "target": "966"
+            "target": "969"
         },
         "edge": {
-            "target": "966"
+            "target": "969"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "967"
+            "target": "970"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -228,7 +228,10 @@ def main():
         # so let's remove this field since we don't need it for the builds
         del build["release"]
 
-    release_to = "true" if "release" in image_trigger else ""
+    release_to = "true" if any("release" in track for track in image_trigger["upload"]) else ""
+
+    print(image_trigger.keys())
+    print(image_trigger["upload"][0].keys())
 
     write_github_output(release_to, builds, args.revision_data_dir)
 


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
This PR fixes the issue that the images are not properly released even `release` key exists in the tracks of the image triggers.

### Related issues
https://github.com/canonical/oci-factory/actions/runs/12233830572/job/34122190700
