### PR TITLE
feat: add dotnet-runtime:9.0-25.04_edge

### DIFF
--- a/oci/dotnet-runtime/contacts.yaml
+++ b/oci/dotnet-runtime/contacts.yaml
@@ -1,0 +1,5 @@
+notify:
+  emails:
+    - rocks@canonical.com
+  mattermost-channels:
+    - fbdezwkcxpfofpysjore1wpfoc

--- a/oci/dotnet-runtime/documentation.yaml
+++ b/oci/dotnet-runtime/documentation.yaml
@@ -145,3 +145,9 @@ debug:
     ```bash
     docker logs -f dotnet-runtime-container
     ```
+
+    For versions 9.0-25.04 and onward, to inspect application logs:
+
+    ```bash
+    docker exec -it dotnet-runtime-container pebble logs
+    ```

--- a/oci/dotnet-runtime/documentation.yaml
+++ b/oci/dotnet-runtime/documentation.yaml
@@ -1,0 +1,147 @@
+version: 1
+
+application: dotnet-runtime
+is_chiselled: true
+description: |
+  # Chiselled Ubuntu for Chiselled .NET
+
+  Current Chiselled .NET Docker Image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and rolls to newer Chiselled .NET or Ubuntu release. **This repository is free to use and exempted from per-user rate limits.**
+
+
+  ## About Chiselled .NET
+
+  .NET is a free, cross-platform, open source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
+  Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.
+
+  ### About Chiselled Ubuntu
+
+  **This image does not include bash nor a package manager nor the .NET SDK.**
+  Read more about Chiselled Ubuntu for .NET, a new class of OCI images, on [the Ubuntu blog](https://ubuntu.com/blog/install-dotnet-on-ubuntu); reading how Canonical and Microsoft partner together to deliver and support .NET on Ubuntu.
+
+  If you're looking to publish a self-contained .NET app, please have a look at the `ubuntu/dotnet-deps` repository.
+  If you're looking to publish an ASP.NET app, please then look at the `ubuntu/dotnet-aspnet` repository.
+
+  Please note that the images tagged 6.0, 8.0 and 9.0-24.10 are Dockerfile-based images,
+  whereas from version 9.0-25.04 onward the images are now rocks. As such the
+  entrypoint is now Pebble. Read more on the
+  [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/).
+
+  Versions 6.0, 8.0 and 9.0-24.10 images have `dotnet` as the entrypoint.
+
+  ```sh
+  $ docker run --rm ubuntu/dotnet-runtime:8.0-24.04_stable 
+  Host:
+  Version:      8.0.16
+  ...
+  ```
+
+  Versions 9.0-25.04 and later images have `pebble enter` as the entrypoint. You can
+  access the `dotnet` with the following command:
+  ```sh
+  $ docker run --rm ubuntu/dotnet-runtime:9.0-25.04_edge exec dotnet
+  Usage: dotnet [options]
+  ...
+  ```
+
+  ## Usage
+
+  Launch this image locally:
+
+  For versions 6.0, 8.0 and 9.0-24.10:
+
+  ```sh
+  docker run -d --name dotnet-runtime-container -e TZ=UTC ubuntu/dotnet-runtime:8.0-24.04_stable
+  ```
+
+  The container logs will simply show the .NET Runtime help message.
+  This is because the container expects a .NET application to be given.
+
+  Let's use the following HelloWorld application as an example:
+
+  ```bash
+  $ # Create a HelloWorld.csproj file with the following content
+  $ cat HelloWorld.csproj
+  <Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <OutputType>Exe</OutputType>
+      <TargetFramework>net8.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+  </Project>
+  $
+  $ # Create a Program.cs file with the following code
+  $ cat Program.cs
+  Console.WriteLine("Hello, World!");
+  $
+  $ # Publish the .NET application (you need the "dotnet8" package)
+  $ dotnet publish -c Release -o app
+  MSBuild version 17.8.27+3ab07f0cf for .NET
+    Determining projects to restore...
+    Restored /tmp/demo/HelloWorld.csproj (in 59 ms).
+    HelloWorld -> /tmp/demo/bin/Release/net8.0/HelloWorld.dll
+    HelloWorld -> /tmp/demo/bin/Release/net6.0/publish/
+  $
+  $ # Now you can run the app with "ubuntu/dotnet-runtime:8.0-24.04_stable"
+  $ docker run --rm -v $PWD/app:/app ubuntu/dotnet-runtime:8.0-24.04_stable /app/HelloWorld.dll
+  Hello, World!
+  ```
+
+  Here's the same example as above, but for building your own .NET application image, by building the .NET 8 HelloWorld app on Ubuntu 24.04 and packaging it on top of ubuntu/dotnet-runtime:8.0-24.04_stable:
+
+  ```Dockerfile
+  FROM ubuntu:24.04 AS builder
+
+  # install the .NET 8 SDK from the Ubuntu archive
+  # (no need to clean the apt cache as this is an unpublished stage)
+  RUN apt-get update && apt-get install -y dotnet8 ca-certificates
+
+  # add your application code (the HelloWorld example from above)
+  WORKDIR /source
+  COPY . .
+
+  # publish your .NET app
+  RUN dotnet publish -c Release -o /app
+
+  FROM ubuntu/dotnet-runtime:8.0-24.04_beta
+
+  WORKDIR /app
+  COPY --from=builder /app ./
+
+  ENTRYPOINT ["dotnet", "/app/HelloWorld.dll"]
+  ```
+
+  For versions 9.0-25.04 and onward, please use
+
+  ```docker
+  FROM ubuntu:25.04 AS builder
+
+  RUN apt-get update && apt-get install -y dotnet9 ca-certificates
+
+  # add your application code (the HelloWorld example from above),
+  # and change the TargetFramework to net9.0 in the HelloWorld.csproj
+  WORKDIR /source
+  COPY . .
+
+  # publish your .NET app
+  RUN dotnet publish -c Release -o /app
+
+  FROM ubuntu/dotnet-runtime:9.0-25.04_edge
+
+  WORKDIR /app
+  COPY --from=builder /app ./
+
+  ENTRYPOINT ["exec", "dotnet", "/app/HelloWorld.dll"]
+  ```
+
+debug:
+  text: |
+    ### Debugging
+
+    To debug the container:
+
+    ```bash
+    docker logs -f dotnet-runtime-container
+    ```

--- a/oci/dotnet-runtime/documentation.yaml
+++ b/oci/dotnet-runtime/documentation.yaml
@@ -144,14 +144,14 @@ docker:
     WORKDIR /app
     COPY --from=builder /app ./
 
-    ENTRYPOINT ["exec", "dotnet", "/app/HelloWorld.dll"]
+    CMD ["exec", "dotnet", "/app/HelloWorld.dll"]
     ```
 
 # Debug docs will be automatically generated for the rock-based images.
 debug:
   text: |
-    To debug the container for versions 6.0, 8.0 and 9.0-24.10:
+    To debug the container for versions 9.0-25.04 and later:
 
     ```bash
-    docker logs -f dotnet-runtime-container
+    docker exec -it dotnet-runtime-container pebble logs
     ```

--- a/oci/dotnet-runtime/documentation.yaml
+++ b/oci/dotnet-runtime/documentation.yaml
@@ -3,13 +3,6 @@ version: 1
 application: dotnet-runtime
 is_chiselled: true
 description: |
-  # Chiselled Ubuntu for Chiselled .NET
-
-  Current Chiselled .NET Docker Image [from Canonical](https://ubuntu.com/security/docker-images), based on Ubuntu. Receives security updates and rolls to newer Chiselled .NET or Ubuntu release. **This repository is free to use and exempted from per-user rate limits.**
-
-
-  ## About Chiselled .NET
-
   .NET is a free, cross-platform, open source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
   Read [the .NET documentation](https://docs.microsoft.com/en-us/dotnet/core/deploying/) to learn how to deploy your .NET application with container images.
 

--- a/oci/dotnet-runtime/documentation.yaml
+++ b/oci/dotnet-runtime/documentation.yaml
@@ -20,6 +20,8 @@ docker:
   parameters:
     - -e TZ=UTC
   access: |
+    ### New entrypoint `pebble`
+
     Please note that the images tagged 6.0, 8.0 and 9.0-24.10 are Dockerfile-based images,
     whereas from version 9.0-25.04 onward the images are now rocks. As such the
     entrypoint is now Pebble. Read more on the
@@ -42,18 +44,14 @@ docker:
     ...
     ```
 
-    Launch this image tagged with versions 6.0, 8.0 and 9.0-24.10 locally:
-
-    ```sh
-    docker run -d --name dotnet-runtime-container -e TZ=UTC ubuntu/dotnet-runtime:8.0-24.04_stable
-    ```
-
-    The container logs will simply show the .NET Runtime help message.
+    The container logs simply show the .NET help message.
     This is because the container expects a .NET application to be given.
+
+    ### Run a .NET application
 
     Let's use the following HelloWorld application as an example:
 
-    ### Using the images tagged with versions 6.0, 8.0 and 9.0-24.10
+    #### Using the images tagged with versions 6.0, 8.0 and 9.0-24.10
 
     ```bash
     $ # Create a HelloWorld.csproj file with the following content
@@ -68,20 +66,20 @@ docker:
       </PropertyGroup>
 
     </Project>
-    $
-    $ # Create a Program.cs file with the following code
+
+    # Create a Program.cs file with the following code
     $ cat Program.cs
     Console.WriteLine("Hello, World!");
-    $
-    $ # Publish the .NET application (you need the "dotnet8" package)
+
+    # Publish the .NET application (you need the "dotnet8" package)
     $ dotnet publish -c Release -o app
     MSBuild version 17.8.27+3ab07f0cf for .NET
       Determining projects to restore...
       Restored /tmp/demo/HelloWorld.csproj (in 59 ms).
       HelloWorld -> /tmp/demo/bin/Release/net8.0/HelloWorld.dll
       HelloWorld -> /tmp/demo/bin/Release/net8.0/publish/
-    $
-    $ # Now you can run the app with "ubuntu/dotnet-runtime:8.0-24.04_stable"
+
+    # Now you can run the app with "ubuntu/dotnet-runtime:8.0-24.04_stable"
     $ docker run --rm -v $PWD/app:/app ubuntu/dotnet-runtime:8.0-24.04_stable /app/HelloWorld.dll
     Hello, World!
     ```
@@ -98,7 +96,9 @@ docker:
     Hello, World!
     ```
 
-    ### Build your own .NET application image
+    ### Build a .NET application image
+
+    #### Using the images tagged 6.0, 8.0 and 9.0-24.10
 
     Here's the same example as above, but for building your own .NET application image, by building the .NET 8 HelloWorld app on Ubuntu 24.04 and packaging it on top of ubuntu/dotnet-runtime:8.0-24.04_stable:
 
@@ -124,7 +124,9 @@ docker:
     ENTRYPOINT ["dotnet", "/app/HelloWorld.dll"]
     ```
 
-    For versions 9.0-25.04 and onward, please use
+    #### Using the images tagged 9.0-25.04 and later
+
+    Here is the example Dockerfile to build your own .NET application image on top of `ubuntu/dotnet-runtime:9.0-25.04_edge`. You need to replace the `net8.0` in the `HelloWorld.csproj` file with `net9.0`:
 
     ```docker
     FROM ubuntu:25.04 AS builder
@@ -147,11 +149,11 @@ docker:
     CMD ["exec", "dotnet", "/app/HelloWorld.dll"]
     ```
 
-# Debug docs will be automatically generated for the rock-based images.
-debug:
-  text: |
-    To debug the container for versions 9.0-25.04 and later:
+    # Debug docs will be automatically generated for the rock-based images.
+    debug:
+      text: |
+        To debug the container for versions 9.0-25.04 and later:
 
-    ```bash
-    docker exec -it dotnet-runtime-container pebble logs
-    ```
+        ```bash
+        docker exec -it dotnet-runtime-container pebble logs
+        ```

--- a/oci/dotnet-runtime/documentation.yaml
+++ b/oci/dotnet-runtime/documentation.yaml
@@ -21,133 +21,144 @@ description: |
   If you're looking to publish a self-contained .NET app, please have a look at the `ubuntu/dotnet-deps` repository.
   If you're looking to publish an ASP.NET app, please then look at the `ubuntu/dotnet-aspnet` repository.
 
-  Please note that the images tagged 6.0, 8.0 and 9.0-24.10 are Dockerfile-based images,
-  whereas from version 9.0-25.04 onward the images are now rocks. As such the
-  entrypoint is now Pebble. Read more on the
-  [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/).
+# "Launch the image locally" section is automatically generated for the rock-based images.
+# For the Dockerfile-based images, it is manually written.
+docker:
+  parameters:
+    - -e TZ=UTC
+  access: |
+    Please note that the images tagged 6.0, 8.0 and 9.0-24.10 are Dockerfile-based images,
+    whereas from version 9.0-25.04 onward the images are now rocks. As such the
+    entrypoint is now Pebble. Read more on the
+    [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/).
 
-  Versions 6.0, 8.0 and 9.0-24.10 images have `dotnet` as the entrypoint.
+    Versions 6.0, 8.0 and 9.0-24.10 images have `dotnet` as the entrypoint.
 
-  ```sh
-  $ docker run --rm ubuntu/dotnet-runtime:8.0-24.04_stable 
-  Host:
-  Version:      8.0.16
-  ...
-  ```
+    ```sh
+    $ docker run --rm ubuntu/dotnet-runtime:8.0-24.04_stable
+    Host:
+    Version:      8.0.16
+    ...
+    ```
 
-  Versions 9.0-25.04 and later images have `pebble enter` as the entrypoint. You can
-  access the `dotnet` with the following command:
-  ```sh
-  $ docker run --rm ubuntu/dotnet-runtime:9.0-25.04_edge exec dotnet
-  Usage: dotnet [options]
-  ...
-  ```
+    Versions 9.0-25.04 and later images have `pebble enter` as the entrypoint. You can
+    access the `dotnet` with the following command:
+    ```sh
+    $ docker run --rm ubuntu/dotnet-runtime:9.0-25.04_edge exec dotnet
+    Usage: dotnet [options]
+    ...
+    ```
 
-  ## Usage
+    Launch this image tagged with versions 6.0, 8.0 and 9.0-24.10 locally:
 
-  Launch this image locally:
+    ```sh
+    docker run -d --name dotnet-runtime-container -e TZ=UTC ubuntu/dotnet-runtime:8.0-24.04_stable
+    ```
 
-  For versions 6.0, 8.0 and 9.0-24.10:
+    The container logs will simply show the .NET Runtime help message.
+    This is because the container expects a .NET application to be given.
 
-  ```sh
-  docker run -d --name dotnet-runtime-container -e TZ=UTC ubuntu/dotnet-runtime:8.0-24.04_stable
-  ```
+    Let's use the following HelloWorld application as an example:
 
-  The container logs will simply show the .NET Runtime help message.
-  This is because the container expects a .NET application to be given.
+    ### Using the images tagged with versions 6.0, 8.0 and 9.0-24.10
 
-  Let's use the following HelloWorld application as an example:
+    ```bash
+    $ # Create a HelloWorld.csproj file with the following content
+    $ cat HelloWorld.csproj
+    <Project Sdk="Microsoft.NET.Sdk">
 
-  ```bash
-  $ # Create a HelloWorld.csproj file with the following content
-  $ cat HelloWorld.csproj
-  <Project Sdk="Microsoft.NET.Sdk">
+      <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+      </PropertyGroup>
 
-    <PropertyGroup>
-      <OutputType>Exe</OutputType>
-      <TargetFramework>net8.0</TargetFramework>
-      <ImplicitUsings>enable</ImplicitUsings>
-      <Nullable>enable</Nullable>
-    </PropertyGroup>
+    </Project>
+    $
+    $ # Create a Program.cs file with the following code
+    $ cat Program.cs
+    Console.WriteLine("Hello, World!");
+    $
+    $ # Publish the .NET application (you need the "dotnet8" package)
+    $ dotnet publish -c Release -o app
+    MSBuild version 17.8.27+3ab07f0cf for .NET
+      Determining projects to restore...
+      Restored /tmp/demo/HelloWorld.csproj (in 59 ms).
+      HelloWorld -> /tmp/demo/bin/Release/net8.0/HelloWorld.dll
+      HelloWorld -> /tmp/demo/bin/Release/net8.0/publish/
+    $
+    $ # Now you can run the app with "ubuntu/dotnet-runtime:8.0-24.04_stable"
+    $ docker run --rm -v $PWD/app:/app ubuntu/dotnet-runtime:8.0-24.04_stable /app/HelloWorld.dll
+    Hello, World!
+    ```
 
-  </Project>
-  $
-  $ # Create a Program.cs file with the following code
-  $ cat Program.cs
-  Console.WriteLine("Hello, World!");
-  $
-  $ # Publish the .NET application (you need the "dotnet8" package)
-  $ dotnet publish -c Release -o app
-  MSBuild version 17.8.27+3ab07f0cf for .NET
-    Determining projects to restore...
-    Restored /tmp/demo/HelloWorld.csproj (in 59 ms).
-    HelloWorld -> /tmp/demo/bin/Release/net8.0/HelloWorld.dll
-    HelloWorld -> /tmp/demo/bin/Release/net6.0/publish/
-  $
-  $ # Now you can run the app with "ubuntu/dotnet-runtime:8.0-24.04_stable"
-  $ docker run --rm -v $PWD/app:/app ubuntu/dotnet-runtime:8.0-24.04_stable /app/HelloWorld.dll
-  Hello, World!
-  ```
+    #### Using the images tagged with versions 9.0-25.04 and later
 
-  Here's the same example as above, but for building your own .NET application image, by building the .NET 8 HelloWorld app on Ubuntu 24.04 and packaging it on top of ubuntu/dotnet-runtime:8.0-24.04_stable:
+    Use the same example, but change the TargetFramework to `net9.0` in the
+    `HelloWorld.csproj` file, and then run the following commands:
 
-  ```Dockerfile
-  FROM ubuntu:24.04 AS builder
+    ```bash
+    $ # Publish the .NET application (you need the "dotnet9" package)
+    $ dotnet publish -c Release -o app
+    $ docker run --rm -v $PWD/app:/app ubuntu/dotnet-runtime:9.0-25.04_edge exec dotnet /app/HelloWorld.dll
+    Hello, World!
+    ```
 
-  # install the .NET 8 SDK from the Ubuntu archive
-  # (no need to clean the apt cache as this is an unpublished stage)
-  RUN apt-get update && apt-get install -y dotnet8 ca-certificates
+    ### Build your own .NET application image
 
-  # add your application code (the HelloWorld example from above)
-  WORKDIR /source
-  COPY . .
+    Here's the same example as above, but for building your own .NET application image, by building the .NET 8 HelloWorld app on Ubuntu 24.04 and packaging it on top of ubuntu/dotnet-runtime:8.0-24.04_stable:
 
-  # publish your .NET app
-  RUN dotnet publish -c Release -o /app
+    ```Dockerfile
+    FROM ubuntu:24.04 AS builder
 
-  FROM ubuntu/dotnet-runtime:8.0-24.04_beta
+    # install the .NET 8 SDK from the Ubuntu archive
+    # (no need to clean the apt cache as this is an unpublished stage)
+    RUN apt-get update && apt-get install -y dotnet8 ca-certificates
 
-  WORKDIR /app
-  COPY --from=builder /app ./
+    # add your application code (the HelloWorld example from above)
+    WORKDIR /source
+    COPY . .
 
-  ENTRYPOINT ["dotnet", "/app/HelloWorld.dll"]
-  ```
+    # publish your .NET app
+    RUN dotnet publish -c Release -o /app
 
-  For versions 9.0-25.04 and onward, please use
+    FROM ubuntu/dotnet-runtime:8.0-24.04_beta
 
-  ```docker
-  FROM ubuntu:25.04 AS builder
+    WORKDIR /app
+    COPY --from=builder /app ./
 
-  RUN apt-get update && apt-get install -y dotnet9 ca-certificates
+    ENTRYPOINT ["dotnet", "/app/HelloWorld.dll"]
+    ```
 
-  # add your application code (the HelloWorld example from above),
-  # and change the TargetFramework to net9.0 in the HelloWorld.csproj
-  WORKDIR /source
-  COPY . .
+    For versions 9.0-25.04 and onward, please use
 
-  # publish your .NET app
-  RUN dotnet publish -c Release -o /app
+    ```docker
+    FROM ubuntu:25.04 AS builder
 
-  FROM ubuntu/dotnet-runtime:9.0-25.04_edge
+    RUN apt-get update && apt-get install -y dotnet9 ca-certificates
 
-  WORKDIR /app
-  COPY --from=builder /app ./
+    # add your application code (the HelloWorld example from above),
+    # and change the TargetFramework to net9.0 in the HelloWorld.csproj
+    WORKDIR /source
+    COPY . .
 
-  ENTRYPOINT ["exec", "dotnet", "/app/HelloWorld.dll"]
-  ```
+    # publish your .NET app
+    RUN dotnet publish -c Release -o /app
 
+    FROM ubuntu/dotnet-runtime:9.0-25.04_edge
+
+    WORKDIR /app
+    COPY --from=builder /app ./
+
+    ENTRYPOINT ["exec", "dotnet", "/app/HelloWorld.dll"]
+    ```
+
+# Debug docs will be automatically generated for the rock-based images.
 debug:
   text: |
-    ### Debugging
-
-    To debug the container:
+    To debug the container for versions 6.0, 8.0 and 9.0-24.10:
 
     ```bash
     docker logs -f dotnet-runtime-container
-    ```
-
-    For versions 9.0-25.04 and onward, to inspect application logs:
-
-    ```bash
-    docker exec -it dotnet-runtime-container pebble logs
     ```

--- a/oci/dotnet-runtime/image.yaml
+++ b/oci/dotnet-runtime/image.yaml
@@ -1,7 +1,7 @@
 version: 1
 upload:
   - source: canonical/dotnet-runtime-rock
-    commit: 3541c8cb2bf9f333b8a63b0185e0699a3af4469a
+    commit: 10d8acfff0790cb0ffd37769ad2134850163e60a
     directory: dotnet-runtime-rock/9.0-25.04
     release:
       9.0-25.04:

--- a/oci/dotnet-runtime/image.yaml
+++ b/oci/dotnet-runtime/image.yaml
@@ -1,0 +1,10 @@
+version: 1
+upload:
+  - source: canonical/dotnet-runtime-rock
+    commit: 3541c8cb2bf9f333b8a63b0185e0699a3af4469a
+    directory: dotnet-runtime-rock/9.0-25.04
+    release:
+      9.0-25.04:
+        end-of-life: '2026-01-15T00:00:00Z'
+        risks:
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
This PR adds the dotnet-runtime:9.0-25.04_edge.

The documentation is handled similarly to the `jre` rock to cope with the co-existence of Dockerfile-based images and rocks.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
#517 
