### PR TITLE
fix(ci): have the rocksbot force push to bypass branch protection

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -166,6 +166,7 @@ jobs:
             --update-releases-json
 
       # Commit with actor's GitHub noreply email to pass CLA and keep the privacy of the actor
+      # Use force push, to bypass the branch protection rules
       - name: Commit oci/${{ inputs.oci-image-name }}/_releases.json
         uses: actions-x/commit@v6
         with:
@@ -174,6 +175,7 @@ jobs:
           message: 'ci: automatically update oci/${{ inputs.oci-image-name }}/_releases.json, from ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
           files: oci/${{ inputs.oci-image-name }}/_releases.json
           email: '${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com'
+          force: true
 
       - name: Get commit SHA of _release.json update
         id: release-commit-sha

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1741"
+            "target": "1750"
         },
         "beta": {
-            "target": "1741"
+            "target": "1750"
         },
         "edge": {
-            "target": "1741"
+            "target": "1750"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1741"
+            "target": "1750"
         },
         "beta": {
-            "target": "1741"
+            "target": "1750"
         },
         "edge": {
-            "target": "1741"
+            "target": "1750"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1742"
+            "target": "1751"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
This can only be properly tested in `main`, since that's where the branch protection rules are constraining our workflows