### PR TITLE
Revert "fix(ci): use self-hosted runners for PRs"

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix: ${{ fromJSON(needs.configure-build.outputs.runner-build-matrix) }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-22.04' || matrix.runner }}
     name: "runner-build | ${{ matrix.architecture }} ${{ inputs.build-id != '' && format('| {0}', inputs.build-id) || ' '}}"
     steps:
 

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1194"
+            "target": "1188"
         },
         "beta": {
-            "target": "1194"
+            "target": "1188"
         },
         "edge": {
-            "target": "1194"
+            "target": "1188"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1194"
+            "target": "1188"
         },
         "beta": {
-            "target": "1194"
+            "target": "1188"
         },
         "edge": {
-            "target": "1194"
+            "target": "1188"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1195"
+            "target": "1189"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
Reverts canonical/oci-factory#380

Test to unblock arm based builds failed... reverting.
See: https://github.com/canonical/oci-factory/actions/runs/13679323470/job/38247405335?pr=378#step:2:9