### PR TITLE
feat: add jre/11_edge to oci-factory

### DIFF
--- a/oci/glauth/_releases.json
+++ b/oci/glauth/_releases.json
@@ -1,17 +1,17 @@
 {
     "2-22.04": {
-        "end-of-life": "2025-06-19T00:00:00Z",
+        "end-of-life": "2025-06-24T00:00:00Z",
         "stable": {
-            "target": "14"
+            "target": "15"
         },
         "candidate": {
-            "target": "14"
+            "target": "2-22.04_stable"
         },
         "edge": {
-            "target": "14"
+            "target": "2-22.04_beta"
         },
         "beta": {
-            "target": "14"
+            "target": "2-22.04_candidate"
         }
     }
 }

--- a/oci/jre/documentation.yaml
+++ b/oci/jre/documentation.yaml
@@ -121,7 +121,7 @@ debug:
     docker logs -f openjdk-jre-container
     ```
 
-    For version 11 and 21, to inspect application logs:
+    For versions 11 and 21, to inspect application logs:
 
     ```bash
     docker exec openjdk-jre-container pebble logs

--- a/oci/jre/documentation.yaml
+++ b/oci/jre/documentation.yaml
@@ -94,7 +94,7 @@ description: |
   CMD [ "HelloWorld" ]
   ```
 
-  For version 11 and 21 please use
+  For versions 11 and 21 please use
 
   ```docker
   FROM ubuntu:24.04 AS builder

--- a/oci/jre/documentation.yaml
+++ b/oci/jre/documentation.yaml
@@ -34,7 +34,7 @@ description: |
   Usage: java [options] <mainclass> [args...]
   ```
 
-  Version 21 image has `pebble enter` as the entrypoint. You can
+  Version 11 and 21 images have `pebble enter` as the entrypoint. You can
   access the `java` with the following command:
 
   ```bash
@@ -52,7 +52,7 @@ description: |
   ```bash
   docker run -d --name jre-container -e TZ=UTC ubuntu/jre:17-22.04_edge
   ```
-  For version 21
+  For version 11 and 21
 
   ```bash
   docker run -d --name jre-container -e TZ=UTC ubuntu/jre:21-24.04_edge exec java
@@ -94,10 +94,10 @@ description: |
   CMD [ "HelloWorld" ]
   ```
 
-  For version 21 please use
+  For version 11 and 21 please use
 
   ```docker
-  FROM ubuntu:22.04 AS builder
+  FROM ubuntu:24.04 AS builder
   RUN apt-get update && apt-get install -y openjdk-8-jdk
   WORKDIR /app
   ADD HelloWorld.java .
@@ -121,7 +121,7 @@ debug:
     docker logs -f openjdk-jre-container
     ```
 
-    For version 21, to inspect application logs:
+    For version 11 and 21, to inspect application logs:
 
     ```bash
     docker exec openjdk-jre-container pebble logs

--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -17,7 +17,7 @@ upload:
     directory: jre/ubuntu-24.04-headless
     release:
       11-24.04:
-        end-of-life: "2031-09-30T00:00:00Z"
+        end-of-life: "2026-09-30T00:00:00Z"
         risks:
           - stable
           - candidate

--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -12,3 +12,14 @@ upload:
           - candidate
           - beta
           - edge
+  - source: canonical/jre-rock
+    commit: 6e5b3ee98a7e6991c1913ac8f74596f7c7fbdda9
+    directory: jre/ubuntu-24.04-headless
+    release:
+      21-24.04:
+        end-of-life: "2031-09-30T00:00:00Z"
+        risks:
+          - stable
+          - candidate
+          - beta
+          - edge

--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -16,7 +16,7 @@ upload:
     commit: 6e5b3ee98a7e6991c1913ac8f74596f7c7fbdda9
     directory: jre/ubuntu-24.04-headless
     release:
-      21-24.04:
+      11-24.04:
         end-of-life: "2031-09-30T00:00:00Z"
         risks:
           - stable


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

This PR adds chiselled jre runtime for openjdk 11.

### Related issues

---

*Picture of a cool rock:*
