### PR TITLE
feat: split dive tests to allow fails in highestUserWastedPercent

### DIFF
--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -206,7 +206,21 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v $PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml \
             ${{ env.DIVE_IMAGE }} \
-            ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} --ci-config /.dive-ci.yaml
+            ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+            --ci-config /.dive-ci.yaml \
+            --highestUserWastedPercent disabled
+
+      - name: Dive userWastedPercent test
+        continue-on-error: true
+        run: |
+          docker run -e CI=true --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v $PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml \
+            ${{ env.DIVE_IMAGE }} \
+            ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+            --ci-config /.dive-ci.yaml \
+            --lowestEfficiency disabled
+
 
   test-vulnerabilities:
     runs-on: ubuntu-22.04

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -200,7 +200,7 @@ jobs:
       # The existing Dive GH actions are outdated:
       # https://github.com/MartinHeinz/dive-action/issues/1
       # https://github.com/yuichielectric/dive-action/issues/581
-      - name: Dive efficiency test
+      - name: Dive lowestEfficiency test
         run: |
           docker run -e CI=true --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -210,7 +210,7 @@ jobs:
             --ci-config /.dive-ci.yaml \
             --highestUserWastedPercent disabled
 
-      - name: Dive userWastedPercent test
+      - name: Dive highestUserWastedPercent test
         continue-on-error: true
         run: |
           docker run -e CI=true --rm \

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1323"
+            "target": "1326"
         },
         "beta": {
-            "target": "1323"
+            "target": "1326"
         },
         "edge": {
-            "target": "1323"
+            "target": "1326"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1323"
+            "target": "1326"
         },
         "beta": {
-            "target": "1323"
+            "target": "1326"
         },
         "edge": {
-            "target": "1323"
+            "target": "1326"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1324"
+            "target": "1327"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1326"
+            "target": "1329"
         },
         "beta": {
-            "target": "1326"
+            "target": "1329"
         },
         "edge": {
-            "target": "1326"
+            "target": "1329"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1326"
+            "target": "1329"
         },
         "beta": {
-            "target": "1326"
+            "target": "1329"
         },
         "edge": {
-            "target": "1326"
+            "target": "1329"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1327"
+            "target": "1330"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

OCI Factory has been using `dive` to test the efficiency of the rocks since the very beginning. In some cases (i.e. including the `base-passwd_data` in the parts, and defining `run-user: _daemon_`), `dive` will fail the `highestUserWastedPercent` tests due to modified files in the second layer. However, since the users have no control over the layering when a rock is built with `rockcraft`, we therefore allow the rocks to fail the `highestUserWastedPercent` test, which can serve as a notification that the layering can be improved, but still enforce the `lowestEfficiency` test to pass before a rock can be released.

A minimal case to reproduce this:
```
name: dive-example
base: bare
build-base: ubuntu@24.04
version: '0.1'
summary: summary
description: |
    description
platforms:
    amd64:

run-user: _daemon_

parts:
  my-part:
    plugin: nil
    stage-packages:
      - base-passwd_data
```

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
https://github.com/canonical/oci-factory/actions/runs/14310721814/job/40105243246
