### PR TITLE
feat(ci): replace `print`s with `logging`

### DIFF
--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Prepare test matrix
         id: prepare-test-matrix
-        run: ./src/tests/get_released_revisions.py --oci-images-path $PWD/oci
+        run: python3 -m src.tests.get_released_revisions --oci-images-path $PWD/oci
 
       - name: Infer date of last scan
         id: last-scan

--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -27,7 +27,10 @@ jobs:
         run: |
           # This is scheduled to run every day, so let's look at the previous
           # 26 hours, roughly
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           last_scan="$(date --date='26 hours ago' +'%Y-%m-%dT%H:%M:00Z')"
           echo "date=$last_scan" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -63,7 +63,10 @@ jobs:
       - name: Validate image from dispatch
         id: validate-image
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
 
           # check if this is coming from a workflow dispatch/call
           # as checking github.event_name isn't reliable here
@@ -122,7 +125,10 @@ jobs:
           ECR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ECR_CREDS_PSW || secrets.ECR_CREDS_PSW_DEV }}
           ECR_NAMESPACE: ${{ env.IS_PROD == 'true' && 'ubuntu' || secrets.ECR_NAMESPACE_DEV }}
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           python3 -m src.docs.generate_oci_doc_yaml \
             --all-revision-tags "${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}" \
             --ecr-api-key "${ECR_CREDS_USR}" \
@@ -152,7 +158,10 @@ jobs:
           ECR_REGISTRY_ID: ${{ env.IS_PROD == 'true' && secrets.ECR_REGISTRY_ID || secrets.ECR_REGISTRY_ID_DEV }}
           DOCKER_HUB_NAMESPACE: ${{ env.IS_PROD == 'true' && 'docker.io/ubuntu' || secrets.DOCKER_HUB_NAMESPACE_DEV }}
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           ./src/docs/publish_docs.sh "${{ needs.validate-documentation-request.outputs.oci-img-name }}" "${{ steps.generate-documentation.outputs.name_doc_file }}" "${{ steps.generate-documentation.outputs.image_doc_folder }}"
           
   notify:

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -171,7 +171,7 @@ jobs:
         id: get-summary
         run: |
           echo '${{ toJson(needs) }}' > jobs.json
-          ./src/notifications/summarize_workflow_results.py --jobs-file jobs.json
+          python3 -m src.notifications.summarize_workflow_results --jobs-file jobs.json
 
       - name: Get contacts for ${{ needs.validate-documentation-request.outputs.oci-img-name }}
         id: get-contacts

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -73,7 +73,10 @@ jobs:
       - name: Validate image from dispatch
         id: validate-image
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
 
           # check if this is coming from a workflow dispatch/call
           # as checking github.event_name isn't reliable here
@@ -225,7 +228,10 @@ jobs:
       - name: Prepare builds matrix for upload
         id: prepare-matrix
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
 
           mkdir ${{ env.DATA_DIR }}
 
