### PR TITLE
feat(ci): attach sbom to GH releases

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -31,7 +31,7 @@ on:
       arch-map:
         description: "JSON string mapping target architecture to runners."
         type: string
-        default: '{"amd64": ["self-hosted", "linux", "X64", "medium", "jammy"], "arm64": ["self-hosted", "linux", "ARM64", "medium", "jammy"]}'
+        default: '{"amd64": ["self-hosted", "linux", "X64", "large", "jammy"], "arm64": ["self-hosted", "linux", "ARM64", "medium", "jammy"]}'
       lpci-fallback:
         description: "Enable fallback to Launchpad build when runners for target arch are not available."
         type: boolean

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -346,11 +346,11 @@ jobs:
 
             syft oci-archive:${{ steps.rename-oci-archive.outputs.name }}.${arch} \
               -o spdx-json \
-              --file ${{ steps.rename-oci-archive.outputs.name }}.${arch}.sbom.spdx.json
+              --file ${{ steps.rename-oci-archive.outputs.name }}.${arch}.sbom_preview.spdx.json
           done
 
-          all_sboms_zip="${{ steps.rename-oci-archive.outputs.name }}.sbom.spdx.zip"
-          zip "${all_sboms_zip}" ${{ steps.rename-oci-archive.outputs.name }}.*.sbom.spdx.json
+          all_sboms_zip="${{ steps.rename-oci-archive.outputs.name }}.sbom_preview.spdx.zip"
+          zip "${all_sboms_zip}" ${{ steps.rename-oci-archive.outputs.name }}.*.sbom_preview.spdx.json
 
           echo "sboms=${all_sboms_zip}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -26,7 +26,7 @@ on:
         description: 'Cache key (to fetch image trigger from cache)'
         required: false
         type: string
-           
+
 jobs:
   validate-push-release-request:
     runs-on: ubuntu-22.04
@@ -186,7 +186,23 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ matrix.canonical-tag }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: '*.sbom_preview.spdx.zip'
+          path: sbom
       
+      - name: Unzip SBOM artifacts
+        run: |
+          set -x
+          sbom_target_dir="$(pwd)/sbom"
+          for dir in $(ls sbom); do
+            pushd sbom/$dir
+            unzip '*.zip' -d ${sbom_target_dir}
+            popd
+          done
+
+
       - uses: dev-drprasad/delete-tag-and-release@v1.0
         # We force delete an existing tag because otherwise we won't get
         # an email notification and the GH release will have the date from when
@@ -210,3 +226,4 @@ jobs:
           name: "${{ matrix.release-name }}"
           tag_name: "${{ matrix.release-name }}"
           token: "${{ secrets.ROCKSBOT_TOKEN }}"
+          files: "sbom/*.sbom_preview.spdx.json"

--- a/oci/identity-platform-admin-ui/image.yaml
+++ b/oci/identity-platform-admin-ui/image.yaml
@@ -1,12 +1,36 @@
-version: 1
 upload:
-  - source: "canonical/identity-platform-admin-ui"
-    commit: c46a9568f9be665f86aa5a274d8ac9d90054ba6b
-    directory: .
-    release:
-      1.19.0-22.04:
-        risks:
-          - stable
-          - candidate
-          - edge
-        end-of-life: "2025-03-01T00:00:00Z"
+- commit: c46a9568f9be665f86aa5a274d8ac9d90054ba6b
+  directory: .
+  source: canonical/identity-platform-admin-ui
+- commit: 6978657909ae0735d7d3a9d5a14fd1ed64504459
+  directory: ./
+  source: canonical/identity-platform-admin-ui
+- commit: eb0b7859f2210c9e2ce500e397ae3da688fef4de
+  directory: ./
+  source: canonical/identity-platform-admin-ui
+- commit: 6ddec745cd8011d630d7409cc6996bd1c5488a03
+  directory: ./
+  source: canonical/identity-platform-admin-ui
+- commit: ed4e5f4129513d72060178e87219f7823ed07281
+  directory: ./
+  release:
+    1-22.04:
+      end-of-life: '2025-09-11T00:00:00Z'
+      risks:
+      - stable
+      - candidate
+      - edge
+      - beta
+      - stable
+  source: canonical/identity-platform-admin-ui
+- commit: ed4e5f4129513d72060178e87219f7823ed07281
+  directory: ./
+  release:
+    1.23-22.04:
+      end-of-life: '2025-03-25T00:00:00Z'
+      risks:
+      - candidate
+      - beta
+      - edge
+  source: canonical/identity-platform-admin-ui
+version: 1

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1230"
+            "target": "1257"
         },
         "beta": {
-            "target": "1230"
+            "target": "1257"
         },
         "edge": {
-            "target": "1230"
+            "target": "1257"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1230"
+            "target": "1257"
         },
         "beta": {
-            "target": "1230"
+            "target": "1257"
         },
         "edge": {
-            "target": "1230"
+            "target": "1257"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1231"
+            "target": "1258"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1257"
+            "target": "1260"
         },
         "beta": {
-            "target": "1257"
+            "target": "1260"
         },
         "edge": {
-            "target": "1257"
+            "target": "1260"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1257"
+            "target": "1260"
         },
         "beta": {
-            "target": "1257"
+            "target": "1260"
         },
         "edge": {
-            "target": "1257"
+            "target": "1260"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1258"
+            "target": "1261"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
fix(ci): iterate over artifact dirs

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR adds the SBOMs generated with `syft` to the GH releases upon release.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A

### Releated GH Release:
https://github.com/canonical/oci-factory/releases/tag/mock-rock_1-22.04_candidate
---
