### PR TITLE
fix(ci): git pull finds conflicts merging

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -145,7 +145,7 @@ jobs:
             --all-revision-tags "${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}" \
             --ghcr-repo "${{ github.repository_owner }}/oci-factory"
       
-      - run: git pull --quiet
+      - run: git stash --quiet && git pull --quiet && git stash pop --quiet
 
       # Commit with actor's GitHub noreply email to pass CLA and keep the privacy of the actor
       - name: Commit oci/${{ inputs.oci-image-name }}/_releases.json


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
When more than one new Ubuntu release is published, an image can be rebuilt simultaneously through the `find_images_to_update.py` for different versions.

When versions a and b are triggered for rebuild at a close time, they have the same ref upon which the workflow is run. Suppose version a finishes first, committing to `oci/<image-name>/_releases.json`. No errors should occur. Later version b finishes, in the workflow, the python script modifies the same `_releases.json` file, and tries to run `git pull --quiet`. Now errors occur: 

```
error: Your local changes to the following files would be overwritten by merge:
	oci/<image-name>/_releases.json
Please commit your changes or stash them before you merge.
Aborting
```

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
 [Image - python - refs/heads/main · canonical/oci-factory@33e0a2b](https://github.com/canonical/oci-factory/actions/runs/14381879730/job/40328195914)