@@ -317,7 +323,10 @@ jobs:
       - name: Infer architectures
         id: get-arches
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           arches=$(skopeo inspect --raw \
             oci-archive:${{ steps.rename-oci-archive.outputs.name }} \
             | jq -r 'if has("manifests") then .manifests[].platform.architecture else "${{ runner.arch }}" end' \
@@ -329,7 +338,10 @@ jobs:
       - name: Generate SBOMs
         id: generate-sboms
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           echo "Generating SBOMs for ${{ steps.get-arches.outputs.arches }}"
 
           IFS=',' read -ra arch_list <<< ${{ steps.get-arches.outputs.arches }}
@@ -366,7 +378,10 @@ jobs:
           SBOMS: ${{ steps.generate-sboms.outputs.sboms }}
           OCI_IMAGE_ARCHIVE: ${{ steps.rename-oci-archive.outputs.name }}
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           echo "hashes=$(sha256sum ${{ env.VULN_REPORT }} ${{ env.OCI_IMAGE_ARCHIVE }} ${{ env.SBOMS }} | base64 -w0)"
 
       - name: Login to GHCR
@@ -469,7 +484,10 @@ jobs:
         env:
           PYTHONUNBUFFERED: 1
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           for revision_file in `ls ${{ env.REVISION_DATA_DIR }}`
           do
             ret=0

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Only 1 image can be changed per PR
         run: |
-          set -eux
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
+          set -u
           dir_names="${{ steps.changed-files-dir-names.outputs.all_changed_files }}"
           echo "Can only modify 1 image per PR"
           (( $(echo "${dir_names}" | wc -w) == 1 ))
@@ -80,7 +84,11 @@ jobs:
 
       - name: Validate YAML format
         run: |
-          set -eux
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
+          set -u
           pip install yamllint
           yamllint -c .yamllint.yaml ${{ matrix.filename }}
 

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -58,7 +58,10 @@ jobs:
       - name: Fail if more than one image
         id: get-image-name
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           img_dir="${{ steps.changed-files.outputs.all_changed_files }}"
           occurrences="${img_dir//[^,]}"
           if [ ${#occurrences} -ne 0 ]
@@ -135,7 +138,10 @@ jobs:
 
           PYTHONUNBUFFERED: 1
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           echo "Running in production?  ${{ env.IS_PROD == 'true' && 'YES' || 'NO' }}"
           
           python3 -m src.image.release \
@@ -170,7 +176,10 @@ jobs:
       - name: Get commit SHA of _release.json update
         id: release-commit-sha
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           echo "release-commit-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
 
@@ -204,7 +213,9 @@ jobs:
       
       - name: Unzip SBOM artifacts
         run: |
-          set -x
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           sbom_target_dir="$(pwd)/sbom"
           find sbom -type f -name '*.spdx.zip' -exec unzip {} -d ${sbom_target_dir} \;
 

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -164,7 +164,10 @@ jobs:
 
       - name: Test rock
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           docker run --rm --entrypoint pebble ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
             help | grep Pebble
 
@@ -295,7 +298,9 @@ jobs:
         id: create-markdown
         if: ${{ !cancelled() }}
         run: |
-          set -x
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
 
           vulnerabilities="$(jq -r -c '[
             try(.scanner.result.Results[])
@@ -351,7 +356,10 @@ jobs:
 
       - name: Unpack image
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           umoci unpack \
             --image ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
             --rootless raw

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -364,4 +364,4 @@ jobs:
 
       - name: Scan for malware
         run: |
-          ./src/tests/malware_scan.py --filesystem ./raw/rootfs
+          python3 -m src.tests.malware_scan --filesystem ./raw/rootfs

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -99,7 +99,9 @@ jobs:
         run: |
           report="${{ needs.configure-scan.outputs.vulnerability-report }}" 
           echo "notify=false" >> "$GITHUB_OUTPUT"
-          set -x
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           vulnerabilities="$(jq -r -c '[
                   try(.scanner.result.Results[])
                   | .Target as $target
@@ -193,7 +195,9 @@ jobs:
       - name: Create markdown content
         id: create-markdown
         run: |
-          set -x
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           num_vulns=$(echo '${{ needs.parse-results.outputs.vulnerabilities }}' | jq -r 'length')
           vulnerability_exists=$([[ $num_vulns -gt 0 ]] && echo 'true' || echo 'false')
           echo "vulnerability-exists=$vulnerability_exists" >> "$GITHUB_OUTPUT"
@@ -237,7 +241,9 @@ jobs:
       - name: Notify via GitHub issue
         if: ${{ steps.create-markdown.outputs.vulnerability-exists == 'true' && inputs.create-issue }}
         run: |
-          set -x
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           op=nop
           if [[ ${{ steps.issue-exists.outputs.issue-exists }}  == 'false' ]]; then
             op="create"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1521"
+            "target": "1527"
         },
         "beta": {
-            "target": "1521"
+            "target": "1527"
         },
         "edge": {
-            "target": "1521"
+            "target": "1527"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1521"
+            "target": "1527"
         },
         "beta": {
-            "target": "1521"
+            "target": "1527"
         },
         "edge": {
-            "target": "1521"
+            "target": "1527"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1522"
+            "target": "1528"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1469"
+            "target": "1512"
         },
         "beta": {
-            "target": "1469"
+            "target": "1512"
         },
         "edge": {
-            "target": "1469"
+            "target": "1512"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1469"
+            "target": "1512"
         },
         "beta": {
-            "target": "1469"
+            "target": "1512"
         },
         "edge": {
-            "target": "1469"
+            "target": "1512"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1470"
+            "target": "1513"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1512"
+            "target": "1515"
         },
         "beta": {
-            "target": "1512"
+            "target": "1515"
         },
         "edge": {
-            "target": "1512"
+            "target": "1515"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1512"
+            "target": "1515"
         },
         "beta": {
-            "target": "1512"
+            "target": "1515"
         },
         "edge": {
-            "target": "1512"
+            "target": "1515"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1513"
+            "target": "1516"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1515"
+            "target": "1521"
         },
         "beta": {
-            "target": "1515"
+            "target": "1521"
         },
         "edge": {
-            "target": "1515"
+            "target": "1521"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1515"
+            "target": "1521"
         },
         "beta": {
-            "target": "1515"
+            "target": "1521"
         },
         "edge": {
-            "target": "1515"
+            "target": "1521"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1516"
+            "target": "1522"
         },
         "edge": {
             "target": "1.2-22.04_beta"

--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -25,7 +25,7 @@ from src.docs.schema.triggers import DocSchema
 
 from ..shared.logs import get_logger
 
-logger = get_logger(__package__)
+logger = get_logger()
 
 
 def cli_args() -> argparse.ArgumentParser:

--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -23,9 +23,9 @@ from dateutil import parser
 import src.shared.release_info as shared
 from src.docs.schema.triggers import DocSchema
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 
-logger = Logger().get_logger()
+logger = get_logger(__package__)
 
 
 def cli_args() -> argparse.ArgumentParser:

--- a/src/docs/publish_docs.sh
+++ b/src/docs/publish_docs.sh
@@ -11,7 +11,9 @@ trace_suspend() {
 trace_resume() {
     if [ "${__resume_trace:-0}" = 1 ]; then
         unset __resume_trace
-        set -x
+        if [[ "$RUNNER_DEBUG" == "1" ]]; then
+          set -x
+        fi
     fi
 }
 

--- a/src/image/define_image_revision.sh
+++ b/src/image/define_image_revision.sh
@@ -3,7 +3,9 @@
 # Source Swift config
 source $(dirname $0)/../configs/swift.public.novarc
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 
 # Does image already exist in Swift?
 # If not, then this is immediately revision number 1

--- a/src/image/get_canonical_tags_from_swift.sh
+++ b/src/image/get_canonical_tags_from_swift.sh
@@ -3,7 +3,9 @@
 # Source Swift config
 source $(dirname $0)/../configs/swift.public.novarc
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 
 canonical_tags=$(swift list $SWIFT_CONTAINER_NAME -p $IMAGE_NAME/ \
     | awk -F '/' '{print $2"_"$3}' | uniq | sort | tr '\n' ',')

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -20,11 +20,11 @@ import json
 
 import yaml
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 from .utils.schema.revision_data import RevisionDataSchema
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
-logger = Logger().get_logger()
+logger = get_logger(__package__)
 
 
 def backfill_higher_risks(channels: dict) -> None:

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -17,10 +17,14 @@ analysis.
 
 import argparse
 import json
+
 import yaml
 
-from .utils.schema.triggers import ImageSchema, KNOWN_RISKS_ORDERED
+from ..shared.logs import Logger
 from .utils.schema.revision_data import RevisionDataSchema
+from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
+
+logger = Logger().get_logger()
 
 
 def backfill_higher_risks(channels: dict) -> None:
@@ -55,7 +59,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    print(f"Getting existing image trigger from {args.image_trigger}")
+    logger.info(f"Getting existing image trigger from {args.image_trigger}")
     with open(args.image_trigger, encoding="UTF-8") as trigger:
         image_trigger = yaml.load(trigger, Loader=yaml.BaseLoader)
 
@@ -63,7 +67,7 @@ if __name__ == "__main__":
 
     user_releases = image_trigger.get("release", {})
 
-    print(f"Getting pre-release from {args.revision_data_file}")
+    logger.info(f"Getting pre-release from {args.revision_data_file}")
     with open(args.revision_data_file, encoding="UTF-8") as revision_data_f:
         revision_data = json.load(revision_data_f)
 
@@ -89,8 +93,8 @@ if __name__ == "__main__":
     # Overwrite the image trigger with the new release value
     image_trigger["release"] = user_releases
 
-    print(f"Finished merging pre releases:\n{json.dumps(image_trigger)}")
-    print(f"Overwriting {args.image_trigger}...")
+    logger.info(f"Finished merging pre releases:\n{json.dumps(image_trigger)}")
+    logger.info(f"Overwriting {args.image_trigger}...")
     with open(args.image_trigger, "w") as trigger:
         yaml.dump(
             image_trigger,

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -24,7 +24,7 @@ from ..shared.logs import get_logger
 from .utils.schema.revision_data import RevisionDataSchema
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
-logger = get_logger(__package__)
+logger = get_logger()
 
 
 def backfill_higher_risks(channels: dict) -> None:

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -3,7 +3,6 @@
 import argparse
 import glob
 import json
-import logging
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,6 +14,7 @@ import yaml
 from git import Repo
 
 from ..shared.github_output import GithubOutput
+from ..shared.logs import Logger
 from ..uploads.infer_image_track import get_base_and_track
 from .utils.schema.revision_data import RevisionDataSchema
 from .utils.schema.triggers import ImageSchema
@@ -22,6 +22,8 @@ from .utils.schema.triggers import ImageSchema
 # TODO:
 # - inject_metadata uses a static github url, does this break builds that are sourced
 #   from non-gh repos?
+
+logger = Logger().get_logger()
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -58,7 +60,7 @@ class RevisionDataSchemaFilter(RevisionDataSchema):
     @pydantic.model_validator(mode="before")
     def _warn_extra_fields(cls, data: Any) -> Any:
         for extra_field in data.keys() - cls.model_fields.keys():
-            logging.warning(
+            logger.warning(
                 f'Field "{extra_field}" removed from {data["name"]} revision data'
             )
 
@@ -90,7 +92,7 @@ def is_track_eol(track_value: str, track_name: str | None = None) -> bool:
     is_eol = eol_date < datetime.now(timezone.utc)
 
     if is_eol and track_name is not None:
-        logging.warning(f'Removing EOL track "{track_name}", EOL: {eol_date}')
+        logger.warning(f'Removing EOL track "{track_name}", EOL: {eol_date}')
 
     return is_eol
 
@@ -226,7 +228,7 @@ def main():
     builds = filter_eol_builds(builds)
 
     # pretty print builds
-    logging.info(
+    logger.info(
         f"Generating matrix for following builds: \n {json.dumps(builds, indent=4)}"
     )
 

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -14,7 +14,7 @@ import yaml
 from git import Repo
 
 from ..shared.github_output import GithubOutput
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 from ..uploads.infer_image_track import get_base_and_track
 from .utils.schema.revision_data import RevisionDataSchema
 from .utils.schema.triggers import ImageSchema
@@ -23,7 +23,7 @@ from .utils.schema.triggers import ImageSchema
 # - inject_metadata uses a static github url, does this break builds that are sourced
 #   from non-gh repos?
 
-logger = Logger().get_logger()
+logger = get_logger(__package__)
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -23,7 +23,7 @@ from .utils.schema.triggers import ImageSchema
 # - inject_metadata uses a static github url, does this break builds that are sourced
 #   from non-gh repos?
 
-logger = get_logger(__package__)
+logger = get_logger()
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -21,7 +21,7 @@ from ..shared.logs import get_logger
 from .utils.encoders import DateTimeEncoder
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
-logger = get_logger(__package__)
+logger = get_logger()
 
 # generate single date for consistent EOL checking
 execution_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -17,8 +17,11 @@ import yaml
 
 import src.shared.release_info as shared
 
+from ..shared.logs import Logger
 from .utils.encoders import DateTimeEncoder
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
+
+logger = Logger().get_logger()
 
 # generate single date for consistent EOL checking
 execution_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -287,13 +290,15 @@ def main():
 
             for tag in tags:
                 gh_release_info = {}
-                gh_release_info["canonical-tag"] = f"{img_name}_{revision_track}_{revision}"
+                gh_release_info["canonical-tag"] = (
+                    f"{img_name}_{revision_track}_{revision}"
+                )
                 gh_release_info["release-name"] = f"{img_name}_{tag}"
                 gh_release_info["name"] = f"{img_name}"
                 gh_release_info["revision"] = f"{revision}"
                 gh_release_info["channel"] = f"{tag}"
                 github_tags.append(gh_release_info)
-        
+
         matrix = {"include": github_tags}
 
         with open(os.environ["GITHUB_OUTPUT"], "a", encoding="UTF-8") as gh_out:
@@ -307,6 +312,7 @@ def main():
 
         with open(args.all_releases, "w", encoding="UTF-8") as fd:
             json.dump(all_releases, fd, indent=4, cls=DateTimeEncoder)
+
 
 if __name__ == "__main__":
     main()

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -100,7 +100,9 @@ def remove_eol_tags(tag_to_revision, all_releases):
                 < execution_timestamp
                 and base_tag in filtered_tag_to_revision
             ):
-                print(f"Warning: Removing EOL tag {repr(base_tag)}, date: {eol_date}")
+                logger.warning(
+                    f"Warning: Removing EOL tag {repr(base_tag)}, date: {eol_date}"
+                )
                 filtered_tag_to_revision.pop(base_tag)
 
             # prep next iteration
@@ -121,23 +123,23 @@ def main():
         else os.path.abspath(args.image_trigger).split("/")[-2]
     )
 
-    print(f"Preparing to release revision tags for {img_name}")
+    logger.info(f"Preparing to release revision tags for {img_name}")
     all_revision_tags = shared.get_all_revision_tags(args.all_revision_tags)
     revision_to_track = shared.get_revision_to_track(all_revision_tags)
 
-    print(
+    logger.debug(
         "Revision (aka 'canonical') tags grouped by revision:\n"
         f"{json.dumps(revision_to_track, indent=2)}"
     )
 
-    print(f"Reading all previous releases from {args.all_releases}...")
+    logger.info(f"Reading all previous releases from {args.all_releases}...")
 
     all_releases = shared.read_json_file(args.all_releases)
     tag_mapping_from_all_releases = shared.get_tag_mapping_from_all_releases(
         all_releases
     )
 
-    print(f"Parsing image trigger {args.image_trigger}")
+    logger.info(f"Parsing image trigger {args.image_trigger}")
     with open(args.image_trigger, encoding="UTF-8") as trigger:
         image_trigger = yaml.load(trigger, Loader=yaml.BaseLoader)
 
@@ -146,7 +148,7 @@ def main():
     tag_mapping_from_trigger = {}
     for track, risks in image_trigger["release"].items():
         if track not in all_releases:
-            print(f"Track {track} will be created for the 1st time")
+            logger.info(f"Track {track} will be created for the 1st time")
             all_releases[track] = {}
 
         for risk, value in risks.items():
@@ -158,19 +160,19 @@ def main():
                 continue
 
             if risk not in KNOWN_RISKS_ORDERED:
-                print(f"Skipping unknown risk {risk} in track {track}")
+                logger.warning(f"Skipping unknown risk {risk} in track {track}")
                 continue
 
             all_releases[track][risk] = {"target": value}
             tag = f"{track}_{risk}"
-            print(f"Channel {tag} points to {value}")
+            logger.info(f"Channel {tag} points to {value}")
             tag_mapping_from_trigger[tag] = value
 
     # update EOL dates from upload dictionary
     for upload in image_trigger["upload"] or []:
         for track, upload_release_dict in upload.get("release", {}).items():
             if track not in all_releases:
-                print(f"Track {track} will be created for the 1st time")
+                logger.info(f"Track {track} will be created for the 1st time")
                 all_releases[track] = {}
 
             if (
@@ -179,7 +181,7 @@ def main():
             ):
                 all_releases[track]["end-of-life"] = upload_release_dict["end-of-life"]
 
-    print(
+    logger.info(
         "Going to update channels according to the following:\n"
         f"{json.dumps(tag_mapping_from_trigger, indent=2)}"
     )
@@ -227,7 +229,7 @@ def main():
             # follow the parent tag until it is a digit (ie. revision number)
             parent_tag = all_tags_mapping[follow_tag]
 
-            print(f"Tag {follow_tag} is following tag {parent_tag}.")
+            logger.info(f"Tag {follow_tag} is following tag {parent_tag}.")
             follow_tag = parent_tag
 
         if int(follow_tag) not in revision_to_track:
@@ -253,14 +255,14 @@ def main():
             base_tag,
         ):
             latest_alias = base_tag.split("_")[-1]
-            print(f"Exceptionally converting tag {base_tag} to {latest_alias}.")
+            logger.info(f"Exceptionally converting tag {base_tag} to {latest_alias}.")
             release_tags[latest_alias] = revision
             release_tags.pop(base_tag)
 
         # stable risks have an alias with any risk string
         if base_tag.endswith("_stable"):
             stable_alias = "_".join(base_tag.split("_")[:-1])
-            print(f"Adding stable tag alias {stable_alias} for {base_tag}")
+            logger.info(f"Adding stable tag alias {stable_alias} for {base_tag}")
             release_tags[stable_alias] = revision
 
     # we finally have all the OCI tags to be released,
@@ -270,7 +272,7 @@ def main():
         group_by_revision[revision].append(tag)
 
     if not args.update_releases_json:
-        print(
+        logger.info(
             "Processed tag aliases and ready to release the following revisions:\n"
             f"{json.dumps(group_by_revision, indent=2)}"
         )
@@ -283,7 +285,7 @@ def main():
                 f"{args.ghcr_repo}/{img_name}:{revision_track}_{revision}"
             )
             this_dir = os.path.dirname(__file__)
-            print(f"Releasing {source_img} with tags:\n{tags}")
+            logger.info(f"Releasing {source_img} with tags:\n{tags}")
             subprocess.check_call(
                 [f"{this_dir}/tag_and_publish.sh", source_img, img_name] + tags
             )
@@ -305,7 +307,7 @@ def main():
             print(f"gh-releases-matrix={matrix}", file=gh_out)
 
     else:
-        print(
+        logger.info(
             f"Updating {args.all_releases} file with:\n"
             f"{json.dumps(all_releases, indent=2, cls=DateTimeEncoder)}"
         )

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -17,11 +17,11 @@ import yaml
 
 import src.shared.release_info as shared
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 from .utils.encoders import DateTimeEncoder
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
-logger = Logger().get_logger()
+logger = get_logger(__package__)
 
 # generate single date for consistent EOL checking
 execution_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/image/requirements.sh
+++ b/src/image/requirements.sh
@@ -8,7 +8,9 @@ ssh-keyscan -H git.launchpad.net | tee $HOME/.ssh/known_hosts
 
 echo "${ROCKS_DEV_LP_SSH_PRIVATE}" >$HOME/.ssh/id_rsa
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 chmod 600 $HOME/.ssh/id_rsa
 
 ## To avoid installing Snaps, just take the needed Python script

--- a/src/image/requirements.sh
+++ b/src/image/requirements.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -e
 
 # LP configurations
 mkdir -p $HOME/.ssh

--- a/src/notifications/send_to_mattermost.sh
+++ b/src/notifications/send_to_mattermost.sh
@@ -1,7 +1,12 @@
-#!/bin/bash -eux
+#!/bin/bash -e
 #
 # Send custom notifications to a Mattermost channel.
 #
+
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
+set -u
 
 set -o pipefail
 

--- a/src/shared/logs.py
+++ b/src/shared/logs.py
@@ -1,6 +1,6 @@
 import logging
+import os
 import sys
-from typing import Optional, Union
 
 # ANSI escape codes for colors
 LOG_COLORS = {
@@ -11,7 +11,10 @@ LOG_COLORS = {
     "CRITICAL": "\033[91m",  # Red
 }
 RESET_COLOR = "\033[0m"
-
+RUNNER_LOG_LEVELS = {
+    '0': logging.INFO,
+    '1': logging.DEBUG,
+}
 
 class ColorFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -39,14 +42,17 @@ class Logger:
     def __init__(
         self,
         name: str = __name__,
-        log_file: Optional[str] = None,
-        level: Union[int, str] = logging.INFO,
+        log_file: str | None = None,
+        level: int | str | None = None,
         fmt: str = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s",
-        stream: Union[None, str, object] = "stdout",
+        stream: str | object | None = "stdout",
     ):
         if self._initialized:
             return
         self.logger = logging.getLogger(name)
+
+        if not level:
+            level = RUNNER_LOG_LEVELS[os.environ.get("RUNNER_DEBUG", "0")]
 
         if isinstance(level, str):
             level = getattr(logging, level.upper(), logging.INFO)

--- a/src/shared/logs.py
+++ b/src/shared/logs.py
@@ -13,9 +13,10 @@ LOG_COLORS = {
 }
 RESET_COLOR = "\033[0m"
 RUNNER_LOG_LEVELS = {
-    '0': logging.INFO,
-    '1': logging.DEBUG,
+    "0": logging.INFO,
+    "1": logging.DEBUG,
 }
+
 
 class ColorFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -31,13 +32,20 @@ class ColorFormatter(logging.Formatter):
         return result
 
 
+def get_caller_package() -> str:
+    return inspect.getmodule(inspect.currentframe().f_back).__package__
+
+
 def get_logger(
-        name: str,
-        log_file: str | None = None,
-        level: int | str = None,
-        fmt: str = "[%(asctime)s] [%(name)s.%(module)s.%(funcName)s] [%(levelname)s] %(message)s",
-        stream: str | object | None = "stdout",
+    name: str | None = None,
+    log_file: str | None = None,
+    level: int | str = None,
+    fmt: str = "[%(asctime)s] [%(name)s.%(module)s.%(funcName)s] [%(levelname)s] %(message)s",
+    stream: str | object | None = "stdout",
 ) -> logging.Logger:
+
+    if not name:
+        name = get_caller_package()
 
     if name in logging.root.manager.loggerDict:
         return logging.getLogger(name)
@@ -54,9 +62,7 @@ def get_logger(
 
     if stream:
         color_formatter = ColorFormatter(fmt, datefmt="%Y-%m-%d %H:%M:%S")
-        stream_obj = {"stdout": sys.stdout, "stderr": sys.stderr}.get(
-            stream, stream
-        )
+        stream_obj = {"stdout": sys.stdout, "stderr": sys.stderr}.get(stream, stream)
         sh = logging.StreamHandler(stream_obj)
         sh.setFormatter(color_formatter)
         logger.addHandler(sh)

--- a/src/shared/logs.py
+++ b/src/shared/logs.py
@@ -30,7 +30,7 @@ class ColorFormatter(logging.Formatter):
 class Logger:
     _instances = {}
 
-    def __new__(cls, name: str = __name__):
+    def __new__(cls, name: str = __name__, *args, **kwargs):
         if name not in cls._instances:
             cls._instances[name] = super(Logger, cls).__new__(cls)
             cls._instances[name]._initialized = False

--- a/src/shared/logs.py
+++ b/src/shared/logs.py
@@ -1,0 +1,74 @@
+import logging
+import sys
+from typing import Optional, Union
+
+# ANSI escape codes for colors
+LOG_COLORS = {
+    "DEBUG": "\033[92m",  # Green
+    "INFO": "\033[94m",  # Blue
+    "WARNING": "\033[93m",  # Yellow
+    "ERROR": "\033[91m",  # Red
+    "CRITICAL": "\033[91m",  # Red
+}
+RESET_COLOR = "\033[0m"
+
+
+class ColorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        levelname = record.levelname
+        if levelname in LOG_COLORS:
+            colored_levelname = f"{LOG_COLORS[levelname]}[{levelname}]{RESET_COLOR}"
+        else:
+            colored_levelname = f"[{levelname}]"
+        original = self._style._fmt
+        self._style._fmt = original.replace("[%(levelname)s]", colored_levelname)
+        result = super().format(record)
+        self._style._fmt = original  # restore for future calls
+        return result
+
+
+class Logger:
+    _instances = {}
+
+    def __new__(cls, name: str = __name__):
+        if name not in cls._instances:
+            cls._instances[name] = super(Logger, cls).__new__(cls)
+            cls._instances[name]._initialized = False
+        return cls._instances[name]
+
+    def __init__(
+        self,
+        name: str = __name__,
+        log_file: Optional[str] = None,
+        level: Union[int, str] = logging.INFO,
+        fmt: str = "[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s",
+        stream: Union[None, str, object] = "stdout",
+    ):
+        if self._initialized:
+            return
+        self.logger = logging.getLogger(name)
+
+        if isinstance(level, str):
+            level = getattr(logging, level.upper(), logging.INFO)
+
+        self.logger.setLevel(level)
+
+        formatter = ColorFormatter(fmt, datefmt="%Y-%m-%d %H:%M:%S")
+
+        if stream:
+            stream_obj = {"stdout": sys.stdout, "stderr": sys.stderr}.get(
+                stream, stream
+            )
+            sh = logging.StreamHandler(stream_obj)
+            sh.setFormatter(formatter)
+            self.logger.addHandler(sh)
+
+        if log_file:
+            fh = logging.FileHandler(log_file)
+            fh.setFormatter(formatter)
+            self.logger.addHandler(fh)
+
+        self._initialized = True
+
+    def get_logger(self) -> logging.Logger:
+        return self.logger

--- a/src/tests/get_released_revisions.py
+++ b/src/tests/get_released_revisions.py
@@ -18,12 +18,12 @@ from datetime import datetime, timezone
 
 import docker
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 
 SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", "quay.io/skopeo/stable:v1.15.1")
 REGISTRY = "ghcr.io/canonical/oci-factory"
 
-logger = Logger(stream=sys.stdout, level="INFO").get_logger()
+logger = get_logger(stream=sys.stdout, level="INFO")
 
 
 def get_image_name_in_registry(img_name: str, revision: str) -> str:

--- a/src/tests/get_released_revisions.py
+++ b/src/tests/get_released_revisions.py
@@ -12,16 +12,18 @@ Activity that runs from within a scheduled workflow.
 
 import argparse
 import json
-import logging
 import os
 import sys
 from datetime import datetime, timezone
+
 import docker
+
+from ..shared.logs import Logger
 
 SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", "quay.io/skopeo/stable:v1.15.1")
 REGISTRY = "ghcr.io/canonical/oci-factory"
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = Logger(stream=sys.stdout, level="INFO").get_logger()
 
 
 def get_image_name_in_registry(img_name: str, revision: str) -> str:
@@ -35,7 +37,7 @@ def get_image_name_in_registry(img_name: str, revision: str) -> str:
 
     tagless_image_name = f"{REGISTRY}/{img_name}"
     cmd = f"list-tags docker://{tagless_image_name}"
-    logging.info(f"Running Skopeo with '{cmd}'")
+    logger.info(f"Running Skopeo with '{cmd}'")
     try:
         all_tags = json.loads(
             d_client.containers.run(
@@ -47,7 +49,7 @@ def get_image_name_in_registry(img_name: str, revision: str) -> str:
     except docker.errors.ContainerError as err:
         if "timeout" not in str(err):
             raise
-        logging.error(
+        logger.error(
             f"Timed out while listing tags for {tagless_image_name}: {str(err)}"
         )
 
@@ -71,7 +73,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    logging.info(f"Looping through OCI images in {args.oci_images_path}")
+    logger.info(f"Looping through OCI images in {args.oci_images_path}")
 
     released_revisions = {}
     ghcr_images = []
@@ -88,13 +90,13 @@ if __name__ == "__main__":
             if risks.get("end-of-life") and risks["end-of-life"] < datetime.now(
                 timezone.utc
             ).strftime("%Y-%m-%dT%H:%M:%SZ"):
-                logging.info(
+                logger.info(
                     f"Skipping track {track} because it reached its end of life"
                     f": {risks['end-of-life']}"
                 )
                 continue
             elif not risks.get("end-of-life"):
-                logging.warning(f"Track {track} is missing its end-of-life field")
+                logger.warning(f"Track {track} is missing its end-of-life field")
 
             for key, targets in risks.items():
                 if key == "end-of-life":
@@ -117,8 +119,8 @@ if __name__ == "__main__":
                     }
                 )
 
-    logging.info(f"Released revisions: {json.dumps(released_revisions, indent=2)}")
-    logging.info(f"Released revisions in GHCR: {ghcr_images}")
+    logger.info(f"Released revisions: {json.dumps(released_revisions, indent=2)}")
+    logger.info(f"Released revisions in GHCR: {ghcr_images}")
 
     matrix = {"include": ghcr_images}
     with open(os.environ["GITHUB_OUTPUT"], "a") as gh_out:

--- a/src/tests/malware_scan.py
+++ b/src/tests/malware_scan.py
@@ -4,10 +4,9 @@ import argparse
 import os
 import sys
 
-import utils.helpers as helper_functions
-from tester import Test, TestingError
-
 from ..shared.logs import Logger
+from .tester import Test, TestingError
+from .utils import helpers as helper_functions
 
 
 class MalwareScan(Test):

--- a/src/tests/malware_scan.py
+++ b/src/tests/malware_scan.py
@@ -4,7 +4,7 @@ import argparse
 import os
 import sys
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 from .tester import Test, TestingError
 from .utils import helpers as helper_functions
 
@@ -46,7 +46,7 @@ class MalwareScan(Test):
 
 
 if __name__ == "__main__":
-    logger = Logger(stream=sys.stdout, level="INFO").get_logger()
+    logger = get_logger(stream=sys.stdout, level="INFO")
 
     parser = argparse.ArgumentParser(
         description="Runs a Malware scan on the provided rock's filesystem"

--- a/src/tests/malware_scan.py
+++ b/src/tests/malware_scan.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
 import argparse
-import logging
 import os
 import sys
-import utils.helpers as helper_functions
 
+import utils.helpers as helper_functions
 from tester import Test, TestingError
+
+from ..shared.logs import Logger
 
 
 class MalwareScan(Test):
@@ -32,21 +33,21 @@ class MalwareScan(Test):
                 )
             except Exception as err:
                 if err.args[-1] == 137:
-                    logging.error("Malware scan failed due to lack of memory")
+                    logger.error("Malware scan failed due to lack of memory")
                     if tries == 0:
-                        logging.warning("Running malware scan a 2nd time...")
+                        logger.warning("Running malware scan a 2nd time...")
                         continue
                 else:
-                    logging.error(f"Found infected files at {self.image}")
+                    logger.error(f"Found infected files at {self.image}")
                 raise TestingError(str(err))
 
             break
 
-        logging.info(f"Clamav scan result:\n{scan_output}")
+        logger.info(f"Clamav scan result:\n{scan_output}")
 
 
 if __name__ == "__main__":
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logger = Logger(stream=sys.stdout, level="INFO").get_logger()
 
     parser = argparse.ArgumentParser(
         description="Runs a Malware scan on the provided rock's filesystem"
@@ -78,8 +79,8 @@ if __name__ == "__main__":
         msg = "System does not have the minimum requirements to run this scan"
         if args.skip_with_error:
             raise Exception(msg)
-        logging.error(msg)
+        logger.error(msg)
         sys.exit(0)
 
-    logging.info(f"Running Malware scan, recursively, on directory {scanner.image}")
+    logger.info(f"Running Malware scan, recursively, on directory {scanner.image}")
     scanner.clamav_scan(args.clamav_args)

--- a/src/tests/tester.py
+++ b/src/tests/tester.py
@@ -7,9 +7,9 @@ from typing import Literal
 import docker
 from pydantic import BaseModel, PrivateAttr
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 
-logger = Logger().get_logger()
+logger = get_logger(__package__)
 
 
 class TestingError(Exception):

--- a/src/tests/tester.py
+++ b/src/tests/tester.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, PrivateAttr
 
 from ..shared.logs import get_logger
 
-logger = get_logger(__package__)
+logger = get_logger()
 
 
 class TestingError(Exception):

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -2,12 +2,13 @@
 
 import argparse
 import os
-import logging
 import subprocess
+
 import yaml
 
+from ..shared.logs import Logger
 
-logging.basicConfig()
+logger = Logger().get_logger()
 
 
 def get_release_from_codename(codename: str) -> str:
@@ -31,7 +32,7 @@ def get_base_and_track(rockcraft_yaml) -> tuple[str, str]:
     try:
         base_release = float(rock_base.replace(":", "@").split("@")[-1])
     except ValueError:
-        logging.warning(
+        logger.warning(
             f"Could not infer ROCK's base release from {rock_base}. Trying with codename."
         )
         base_release = float(

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -8,7 +8,7 @@ import yaml
 
 from ..shared.logs import get_logger
 
-logger = get_logger(__package__)
+logger = get_logger()
 
 
 def get_release_from_codename(codename: str) -> str:

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -6,9 +6,9 @@ import subprocess
 
 import yaml
 
-from ..shared.logs import Logger
+from ..shared.logs import get_logger
 
-logger = Logger().get_logger()
+logger = get_logger(__package__)
 
 
 def get_release_from_codename(codename: str) -> str:

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     base_release, track = get_base_and_track(rockcraft_yaml)
 
-    print(f"rock track: {track}")
+    logger.info(f"rock track: {track}")
 
     with open(os.environ["GITHUB_OUTPUT"], "a") as gh_out:
         print(f"track={track}", file=gh_out)

--- a/src/uploads/preempt_swift_slots.sh
+++ b/src/uploads/preempt_swift_slots.sh
@@ -3,7 +3,9 @@
 # Source Swift config
 source $(dirname $0)/../configs/swift.public.novarc
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 
 REVISION_DATA_DIR=$1
 

--- a/src/uploads/swift_lockfile_lock.sh
+++ b/src/uploads/swift_lockfile_lock.sh
@@ -3,7 +3,9 @@
 # Source Swift config
 source $(dirname $0)/../configs/swift.public.novarc
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 
 IMAGE_NAME=$1
 # Timeout and sleep time in seconds

--- a/src/uploads/swift_lockfile_unlock.sh
+++ b/src/uploads/swift_lockfile_unlock.sh
@@ -3,7 +3,9 @@
 # Source Swift config
 source $(dirname $0)/../configs/swift.public.novarc
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 
 IMAGE_NAME=$1
 

--- a/src/uploads/upload_to_swift.sh
+++ b/src/uploads/upload_to_swift.sh
@@ -3,7 +3,9 @@
 # Source Swift config
 source $(dirname $0)/../configs/swift.public.novarc
 
-set -x
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
 
 IMAGE_NAME=$1
 TRACK=$2


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
- `print`s are replaces by `logging` in CI Python source code
- Lengthy logs are categorized as `debug` logs
- Log level is controlled by `RUNNER_DEBUG`, which can be toggled by `Enable debug logging` when re-running workflows
- Optionally set `-x` for the shell scripts when `RUNNER_DEBUG` is set.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A
---

