### PR TITLE
fix(ci): only use GH runners for PRs

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix: ${{ fromJSON(needs.configure-build.outputs.runner-build-matrix) }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-22.04' || matrix.runner }}
     name: "runner-build | ${{ matrix.architecture }} ${{ inputs.build-id != '' && format('| {0}', inputs.build-id) || ' '}}"
     steps:
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1074"
+            "target": "1077"
         },
         "beta": {
-            "target": "1074"
+            "target": "1077"
         },
         "edge": {
-            "target": "1074"
+            "target": "1077"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1074"
+            "target": "1077"
         },
         "beta": {
-            "target": "1074"
+            "target": "1077"
         },
         "edge": {
-            "target": "1074"
+            "target": "1077"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1075"
+            "target": "1078"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This is used to overcome the compliance issues
wrt using self-hosted runners within PRs


### Related issues
Ref: https://github.com/canonical/oci-factory/actions/runs/12765151616/job/35578834432?pr=306

