### PR TITLE
fix: release identification in prepare_single_image_build_matrix.py

### DIFF
--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -117,7 +117,6 @@ jobs:
   #     test-oci-compliance: true
   #     test-vulnerabilities: true
 
-
   # # Test workflow used in continuous testing
   # test-vulnerability-scan:
   #   name: Test vulnerability scan workflow

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "981"
+            "target": "984"
         },
         "beta": {
-            "target": "981"
+            "target": "984"
         },
         "edge": {
-            "target": "981"
+            "target": "984"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "981"
+            "target": "984"
         },
         "beta": {
-            "target": "981"
+            "target": "984"
         },
         "edge": {
-            "target": "981"
+            "target": "984"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "982"
+            "target": "985"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -107,11 +107,20 @@ def filter_eol_tracks(build: dict[str, Any]) -> dict[str, Any]:
 
 
 def filter_eol_builds(builds: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Remove any builds with no tracks specified."""
-    # remove any end of life tracks
-    builds = [filter_eol_tracks(build) for build in builds]
+    """Remove any builds with eol tracks."""
 
-    return [build for build in builds if len(build["release"])]
+    # if no release exists and therefore no eol is specified, do nothing
+    non_release_builds = [build for build in builds if "release" not in build]
+
+    # if we have release info, then filter based on eol
+    release_builds = [
+        filtered_build
+        for build in builds
+        if "release" in build
+        and (filtered_build := filter_eol_tracks(build))["release"]
+    ]
+
+    return non_release_builds + release_builds
 
 
 def write_revision_data(data_dir: Path, build: dict[str, Any]):
@@ -157,7 +166,7 @@ def write_github_output(
     """Write script result to GITHUB_OUTPUT."""
     outputs = {
         "build-matrix": {"include": builds},
-        "release-to": release_to,
+        "release-to": "true" if release_to else "",
         "revision-data-dir": str(revision_data_dir),
     }
     with GithubOutput() as github_output:
@@ -221,16 +230,21 @@ def main():
         f"Generating matrix for following builds: \n {json.dumps(builds, indent=4)}"
     )
 
+    # trigger a release if specified in the image_trigger root
+    release = "release" in image_trigger
+
     for build in builds:
         write_revision_data(args.revision_data_dir, build)
 
-        # the workflow GH matrix has a problem parsing nested JSON dicts
-        # so let's remove this field since we don't need it for the builds
-        del build["release"]
+        if "release" in build:
+            # trigger a release if specified in any of the builds
+            release = True
 
-    release_to = "true" if builds else ""
+            # the workflow GH matrix has a problem parsing nested JSON dicts
+            # so let's remove this field since we don't need it for the builds themselves
+            del build["release"]
 
-    write_github_output(release_to, builds, args.revision_data_dir)
+    write_github_output(release, builds, args.revision_data_dir)
 
 
 if __name__ == "__main__":

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -228,7 +228,7 @@ def main():
         # so let's remove this field since we don't need it for the builds
         del build["release"]
 
-    release_to = "true" if "release" in image_trigger else ""
+    release_to = "true" if builds else ""
 
     write_github_output(release_to, builds, args.revision_data_dir)
 

--- a/tests/data/image_all_eol_tracks.yaml
+++ b/tests/data/image_all_eol_tracks.yaml
@@ -1,0 +1,45 @@
+version: 1
+
+release:
+  latest:
+    end-of-life: "2030-05-01T00:00:00Z"
+    candidate: 1.2-22.04_beta
+  test:
+    end-of-life: "2030-05-01T00:00:00Z"
+    beta: 1.1-22.04_beta
+
+upload:
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.0
+    release:
+      1.0-22.04:
+        end-of-life: "2000-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.1
+    release:
+      1.1-22.04:
+        end-of-life: "2000-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+      1-22.04:
+        end-of-life: "2000-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.2
+    release:
+      1.2-22.04:
+        end-of-life: "2000-05-01T00:00:00Z"
+        risks:
+          - beta

--- a/tests/data/image_all_eol_tracks_with_release.yaml
+++ b/tests/data/image_all_eol_tracks_with_release.yaml
@@ -1,5 +1,13 @@
 version: 1
 
+release:
+  latest:
+    end-of-life: "2030-05-01T00:00:00Z"
+    candidate: 1.2-22.04_beta
+  test:
+    end-of-life: "2030-05-01T00:00:00Z"
+    beta: 1.1-22.04_beta
+
 upload:
   - source: "canonical/rocks-toolbox"
     commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f

--- a/tests/data/image_no_track_releases.yaml
+++ b/tests/data/image_no_track_releases.yaml
@@ -1,0 +1,14 @@
+version: 1
+
+upload:
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.0
+
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.1
+
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.2

--- a/tests/data/image_single_track_release.yaml
+++ b/tests/data/image_single_track_release.yaml
@@ -1,0 +1,19 @@
+version: 1
+
+upload:
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.0
+
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.1
+
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.2
+    release:
+      1.2-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - beta

--- a/tests/data/image_with_release.yaml
+++ b/tests/data/image_with_release.yaml
@@ -1,0 +1,45 @@
+version: 1
+
+release:
+  latest:
+    end-of-life: "2030-05-01T00:00:00Z"
+    candidate: 1.2-22.04_beta
+  test:
+    end-of-life: "2030-05-01T00:00:00Z"
+    beta: 1.1-22.04_beta
+
+upload:
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.0
+    release:
+      1.0-22.04:
+        end-of-life: "2024-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.1
+    release:
+      1.1-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+      1-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.2
+    release:
+      1.2-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - beta

--- a/tests/data/image_without_release.yaml
+++ b/tests/data/image_without_release.yaml
@@ -1,0 +1,37 @@
+version: 1
+
+upload:
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.0
+    release:
+      1.0-22.04:
+        end-of-life: "2024-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.1
+    release:
+      1.1-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+      1-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - candidate
+          - edge
+          - beta
+  - source: "canonical/rocks-toolbox"
+    commit: 17916dd5de270e61a6a3fd3f4661a6413a50fd6f
+    directory: mock_rock/1.2
+    release:
+      1.2-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - beta

--- a/tests/integration/test_prepare_single_image_build_matrix.py
+++ b/tests/integration/test_prepare_single_image_build_matrix.py
@@ -46,9 +46,12 @@ def prep_execution(tmpdir, monkeypatch, request):
 @pytest.mark.parametrize(
     "prep_execution, release_to",
     [
+        (DATA_DIR / "image_all_eol_tracks_with_release.yaml", True),
+        (DATA_DIR / "image_all_eol_tracks.yaml", False),
+        (DATA_DIR / "image_no_track_releases.yaml", False),
+        (DATA_DIR / "image_single_track_release.yaml", True),
         (DATA_DIR / "image_with_release.yaml", True),
         (DATA_DIR / "image_without_release.yaml", True),
-        (DATA_DIR / "image_all_eol_tracks.yaml", False),
     ],
     indirect=["prep_execution"],
 )
@@ -62,5 +65,6 @@ def test_release_to(prep_execution, release_to):
     github_output_content = github_output.read_text("utf8")
     
     assert re.search(
-        "^release-to=" + "true" if release_to else "", github_output_content, re.M
-    ), "Invalid release-to value"
+                f'^release-to={"true" if release_to else ""}$' , github_output_content, re.M
+            ), \
+        "Invalid release-to value"

--- a/tests/integration/test_prepare_single_image_build_matrix.py
+++ b/tests/integration/test_prepare_single_image_build_matrix.py
@@ -60,7 +60,7 @@ def test_release_to(prep_execution, release_to):
     prepare_build_matrix()
 
     github_output_content = github_output.read_text("utf8")
-    print(github_output_content)
+    
     assert re.search(
         "^release-to=" + "true" if release_to else "", github_output_content, re.M
     ), "Invalid release-to value"

--- a/tests/integration/test_prepare_single_image_build_matrix.py
+++ b/tests/integration/test_prepare_single_image_build_matrix.py
@@ -1,0 +1,66 @@
+# from pathlib import Path
+# import pytest
+
+# from src.image.utils.schema.triggers import ImageTriggerValidationError
+# import yaml
+# from glob import glob
+from src.image.prepare_single_image_build_matrix import main as prepare_build_matrix
+import pytest
+import re
+import shutil
+import sys
+
+from .. import DATA_DIR
+
+
+@pytest.fixture
+def prep_execution(tmpdir, monkeypatch, request):
+
+    image_trigger_sample = getattr(request, "param", None)
+
+    # configure files/env requried for the test
+    github_output = tmpdir / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+
+    revision_data_dir = tmpdir / "revision-data"
+    revision_data_dir.mkdir()
+
+    oci_trigger_dir = tmpdir / "image_trigger"
+    oci_trigger_dir.mkdir()
+    shutil.copy(
+        image_trigger_sample,
+        oci_trigger_dir / "image.yaml",
+    )
+
+    # patch the arv for the test. script.py can be anything
+    args = (
+        f"--oci-path {oci_trigger_dir} --revision-data-dir {revision_data_dir}".split(
+            " "
+        )
+    )
+    monkeypatch.setattr(sys, "argv", ["script.py"] + args)
+
+    return revision_data_dir, github_output
+
+
+@pytest.mark.parametrize(
+    "prep_execution, release_to",
+    [
+        (DATA_DIR / "image_with_release.yaml", True),
+        (DATA_DIR / "image_without_release.yaml", True),
+        (DATA_DIR / "image_all_eol_tracks.yaml", False),
+    ],
+    indirect=["prep_execution"],
+)
+def test_release_to(prep_execution, release_to):
+    """Test state of release-to in github output after running prepare_single_image_build_matrix"""
+    _, github_output = prep_execution
+
+    # run main from prepare_single_image_build_matrix
+    prepare_build_matrix()
+
+    github_output_content = github_output.read_text("utf8")
+    print(github_output_content)
+    assert re.search(
+        "^release-to=" + "true" if release_to else "", github_output_content, re.M
+    ), "Invalid release-to value"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines
---

Included in this PR:
- fix for determining if there are builds to execute for image trigger files
- tests to check behavior of this change
