### PR TITLE
feat: use dedicated mattermost channel for jre rock notifications

### DIFF
--- a/oci/jre/contacts.yaml
+++ b/oci/jre/contacts.yaml
@@ -2,4 +2,4 @@ notify:
   emails:
     - foundations-crew@lists.canonical.com
   mattermost-channels:
-    - oau4mk4kw7y17psmmc9jyeyeeo
+    - fjogmntyqpy99cjfhdkzuet57h


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

In order to avoid spamming discussion channels, make a dedicated notification channel.

### Related issues

---

*Picture of a cool rock:*
