### PR TITLE
add node exporter oci image v 1.9.1

### DIFF
--- a/oci/node-exporter/contacts.yaml
+++ b/oci/node-exporter/contacts.yaml
@@ -1,0 +1,6 @@
+notify:
+  emails:
+    - observability@lists.launchpad.net
+  mattermost-channels:
+    - 1ayd5kim67bbing34i3h1x9uac
+

--- a/oci/node-exporter/contacts.yaml
+++ b/oci/node-exporter/contacts.yaml
@@ -3,4 +3,3 @@ notify:
     - observability@lists.launchpad.net
   mattermost-channels:
     - 1ayd5kim67bbing34i3h1x9uac
-

--- a/oci/node-exporter/documentation.yaml
+++ b/oci/node-exporter/documentation.yaml
@@ -31,4 +31,3 @@ debug:
     ```bash
     docker exec -it node-exporter-container /bin/bash
     ```
-

--- a/oci/node-exporter/documentation.yaml
+++ b/oci/node-exporter/documentation.yaml
@@ -25,7 +25,7 @@ debug:
     
     To debug the container:
     ```bash
-    docker logs -f node-exporter-container
+    docker exec node-exporter-container pebble logs node-exporter
     ```
     To get an interactive shell:
     ```bash

--- a/oci/node-exporter/documentation.yaml
+++ b/oci/node-exporter/documentation.yaml
@@ -1,0 +1,34 @@
+version: 1
+# --- OVERVIEW INFORMATION ---
+application: node-exporter
+description: >
+  Node-exporter exposes machine metrics in Prometheus format.
+  Read more in the [official documentation](https://github.com/prometheus/node_exporter)
+  Please note that this repository holds a rock instead of a Dockerfile-based image.
+  As such, the entrypoint is Pebble.
+  Read more in the [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/).
+# --- USAGE INFORMATION ---
+docker:
+  parameters:
+    - -p 9100:9100
+  access: The metrics endpoint is available at `http://localhost:9100/metrics` 
+parameters:
+  - type: -e
+    value: 'TZ=UTC'
+    description: Timezone.
+  - type: -p
+    value: '9100:9100'
+    description: Expose the metrics endpoint on `localhost:9100/metrics`.
+debug:
+  text: |
+    ### Debugging
+    
+    To debug the container:
+    ```bash
+    docker logs -f node-exporter-container
+    ```
+    To get an interactive shell:
+    ```bash
+    docker exec -it node-exporter-container /bin/bash
+    ```
+

--- a/oci/node-exporter/image.yaml
+++ b/oci/node-exporter/image.yaml
@@ -1,0 +1,18 @@
+version: 1
+upload:
+  - source: canonical/node-exporter-rock
+    commit: 2d4179e10e761a56e54adb3a3ca43777636a3bd4
+    directory: 1.9.1
+    release:
+      1-24.04:
+        end-of-life: '2025-07-14T00:00:00Z'
+        risks:
+          - stable
+      1.9-24.04:
+        end-of-life: '2025-07-14T00:00:00Z'
+        risks:
+          - stable
+      1.9.1-24.04:
+        end-of-life: '2025-04-16T00:00:00Z'
+        risks:
+          - stable


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Adds an initial version of the node-exporter rock

### Related issues
#413 
---

*Picture of cool rock:*
![image](https://github.com/user-attachments/assets/1492b328-1b56-4dfb-bb04-dc12107b1e13)
