### PR TITLE
chore: drop support for 20.04

### DIFF
--- a/.github/base_digests/20.04
+++ b/.github/base_digests/20.04
@@ -1,1 +1,0 @@
-public.ecr.aws/ubuntu/ubuntu:focal@sha256:d8f8f65ad0e88f7ec2ae5ca1549784c72c97bed14bf34d4b1682aa30bc8ba82c


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR drops the renovate target of 20.04 as a part of ending the standard support for Ubuntu 20.04.
