### PR TITLE
Add required config files to onboard temporal-ui onto oci-factory

### DIFF
--- a/oci/temporal-ui/contacts.yaml
+++ b/oci/temporal-ui/contacts.yaml
@@ -1,0 +1,5 @@
+notify:
+  emails:
+    - workflows-charmers@canonical.com
+  mattermost-channels:
+    - tbgx8brhn3b3djrh57aqctuibo

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -1,0 +1,35 @@
+version: 1
+
+application: temporal-ui
+description: >
+  The Temporal UI provides a browser-based user interface for Temporal, allowing users to view Workflow Execution state, metadata, and debug their Temporal applications.
+
+docker:
+  parameters:
+    - -p 8081:8081
+  access: Access the Temporal UI at localhost:8081
+
+parameters:
+  - type: -e
+    value: 'TEMPORAL_ROOT=/home/ui-server'
+    description: Root directory of execution environment
+  - type: -e
+    value: 'TEMPORAL_CONFIG_DIR=config'
+    description: Config directory path relative to the root
+  - type: -e
+    value: 'TEMPORAL_ENVIRONMENT=development'
+    description: Runtime environment
+
+debug:
+  text: |
+    ### Debugging
+    
+    To debug the container:
+    ```bash
+    docker logs -f temporal-ui-container
+    ```
+
+    To get an interactive shell:
+    ```bash
+    docker exec -it temporal-ui-container /bin/bash
+    ```

--- a/oci/temporal-ui/image.yaml
+++ b/oci/temporal-ui/image.yaml
@@ -1,0 +1,18 @@
+version: 1
+upload:
+  - source: canonical/temporal-rocks
+    commit: 865b4b3ec8be4d0ec768ccd2be84218e76b0c538
+    directory: 2.39.0
+    release:
+      2-24.04:
+        end-of-life: '2025-10-14T00:00:00Z'
+        risks:
+          - edge
+      2.39-24.04:
+        end-of-life: '2025-10-14T00:00:00Z'
+        risks:
+          - edge
+      2.39.0-24.04:
+        end-of-life: '2025-07-14T00:00:00Z'
+        risks:
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
This PR introduces the temporal-ui, which runs the temporal ui server (serving the web server to manage temporal).

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
<img width="450" height="320" alt="image" src="https://github.com/user-attachments/assets/accec531-50e2-415e-bacb-5a023f2c0800" />
