### PR TITLE
Add required config files to onboard temporal-admin-tools onto oci-factory

### DIFF
--- a/oci/temporal-admin-tools/contacts.yaml
+++ b/oci/temporal-admin-tools/contacts.yaml
@@ -1,0 +1,5 @@
+notify:
+  emails:
+    - workflows-charmers@canonical.com
+  mattermost-channels:
+    - tbgx8brhn3b3djrh57aqctuibo

--- a/oci/temporal-admin-tools/documentation.yaml
+++ b/oci/temporal-admin-tools/documentation.yaml
@@ -1,0 +1,80 @@
+version: 1
+
+application: temporal-admin-tools
+description: >
+  This image contains necessary tools to configure and administer a Temporal server.
+
+docker:
+  parameters:
+    - -e SQL_HOST=1.2.3.4
+
+parameters:
+  - type: -e
+    value: 'SQL_HOST=1.2.3.4'
+    description: Hostname or IP address of SQL host to connect to with temporal-sql-tool
+  - type: -e
+    value: 'SQL_PORT=3306'
+    description: Port of SQL host to connect to with temporal-sql-tool
+  - type: -e
+    value: 'SQL_USER=mysql'
+    description: User name used for authentication when connecting to SQL host with temporal-sql-tool
+  - type: -e
+    value: 'SQL_PASSWORD=supersecretpassword'
+    description: Password used for authentication when connecting to SQL host with temporal-sql-tool
+  - type: -e
+    value: 'SQL_DATABASE=temporal'
+    description: Name of SQL database used with temporal-sql-tool
+  - type: -e
+    value: 'SQL_PLUGIN=mysql'
+    description: Name of the SQL plugin for temporal-sql-tool
+  - type: -e
+    value: 'SQL_CONNECT_ATTRIBUTES'
+    description: SQL connect attributes for temporal-sql-tool
+  - type: -e
+    value: 'SQL_TLS=true'
+    description: Enable TLS over SQL connection with temporal-sql-tool
+  - type: -e
+    value: 'SQL_TLS_CERT_FILE=/path/to/client.crt'
+    description: SQL TLS client certificate path for temporal-sql-tool
+  - type: -e
+    value: 'SQL_TLS_KEY_FILE=/path/to/client.key'
+    description: SQL TLS client key path for temporal-sql-tool
+  - type: -e
+    value: 'SQL_TLS_CA_FILE=/path/to/client-ca.crt'
+    description: SQL TLS client CA file for temporal-sql-tool
+  - type: -e
+    value: 'SQL_TLS_SERVER_NAME=test-server-name'
+    description: Override for target server name with temporal-sql-tool
+  - type: -e
+    value: 'SQL_TLS_DISABLE_HOST_VERIFICATION=true'
+    description: Disable TLS host name verifaction with temporal-sql-tool (tls must be enabled)
+  - type: -e
+    value: 'TEMPORAL_CLI_ADDRESS=1.2.3.4:5555'
+    description: host:port for Temporal frontend service used by tdbg
+  - type: -e
+    value: 'TEMPORAL_CLI_NAMESPACE=testnamespace'
+    description: Temporal workflow namespace used by tdbg
+  - type: -e
+    value: 'TEMPORAL_CONTEXT_TIMEOUT=10'
+    description: Optional timeout for context of RPC calls in seconds for tdbg
+  - type: -e
+    value: 'TEMPORAL_CLI_TLS_CERT=/path/to/tls.cert'
+    description: Path to x509 certificate used by tdbg
+  - type: -e
+    value: 'TEMPORAL_CLI_TLS_KEY=/path/to/tls.key'
+    description: Path to private key used by tdbg
+  - type: -e
+    value: 'TEMPORAL_CLI_TLS_CA=/path/to/server-ca.crt'
+    description: Path to server CA certificate used by tdbg
+  - type: -e
+    value: 'TEMPORAL_CLI_TLS_DISABLE_HOST_VERFICATION=true'
+    description: Disable TLS host name verification for tdbg (tls must be enabled)
+
+debug:
+  text: |
+    ### Debugging
+    
+    To get an interactive shell:
+    ```bash
+    docker exec -it temporal-admin-tools-container /bin/bash
+    ```

--- a/oci/temporal-admin-tools/image.yaml
+++ b/oci/temporal-admin-tools/image.yaml
@@ -1,0 +1,18 @@
+version: 1
+upload:
+  - source: canonical/temporal-rocks
+    commit: 865b4b3ec8be4d0ec768ccd2be84218e76b0c538
+    directory: 1.23.1
+    release:
+      1-24.04:
+        end-of-life: '2025-10-14T00:00:00Z'
+        risks:
+          - edge
+      1.23-24.04:
+        end-of-life: '2025-10-14T00:00:00Z'
+        risks:
+          - edge
+      1.23.1-24.04:
+        end-of-life: '2025-07-14T00:00:00Z'
+        risks:
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
This PR introduces the temporal-admin-tools rock, which is used to administer and configure the temporal server.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
<img width="451" height="447" alt="image" src="https://github.com/user-attachments/assets/03382b19-58bc-4e99-880b-bbc3dec7398f" />
