### PR TITLE
Valkey - remove "edge" from command in docs

### DIFF
--- a/oci/valkey/documentation.yaml
+++ b/oci/valkey/documentation.yaml
@@ -11,7 +11,7 @@ description: |
 
   To deploy a simple Valkey container:
   ```bash
-  docker run --name valkey ubuntu/valkey:7.2.7-24.04_edge
+  docker run --name valkey ubuntu/valkey:7.2.7-24.04
   ```
 
   To connect to Valkey and check status:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
I have removed the suffix `_edge` from the command in the docs
