### PR TITLE
fix(ci): use self-hosted runners for PRs

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix: ${{ fromJSON(needs.configure-build.outputs.runner-build-matrix) }}
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-22.04' || matrix.runner }}
+    runs-on: ${{ matrix.runner }}
     name: "runner-build | ${{ matrix.architecture }} ${{ inputs.build-id != '' && format('| {0}', inputs.build-id) || ' '}}"
     steps:
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1182"
+            "target": "1191"
         },
         "beta": {
-            "target": "1182"
+            "target": "1191"
         },
         "edge": {
-            "target": "1182"
+            "target": "1191"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1182"
+            "target": "1191"
         },
         "beta": {
-            "target": "1182"
+            "target": "1191"
         },
         "edge": {
-            "target": "1182"
+            "target": "1191"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1183"
+            "target": "1192"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1191"
+            "target": "1194"
         },
         "beta": {
-            "target": "1191"
+            "target": "1194"
         },
         "edge": {
-            "target": "1191"
+            "target": "1194"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1191"
+            "target": "1194"
         },
         "beta": {
-            "target": "1191"
+            "target": "1194"
         },
         "edge": {
-            "target": "1191"
+            "target": "1194"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1192"
+            "target": "1195"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
The compliance setups have changed in canonical/repo-policy-compliance. Trying to restore the use of self-hosted runners to enable onboarding images that support archs other than `amd64`.

### Related workflow runs
Workflow on self-hosted arm64 runner triggered by PR: https://github.com/canonical/oci-factory/actions/runs/13674237778/job/38231123800?pr=379

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
https://github.com/canonical/repo-policy-compliance/pull/1905
