### PR TITLE
chore(ci): bump and remove runs on ubuntu 20.04

### DIFF
--- a/.github/workflows/CLA-Check.yaml
+++ b/.github/workflows/CLA-Check.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   cla-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v2

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -139,7 +139,7 @@ jobs:
   test-black-box:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     name: "test-black-box ${{ inputs.oci-archive-name != '' && format('| {0}', inputs.oci-archive-name) || ' '}}"
     needs: [configure-tests]

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1182"
+            "target": "1185"
         },
         "beta": {
-            "target": "1182"
+            "target": "1185"
         },
         "edge": {
-            "target": "1182"
+            "target": "1185"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1182"
+            "target": "1185"
         },
         "beta": {
-            "target": "1182"
+            "target": "1185"
         },
         "edge": {
-            "target": "1182"
+            "target": "1185"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1183"
+            "target": "1186"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
Bump jobs running on Ubuntu 20.04 runner to 22.04, and remove 20.04 from `Test-Rock` runner os matrix.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
https://github.com/actions/runner-images/issues/11101
