### PR TITLE
Allow black-box test on non-pebble entrypoint

### DIFF
--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -158,11 +158,22 @@ jobs:
         run: |
           docker create ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
 
-      - name: Test rock
+      - name: Test rock with pebble entry point
+        id: test-pebble-entrypoint
+        timeout-minutes: 10
+        continue-on-error: true
         run: |
           set -ex
           docker run --rm ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
             help | grep Pebble
+
+      - name: Test rock with custom entry point
+        if: steps.test-pebble-entrypoint.outcome == 'failure' || steps.test-pebble-entrypoint.outcome == 'cancelled'
+        timeout-minutes: 10
+        run: |
+          set -ex
+          docker run --rm -d --name ${{ env.TEST_IMAGE_NAME }} ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
+          docker exec ${{ env.TEST_IMAGE_NAME }} pebble help | grep Pebble
 
   test-efficiency:
     runs-on: ubuntu-22.04

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -158,18 +158,29 @@ jobs:
         run: |
           docker create ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
 
-      - name: Test rock with pebble entry point
+      - name: Test if rock is with pebble entrypoint
         id: test-pebble-entrypoint
-        timeout-minutes: 10
-        continue-on-error: true
+        run: |
+          set -ex
+          entrypoint_cmd="$(docker inspect ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} | jq -r '.[0].Config.Entrypoint | join(" ")')"
+          entrypoint="$(echo $entrypoint_cmd | cut -d' ' -f1)"
+          rock_has_entrypoint_service=false
+          test "$entrypoint" = "/bin/pebble" || test "$entrypoint" = "/usr/bin/pebble"
+          if [ $(echo "$entrypoint_cmd" | wc -w) -gt 2 ]; then
+            rock_has_entrypoint_service=true
+          fi
+          echo "rock_has_entrypoint_service=$rock_has_entrypoint_service" >> "$GITHUB_OUTPUT"
+          
+
+      - name: Test rock with pebble entry point
+        if: steps.test-pebble-entrypoint.outputs.rock_has_entrypoint_service == 'false'
         run: |
           set -ex
           docker run --rm ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
             help | grep Pebble
 
       - name: Test rock with custom entry point
-        if: steps.test-pebble-entrypoint.outcome == 'failure' || steps.test-pebble-entrypoint.outcome == 'cancelled'
-        timeout-minutes: 10
+        if: steps.test-pebble-entrypoint.outputs.rock_has_entrypoint_service == 'true'
         run: |
           set -ex
           docker run --rm -d --name ${{ env.TEST_IMAGE_NAME }} ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -158,33 +158,11 @@ jobs:
         run: |
           docker create ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
 
-      - name: Test if rock is with pebble entrypoint
-        id: test-pebble-entrypoint
+      - name: Test rock
         run: |
           set -ex
-          entrypoint_cmd="$(docker inspect ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} | jq -r '.[0].Config.Entrypoint | join(" ")')"
-          entrypoint="$(echo $entrypoint_cmd | cut -d' ' -f1)"
-          rock_has_entrypoint_service=false
-          test "$entrypoint" = "/bin/pebble" || test "$entrypoint" = "/usr/bin/pebble"
-          if [ $(echo "$entrypoint_cmd" | wc -w) -gt 2 ]; then
-            rock_has_entrypoint_service=true
-          fi
-          echo "rock_has_entrypoint_service=$rock_has_entrypoint_service" >> "$GITHUB_OUTPUT"
-          
-
-      - name: Test rock with pebble entry point
-        if: steps.test-pebble-entrypoint.outputs.rock_has_entrypoint_service == 'false'
-        run: |
-          set -ex
-          docker run --rm ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+          docker run --rm --entrypoint pebble ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
             help | grep Pebble
-
-      - name: Test rock with custom entry point
-        if: steps.test-pebble-entrypoint.outputs.rock_has_entrypoint_service == 'true'
-        run: |
-          set -ex
-          docker run --rm -d --name ${{ env.TEST_IMAGE_NAME }} ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
-          docker exec ${{ env.TEST_IMAGE_NAME }} pebble help | grep Pebble
 
   test-efficiency:
     runs-on: ubuntu-22.04

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1086"
+            "target": "1095"
         },
         "beta": {
-            "target": "1086"
+            "target": "1095"
         },
         "edge": {
-            "target": "1086"
+            "target": "1095"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1086"
+            "target": "1095"
         },
         "beta": {
-            "target": "1086"
+            "target": "1095"
         },
         "edge": {
-            "target": "1086"
+            "target": "1095"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1087"
+            "target": "1096"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1101"
+            "target": "1104"
         },
         "beta": {
-            "target": "1101"
+            "target": "1104"
         },
         "edge": {
-            "target": "1101"
+            "target": "1104"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1101"
+            "target": "1104"
         },
         "beta": {
-            "target": "1101"
+            "target": "1104"
         },
         "edge": {
-            "target": "1101"
+            "target": "1104"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1102"
+            "target": "1105"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1095"
+            "target": "1101"
         },
         "beta": {
-            "target": "1095"
+            "target": "1101"
         },
         "edge": {
-            "target": "1095"
+            "target": "1101"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1095"
+            "target": "1101"
         },
         "beta": {
-            "target": "1095"
+            "target": "1101"
         },
         "edge": {
-            "target": "1095"
+            "target": "1101"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1096"
+            "target": "1102"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR allows the Test-Rock workflow to test rocks using [entrypoint services](https://documentation.ubuntu.com/rockcraft/en/latest/reference/rockcraft.yaml.html#entrypoint-service) as the entrypoint.

Current black-box testing workflow gets stuck in infinite loops in this scenarios.

### Related issues
https://github.com/canonical/oci-factory/actions/runs/13135426670/job/36650178857?pr=342

### Test workflow runs:
- Black-box testing mock-rock with "entrypoint-service": https://github.com/canonical/oci-factory/actions/runs/13178150156/job/36782455844#step:7:17
- Black-box testing mock-rock with normal pebble entrypoint: https://github.com/canonical/oci-factory/actions/runs/13178315059/job/36783170764#step:6:17