### PR TITLE
Relocate GitHub Summary Vulnerability Report

### DIFF
--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -271,35 +271,6 @@ jobs:
           name: ${{ steps.configure-trivy.outputs.report-name }}
           path: ${{ steps.configure-trivy.outputs.report-name}}
 
-
-      # We have to walk through the vulnerabilities since trivy does not support outputting the results as Markdown
-      - name: Create markdown content
-        id: create-markdown
-        run: |
-          set -x
-
-          vulnerabilities="$(jq -r -c '[
-            try(.scanner.result.Results[])
-            | .Target as $target
-            | .Vulnerabilities
-            | select(. != null)
-            | .[]
-            | {Target: $target, LastModifiedDate: .LastModifiedDate, VulnerabilityID: .VulnerabilityID,
-              PkgName: .PkgName, Severity: .Severity}
-                  ]' < ${{ steps.configure-trivy.outputs.report-name }})"
-
-          num_vulns=$(echo '$vulnerabilities' | jq -r 'length')
-          
-          if [[ $num_vulns -gt 0 ]]; then
-            echo "# Vulnerabilities found for ${{ inputs.oci-archive-name }}" >> $GITHUB_STEP_SUMMARY
-            title="Vulnerabilities found for ${{ inputs.oci-archive-name }}"
-            echo "## $title" >> $GITHUB_STEP_SUMMARY
-            echo "| ID | Target | Severity | Package |" >> $GITHUB_STEP_SUMMARY
-            echo "| -- | ----- | -------- | ------- |" >> $GITHUB_STEP_SUMMARY
-            echo '$vulnerabilities' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> $GITHUB_STEP_SUMMARY
-          fi
-          
-
   test-malware:
     runs-on: ubuntu-22.04
     name: "test-malware ${{ inputs.oci-archive-name != '' && format('| {0}', inputs.oci-archive-name) || ' '}}"

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -271,6 +271,35 @@ jobs:
           name: ${{ steps.configure-trivy.outputs.report-name }}
           path: ${{ steps.configure-trivy.outputs.report-name}}
 
+
+      # We have to walk through the vulnerabilities since trivy does not support outputting the results as Markdown
+      - name: Create markdown content
+        id: create-markdown
+        run: |
+          set -x
+
+          vulnerabilities="$(jq -r -c '[
+            try(.scanner.result.Results[])
+            | .Target as $target
+            | .Vulnerabilities
+            | select(. != null)
+            | .[]
+            | {Target: $target, LastModifiedDate: .LastModifiedDate, VulnerabilityID: .VulnerabilityID,
+              PkgName: .PkgName, Severity: .Severity}
+                  ]' < ${{ steps.configure-trivy.outputs.report-name }})"
+
+          num_vulns=$(echo '$vulnerabilities' | jq -r 'length')
+          
+          if [[ $num_vulns -gt 0 ]]; then
+            echo "# Vulnerabilities found for ${{ inputs.oci-archive-name }}" >> $GITHUB_STEP_SUMMARY
+            title="Vulnerabilities found for ${{ inputs.oci-archive-name }}"
+            echo "## $title" >> $GITHUB_STEP_SUMMARY
+            echo "| ID | Target | Severity | Package |" >> $GITHUB_STEP_SUMMARY
+            echo "| -- | ----- | -------- | ------- |" >> $GITHUB_STEP_SUMMARY
+            echo '$vulnerabilities' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> $GITHUB_STEP_SUMMARY
+          fi
+          
+
   test-malware:
     runs-on: ubuntu-22.04
     name: "test-malware ${{ inputs.oci-archive-name != '' && format('| {0}', inputs.oci-archive-name) || ' '}}"

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -275,6 +275,7 @@ jobs:
       # We have to walk through the vulnerabilities since trivy does not support outputting the results as Markdown
       - name: Create markdown content
         id: create-markdown
+        if: ${{ !cancelled() }}
         run: |
           set -x
 

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -288,7 +288,7 @@ jobs:
               PkgName: .PkgName, Severity: .Severity}
                   ]' < ${{ steps.configure-trivy.outputs.report-name }})"
 
-          num_vulns=$(echo '$vulnerabilities' | jq -r 'length')
+          num_vulns=$(echo "$vulnerabilities" | jq -r 'length')
           
           if [[ $num_vulns -gt 0 ]]; then
             echo "# Vulnerabilities found for ${{ inputs.oci-archive-name }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -297,7 +297,7 @@ jobs:
             echo "## $title" >> $GITHUB_STEP_SUMMARY
             echo "| ID | Target | Severity | Package |" >> $GITHUB_STEP_SUMMARY
             echo "| -- | ----- | -------- | ------- |" >> $GITHUB_STEP_SUMMARY
-            echo '$vulnerabilities' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> $GITHUB_STEP_SUMMARY
+            echo "$vulnerabilities" | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> $GITHUB_STEP_SUMMARY
           fi
           
 

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -213,12 +213,6 @@ jobs:
             echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Write to summary
-        if: ${{ !inputs.create-issue && steps.create-markdown.outputs.vulnerability-exists == 'true' }}
-        run: |
-          echo "# Vulnerabilities found for ${{ inputs.oci-image-name }}" >> $GITHUB_STEP_SUMMARY
-          cat ${{ steps.create-markdown.outputs.issue-body-file }} | tail -n +2 >> $GITHUB_STEP_SUMMARY
-
       - id: issue-exists
         if: ${{ inputs.create-issue}}
         run: |

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -213,6 +213,12 @@ jobs:
             echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Write to summary
+        if: ${{ !inputs.create-issue && steps.create-markdown.outputs.vulnerability-exists == 'true' }}
+        run: |
+          echo "# Vulnerabilities found for ${{ inputs.oci-image-name }}" >> $GITHUB_STEP_SUMMARY
+          cat ${{ steps.create-markdown.outputs.issue-body-file }} | tail -n +2 >> $GITHUB_STEP_SUMMARY
+
       - id: issue-exists
         if: ${{ inputs.create-issue}}
         run: |

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1059"
+            "target": "1065"
         },
         "beta": {
-            "target": "1059"
+            "target": "1065"
         },
         "edge": {
-            "target": "1059"
+            "target": "1065"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1059"
+            "target": "1065"
         },
         "beta": {
-            "target": "1059"
+            "target": "1065"
         },
         "edge": {
-            "target": "1059"
+            "target": "1065"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1060"
+            "target": "1066"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

Included in this PR:
  - remove GitHub summary vulnerability report from .github/workflows/Vulnerability-Scan.yaml and add it to .github/workflows/Test-Rock.yaml so the report is published globally. 
