### PR TITLE
ci(Build-Rock): add flag to run rockcraft test conditionally

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -11,6 +11,10 @@ on:
       build-id:
         description: "Optional string for identifying workflow jobs in GitHub UI"
         type: string
+      rockcraft-test:
+        description: "Whether to run rockcraft test when packing the rock"
+        type: boolean
+        default: false
 
       # source parameters
       rock-repo:
@@ -132,6 +136,7 @@ jobs:
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
           path: "${{ env.ROCK_REPO_DIR }}/${{ inputs.rockfile-directory }}"
+          test: "${{ inputs.rockcraft-test }}"
           verbosity: debug
 
       - name: Collecting Artifacts


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

A new flag to the `rockcraft pack` action will be added to conditionally run `rockcraft test`. This PR adapts the current reusable `Build-Rock` workflow to cope with the new flag.

Blocked by: https://github.com/canonical/craft-actions/pull/40
