### PR TITLE
feat(ci): enable weekly rebuild for all images

### DIFF
--- a/.github/workflows/Rebuild-Images.yaml
+++ b/.github/workflows/Rebuild-Images.yaml
@@ -2,7 +2,7 @@
 name: Rebuild images
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 2 * * 0"
   workflow_dispatch:
     inputs:
       image-name:
@@ -38,8 +38,7 @@ jobs:
             OS_PROJECT_NAME: ${{ secrets.SWIFT_OS_TENANT_NAME }}
             OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL }}
             GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
-          # TODO change the 'mock-rock' to the '*'
           run: |
-            poetry run python3 find_images_to_update.py --image-name ${{ inputs.image-name || 'mock-rock' }} \
-                                                        --ext-ref-prefix daily-rebuild
+            poetry run python3 find_images_to_update.py --image-name ${{ inputs.image-name || '*' }} \
+                                                        --ext-ref-prefix weekly-rebuild
   

--- a/oci/mock-rock/_releases.json
+++ b/oci/mock-rock/_releases.json
@@ -35,31 +35,31 @@
     "1.1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1750"
+            "target": "1773"
         },
         "beta": {
-            "target": "1750"
+            "target": "1773"
         },
         "edge": {
-            "target": "1750"
+            "target": "1773"
         }
     },
     "1-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "candidate": {
-            "target": "1750"
+            "target": "1773"
         },
         "beta": {
-            "target": "1750"
+            "target": "1773"
         },
         "edge": {
-            "target": "1750"
+            "target": "1773"
         }
     },
     "1.2-22.04": {
         "end-of-life": "2030-05-01T00:00:00Z",
         "beta": {
-            "target": "1751"
+            "target": "1774"
         },
         "edge": {
             "target": "1.2-22.04_beta"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR enables the weekly rebuild for all the rocks. Rebuild occurs on Sundays to avoid surges in runners on weekdays.
