### PR TITLE
Update Valkey image to newer commit

### DIFF
--- a/oci/valkey/image.yaml
+++ b/oci/valkey/image.yaml
@@ -2,7 +2,7 @@ version: 1
 
 upload:
   - source: "canonical/charmed-valkey-rock"
-    commit: e244d7a2887a335642ce35e2dd464f8cc41afa22
+    commit: 8cfd60bc4e71754f976cbd498cdd02c43ce2bbfe
     directory: .
     release:
       7.2.7-24.04:


### PR DESCRIPTION
- [X] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR updates the Valkey image published in Dockerhub to a newer commit / version.

The updates in the rock image are based on this PR: https://github.com/canonical/charmed-valkey-rock/pull/11. They include the following changes:
- update Go to version `v1.24.4`
- update metrics exporter to `v1.74.0`

These updates fix the security vulnerabilities identified in [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2).

### Related issues
https://github.com/canonical/oci-factory/actions/runs/15647019716