### PR TITLE
chore: Add CVE-2025-30204 to trivyignore for parca

### DIFF
--- a/oci/parca/.trivyignore
+++ b/oci/parca/.trivyignore
@@ -1,0 +1,4 @@
+# Upstream CVEs
+
+# Codebase not affected, see https://github.com/canonical/parca-rock/issues/6#issuecomment-2812277725
+CVE-2025-30204


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
We used `govulncheck` to verify that parca is not affected by https://github.com/advisories/GHSA-mh63-6h87-95cp . 

### Related issues

https://github.com/canonical/parca-rock/issues/6

---

*Picture of a cool rock:*
![image](https://github.com/user-attachments/assets/56e21831-9520-41ef-b860-2b6d70561320)
