### PR TITLE
chore(ci): bump upload-artifact to v4

### DIFF
--- a/.github/workflows/_CLI-Client.yaml
+++ b/.github/workflows/_CLI-Client.yaml
@@ -31,7 +31,7 @@ jobs:
         id: snapcraft
         with:
           path: tools/cli-client
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1080"
+            "target": "1083"
         },
         "beta": {
-            "target": "1080"
+            "target": "1083"
         },
         "edge": {
-            "target": "1080"
+            "target": "1083"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1080"
+            "target": "1083"
         },
         "beta": {
-            "target": "1080"
+            "target": "1083"
         },
         "edge": {
-            "target": "1080"
+            "target": "1083"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1081"
+            "target": "1084"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Bump `actions/upload-artifact@v3` to `v4`, since `v3` is deprecated.

### Related issues
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

---

*Picture of a cool rock:*
