### PR TITLE
fix(ci): crash when upload does not have release in trigger

### DIFF
--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -1,13 +1,13 @@
 {
     "latest": {
         "candidate": {
-            "target": "1294"
+            "target": "1.2-22.04_beta"
         },
         "beta": {
-            "target": "1294"
+            "target": "latest_candidate"
         },
         "edge": {
-            "target": "1294"
+            "target": "latest_beta"
         },
         "end-of-life": "2030-05-01T00:00:00Z"
     },
@@ -25,44 +25,44 @@
     },
     "test": {
         "beta": {
-            "target": "1293"
+            "target": "1.1-22.04_beta"
         },
         "edge": {
-            "target": "1293"
+            "target": "test_beta"
         },
         "end-of-life": "2030-05-01T00:00:00Z"
     },
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1293"
+            "target": "1296"
         },
         "beta": {
-            "target": "1293"
+            "target": "1296"
         },
         "edge": {
-            "target": "1293"
+            "target": "1296"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1293"
+            "target": "1296"
         },
         "beta": {
-            "target": "1293"
+            "target": "1296"
         },
         "edge": {
-            "target": "1293"
+            "target": "1296"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1294"
+            "target": "1297"
         },
         "edge": {
-            "target": "1294"
+            "target": "1.2-22.04_beta"
         }
     },
     "1.0.0-22.04": {},

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -155,7 +155,7 @@ def main():
 
     # update EOL dates from upload dictionary
     for upload in image_trigger["upload"] or []:
-        for track, upload_release_dict in (upload["release"] or {}).items():
+        for track, upload_release_dict in upload.get("release", {}).items():
             if track not in all_releases:
                 print(f"Track {track} will be created for the 1st time")
                 all_releases[track] = {}


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR fixes the `KeyError` when the custom image trigger passed to the `Release` workflow does not have a `release` field in the `upload` section.

### Related runs
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
https://github.com/canonical/oci-factory/actions/runs/14266265582/job/39989676808