### PR TITLE
feat: notify in MM channel when test-rock fails in Image workflow

### DIFF
--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -171,7 +171,7 @@ jobs:
     needs: [prepare-build, build-rock]
     # TODO: Remove tmp-cache-job when removing the job tmp-cache-job
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-build.outputs.build-matrix) }}
     uses: ./.github/workflows/Test-Rock.yaml
     with:

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -586,7 +586,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Notify
     needs:
-      [prepare-build, build-rock, upload, prepare-releases, generate-provenance]
+      [prepare-build, build-rock, test-rock, upload, prepare-releases, generate-provenance]
     if: ${{ !cancelled() && contains(needs.*.result, 'failure') && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v4

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1110"
+            "target": "1140"
         },
         "beta": {
-            "target": "1110"
+            "target": "1140"
         },
         "edge": {
-            "target": "1110"
+            "target": "1140"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1110"
+            "target": "1140"
         },
         "beta": {
-            "target": "1110"
+            "target": "1140"
         },
         "edge": {
-            "target": "1110"
+            "target": "1140"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1111"
+            "target": "1141"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1140"
+            "target": "1143"
         },
         "beta": {
-            "target": "1140"
+            "target": "1143"
         },
         "edge": {
-            "target": "1140"
+            "target": "1143"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1140"
+            "target": "1143"
         },
         "beta": {
-            "target": "1140"
+            "target": "1143"
         },
         "edge": {
-            "target": "1140"
+            "target": "1143"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1141"
+            "target": "1144"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1143"
+            "target": "1146"
         },
         "beta": {
-            "target": "1143"
+            "target": "1146"
         },
         "edge": {
-            "target": "1143"
+            "target": "1146"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1143"
+            "target": "1146"
         },
         "beta": {
-            "target": "1143"
+            "target": "1146"
         },
         "edge": {
-            "target": "1143"
+            "target": "1146"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1144"
+            "target": "1147"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR allows the Image workflow to send notifications to the corresponding contact MM channel when the Image workflow fails in `test-rock`.

Previously, failures in `test-rock` will not cause notifications to be sent, and found vulnerabilities will be reported as a GH issue only when triggered by the Continuous image testing workflow.

### Related issues
- Failed workflow w/o notifications: https://github.com/canonical/oci-factory/actions/runs/13167940648/job/36752901794
- Test workflow that emits notifications: https://github.com/canonical/oci-factory/actions/runs/13197955628/job/36843962880

---

