### PR TITLE
fix(ci): address CVE-2025-30066

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -51,7 +51,7 @@ jobs:
           github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
       - name: Infer images to document
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         id: changed-files
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         with:

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Infer number of image triggers
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         id: changed-files
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         with:

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         with:
           json: true
           files: |
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get image name
         id: changed-files-dir-names
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         with:
           dir_names: "true"
           files: |

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -48,7 +48,7 @@ jobs:
           github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
       - name: Infer number of image triggers
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         id: changed-files
         with:
           dir_names: "true"

--- a/.github/workflows/_Auto-updates.yaml
+++ b/.github/workflows/_Auto-updates.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Get updated filenames
-        uses: tj-actions/changed-files@v35
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         id: changed-files
         with:
           json: true


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Address https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/ by pinning the action to a known safe sha.

### Related issues
https://github.com/tj-actions/changed-files/issues/2463
