### PR TITLE
fix(Test-Rock): need to checkout oci-factory and not target repo

### DIFF
--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -117,7 +117,12 @@ jobs:
     needs: [configure-tests]
     if: inputs.test-oci-compliance
     steps:
-      - uses: actions/checkout@v4
+      - name: Cloning OCI Factory
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/oci-factory
+          ref: ${{ needs.configure-tests.outputs.oci-factory-ref }}
+          fetch-depth: 1
 
       - uses: actions/cache/restore@v4
         with:

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1602"
+            "target": "1611"
         },
         "beta": {
-            "target": "1602"
+            "target": "1611"
         },
         "edge": {
-            "target": "1602"
+            "target": "1611"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1602"
+            "target": "1611"
         },
         "beta": {
-            "target": "1602"
+            "target": "1611"
         },
         "edge": {
-            "target": "1602"
+            "target": "1611"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1603"
+            "target": "1612"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

When running `umoci`, it uses an oci-factory custom action, by relative path. But it's cloning the repo that calls the workflow, when it should checkout the oci-factory repo.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Fixes https://github.com/canonical/age-rock/actions/runs/15248442623/job/42882190396

---
