### PR TITLE
feat(ci): daily rebuild with its own ext ref id prefix

### DIFF
--- a/.github/workflows/Rebuild-Images.yaml
+++ b/.github/workflows/Rebuild-Images.yaml
@@ -39,5 +39,7 @@ jobs:
             OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL }}
             GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
           # TODO change the 'mock-rock' to the '*'
-          run: poetry run python3 find_images_to_update.py --image-name ${{ inputs.image-name || 'mock-rock' }}
+          run: |
+            poetry run python3 find_images_to_update.py --image-name ${{ inputs.image-name || 'mock-rock' }} \
+                                                        --ext-ref-prefix daily-rebuild
   

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1388"
+            "target": "1394"
         },
         "beta": {
-            "target": "1388"
+            "target": "1394"
         },
         "edge": {
-            "target": "1388"
+            "target": "1394"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1388"
+            "target": "1394"
         },
         "beta": {
-            "target": "1388"
+            "target": "1394"
         },
         "edge": {
-            "target": "1388"
+            "target": "1394"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1389"
+            "target": "1395"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1409"
+            "target": "1415"
         },
         "beta": {
-            "target": "1409"
+            "target": "1415"
         },
         "edge": {
-            "target": "1409"
+            "target": "1415"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1409"
+            "target": "1415"
         },
         "beta": {
-            "target": "1409"
+            "target": "1415"
         },
         "edge": {
-            "target": "1409"
+            "target": "1415"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1410"
+            "target": "1416"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -235,7 +235,7 @@ def trigger_image_rebuild():
             "oci-image-name": image,
             "b64-image-trigger": uber_img_trigger_b64.decode(),
             "upload": True,
-            "external_ref_id": f"workflow-engine-{image}-{int(time.time())}",
+            "external_ref_id": f"{external_ref_id_prefix}-{image}-{int(time.time())}",
         },
     }
     wf_dispatch_url = str(
@@ -272,9 +272,15 @@ if __name__ == "__main__":
         help="The image name to check for updates",
         default="*",
     )
+    parser.add_argument(
+        "--ext-ref-prefix",
+        help="The prefix to use for the external reference ID",
+        default="workflow-engine",
+    )
     args = parser.parse_args()
     ubuntu_release = args.ubuntu_release
     image = args.image_name
+    external_ref_id_prefix = args.ext_ref_prefix
 
     logging.info(f"Checking for image {image} to update for release {ubuntu_release}")
 


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
This PR adds an external reference id for the Image workflow triggered by daily rebuilds.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
https://github.com/canonical/oci-factory/actions/runs/14467743435/attempts/1#summary-40573979209
