### PR TITLE
ci: decouple vulnerability-scan workflow from oci-factory

### DIFF
--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -44,6 +44,7 @@ jobs:
     with:
       oci-image-name: "${{ matrix.source-image }}"
       oci-image-path: "oci/${{ matrix.name }}"
+      trivyignore-path: "oci/${{ matrix.name }}/.trivyignore"
       date-last-scan: ${{ needs.prepare-test-matrix.outputs.last-scan }}
       create-issue: true
     secrets: inherit

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -9,8 +9,12 @@ on:
         required: true
         type: string
       oci-image-path:
-        description: 'Path to the image in this repo (eg. "oci/foo")'
-        required: true
+        description: 'Path to the image in OCI Factory (eg. "oci/foo")'
+        required: false
+        type: string
+      trivyignore-path:
+        description: 'Path to the .trivygnore file'
+        required: false
         type: string
       date-last-scan:
         description: 'If there are new CVEs after this date, we notify'
@@ -35,10 +39,16 @@ jobs:
       oci-image: ${{ steps.configure.outputs.oci-filename }}
       vulnerability-report: ${{ steps.configure.outputs.report-filename }}
     steps:
+      - name: Check required input
+        run: |
+          if [ "${{ github.repository }}" = "canonical/oci-factory" ] && [ -z "${{ inputs.oci-image-path }}" ]; then
+            echo "missing required input: oci-image-path"
+            exit 1
+          fi
+
       - id: configure
         run: |
-          oci_filename="$(echo "${{ inputs.oci-image-name }}" \
-            | sed 's/ghcr.io\/canonical\/oci-factory\///g' | tr ':' '_')"
+          oci_filename="$(basename "${{ inputs.oci-image-name }}" | tr ':' '_')"
 
           echo "oci-filename=$oci_filename" >> "$GITHUB_OUTPUT"
           echo "report-filename=${oci_filename}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
@@ -63,7 +73,7 @@ jobs:
     with:
       oci-archive-name: ${{ needs.configure-scan.outputs.oci-image }}
       test-vulnerabilities: true # just incase we set this to false by default in the future
-      trivyignore-path: ${{ inputs.oci-image-path }}/.trivyignore
+      trivyignore-path: ${{ inputs.trivyignore-path }}
       test-black-box: false
       test-efficiency: false
       test-malware: false
@@ -131,7 +141,7 @@ jobs:
     name: "notify ${{ inputs.oci-image-name != '' && format('| {0}', inputs.oci-image-name) || ' '}}"
     runs-on: ubuntu-22.04
     needs: [parse-results]
-    if: ${{ !cancelled() && needs.parse-results.outputs.notify == 'true' }}
+    if: ${{ !cancelled() && github.repository == 'canonical/oci-factory' && needs.parse-results.outputs.notify == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -188,7 +198,11 @@ jobs:
       - name: Get image repo
         id: get-image-repo
         run: |
-          img_repo=$(yq -r '.upload.[].source' ${{ github.workspace }}/${{ inputs.oci-image-path }}/image.yaml | head -n 1)
+          if [[ -n "${{ inputs.oci-image-path }}" ]]; then
+            img_repo=$(yq -r '.upload.[].source' "${{ github.workspace }}/${{ inputs.oci-image-path }}/image.yaml" | head -n 1)
+          else
+            img_repo="${{ github.repository }}"
+          fi
           echo "img-repo=$img_repo" >> "$GITHUB_OUTPUT"
 
       # We have to walk through the vulnerabilities since trivy does not support outputting the results as Markdown
@@ -207,11 +221,14 @@ jobs:
             echo "| ID | Target | Severity | Package |" >> issue.md
             echo "| -- | ----- | -------- | ------- |" >> issue.md
             echo '${{ needs.parse-results.outputs.vulnerabilities }}' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> issue.md
-            if [[ ${{ inputs.create-issue }} == 'true' ]]; then
-              revision_to_released_tags=$(python3 -m src.shared.release_info get_revision_to_released_tags --all-releases ${{ inputs.oci-image-path }}/_releases.json)
-              affected_tracks=$(echo "${revision_to_released_tags}" | jq -r '."${{ steps.simplify-image-name.outputs.img_revision }}" | map("- `\(.)`") | join("\n")')
-              echo -e "\n### Affected tracks:" >> issue.md
-              echo -e "${affected_tracks}" >> issue.md
+            if [[ "${{ inputs.create-issue }}" == 'true' ]]; then
+              release_json="${{ inputs.oci-image-path }}/_releases.json"
+              if [[ -f "$release_json" ]]; then
+                revision_to_released_tags=$(python3 -m src.shared.release_info get_revision_to_released_tags --all-releases "$release_json")
+                affected_tracks=$(echo "${revision_to_released_tags}" | jq -r '."${{ steps.simplify-image-name.outputs.img_revision }}" | map("- `\(.)`") | join("\n")')
+                echo -e "\n### Affected tracks:" >> issue.md
+                echo -e "${affected_tracks}" >> issue.md
+              fi
               echo -e "\nDetails: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> issue.md
             fi
             echo "issue-title=$title" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The input required only for OCI-Factory are now optional. A check has been added for it.

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Modified the CVE Scanning workflow to make it not depend on OCI-Factory. Now it can be used by other repositories by providing just the image to be scanned.

A new check has been added for the `oci-image-path` input to make sure it is required when the workflow is run in OCI Factory repository, and the `notify` job will only run when the OCI Factory is triggering the workflow.