### PR TITLE
stable release for valkey with LTS support

### DIFF
--- a/oci/valkey/image.yaml
+++ b/oci/valkey/image.yaml
@@ -6,6 +6,6 @@ upload:
     directory: .
     release:
       7.2.7-24.04:
-        end-of-life: "2025-12-01T00:00:00Z"
+        end-of-life: "2034-04-01T00:00:00Z"
         risks:
-          - edge
+          - stable


### PR DESCRIPTION
Update the channel tag for Valkey from `edge` to `stable` and update the support period according to the LTS of 24.04.