### PR TITLE
Fix image name collision in Swift

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "987"
+            "target": "996"
         },
         "beta": {
-            "target": "987"
+            "target": "996"
         },
         "edge": {
-            "target": "987"
+            "target": "996"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "987"
+            "target": "996"
         },
         "beta": {
-            "target": "987"
+            "target": "996"
         },
         "edge": {
-            "target": "987"
+            "target": "996"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "988"
+            "target": "997"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/prometheus/_releases.json
+++ b/oci/prometheus/_releases.json
@@ -268,5 +268,80 @@
         "edge": {
             "target": "2.45-22.04_beta"
         }
+    },
+    "2.53-24.04": {
+        "end-of-life": "2025-03-14T00:00:00Z",
+        "stable": {
+            "target": "111"
+        },
+        "candidate": {
+            "target": "2.53-24.04_stable"
+        },
+        "beta": {
+            "target": "2.53-24.04_candidate"
+        },
+        "edge": {
+            "target": "2.53-24.04_beta"
+        }
+    },
+    "2.53.3-24.04": {
+        "end-of-life": "2025-03-14T00:00:00Z",
+        "stable": {
+            "target": "111"
+        },
+        "candidate": {
+            "target": "2.53.3-24.04_stable"
+        },
+        "beta": {
+            "target": "2.53.3-24.04_candidate"
+        },
+        "edge": {
+            "target": "2.53.3-24.04_beta"
+        }
+    },
+    "2-24.04": {
+        "end-of-life": "2025-03-14T00:00:00Z",
+        "stable": {
+            "target": "112"
+        },
+        "candidate": {
+            "target": "2-24.04_stable"
+        },
+        "beta": {
+            "target": "2-24.04_candidate"
+        },
+        "edge": {
+            "target": "2-24.04_beta"
+        }
+    },
+    "2.55-24.04": {
+        "end-of-life": "2025-03-14T00:00:00Z",
+        "stable": {
+            "target": "112"
+        },
+        "candidate": {
+            "target": "2.55-24.04_stable"
+        },
+        "beta": {
+            "target": "2.55-24.04_candidate"
+        },
+        "edge": {
+            "target": "2.55-24.04_beta"
+        }
+    },
+    "2.55.1-24.04": {
+        "end-of-life": "2025-03-14T00:00:00Z",
+        "stable": {
+            "target": "112"
+        },
+        "candidate": {
+            "target": "2.55.1-24.04_stable"
+        },
+        "beta": {
+            "target": "2.55.1-24.04_candidate"
+        },
+        "edge": {
+            "target": "2.55.1-24.04_beta"
+        }
     }
 }

--- a/src/image/define_image_revision.sh
+++ b/src/image/define_image_revision.sh
@@ -7,11 +7,11 @@ set -x
 
 # Does image already exist in Swift?
 # If not, then this is immediately revision number 1
-swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME | grep $IMAGE_NAME || \
+swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME/ | grep $IMAGE_NAME || \
     (echo "revision=1" >> "$GITHUB_OUTPUT" && exit 0)
 
 # If the script gets here, then it means this image already has revisions
-highest_revision=$(swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME \
+highest_revision=$(swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME/ \
                     | sort -t / -k 3 -V \
                     | tail -1 \
                     | awk -F'/' '{print $3}')

--- a/src/image/get_canonical_tags_from_swift.sh
+++ b/src/image/get_canonical_tags_from_swift.sh
@@ -5,7 +5,7 @@ source $(dirname $0)/../configs/swift.public.novarc
 
 set -x
 
-canonical_tags=$(swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME \
+canonical_tags=$(swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME/ \
     | awk -F '/' '{print $2"_"$3}' | uniq | sort | tr '\n' ',')
 
 echo "canonical-tags=${canonical_tags}" >> "$GITHUB_OUTPUT"

--- a/src/uploads/swift_lockfile_lock.sh
+++ b/src/uploads/swift_lockfile_lock.sh
@@ -26,7 +26,7 @@ pushd "${staging_area}"
 # are waiting for the lockfile to get removed, and they may exit 
 # the while loop at the same time, getting into a race condition.
 while [ $TIMEOUT -gt 0 ]; do
-    swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME | grep "lockfile.lock" && sleep $SLEEP_TIME || break
+    swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME/ | grep "lockfile.lock" && sleep $SLEEP_TIME || break
     TIMEOUT=$(( $TIMEOUT - $SLEEP_TIME ))
     if [ $TIMEOUT -lt 1 ]; then
         echo "Timeout reached while waiting to write lockfile into the Swift container for ${IMAGE_NAME}."

--- a/src/uploads/swift_lockfile_unlock.sh
+++ b/src/uploads/swift_lockfile_unlock.sh
@@ -12,6 +12,6 @@ IMAGE_NAME=$1
 # if it does not, emit an error
 # SWIFT_CONTAINER_NAME comes from env
 LOCKFILE="${IMAGE_NAME}/lockfile.lock"
-swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME | grep "$LOCKFILE" && \
+swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME/ | grep "$LOCKFILE" && \
     (swift delete $SWIFT_CONTAINER_NAME "$LOCKFILE" && echo "Lock file removed successfully.") || \
     echo "Lock file does not exist."

--- a/tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -15,15 +15,16 @@ import io
 import json
 import logging
 import os
-from datetime import datetime, timezone
-import requests
-import swiftclient
 import sys
 import tempfile
 import time
-import yaml
 import zipfile
+from datetime import datetime, timezone
+from fnmatch import fnmatchcase
 
+import requests
+import swiftclient
+import yaml
 
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)
@@ -103,11 +104,10 @@ if __name__ == "__main__":
             )
 
             # This is the metadata file we want to get from Swift
-            build_metadata_file = "build_metadata.json"
+            # match objects with name <IMAGE_NAME>/<TRACK>/<REVISION>/build_metadata.json
             img_objs = list(
                 filter(
-                    lambda o: o["name"].startswith(image)
-                    and o["name"].endswith(build_metadata_file),
+                    lambda o: fnmatchcase(o["name"], f"{image}/*/*/build_metadata.json"),
                     swift_oci_factory_objs,
                 )
             )


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

This PR fixes the recent bug in OCI-Factory where incorrect revision data was selected causing an error. Previously the start of the image name was selected, creating collisions between images like grafana and grafana-agent. This PR ensure the full image name is matched.