### PR TITLE
fix: update jre 11 EOL date

### DIFF
--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -17,7 +17,7 @@ upload:
     directory: jre/ubuntu-24.04-headless
     release:
       11-24.04:
-        end-of-life: "2026-09-30T00:00:00Z"
+        end-of-life: "2032-01-30T00:00:00Z"
         risks:
           - stable
           - candidate


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

Updated JRE 11 EOL date as per Oracle Roadmap[1]

[1] https://www.oracle.com/in/java/technologies/java-se-support-roadmap.html


### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
