### PR TITLE
feat: add MySQL .trivyignore file

### DIFF
--- a/oci/mysql/.trivyignore
+++ b/oci/mysql/.trivyignore
@@ -1,11 +1,17 @@
 # Golang CVE fixed in upstream PR
 # https://go-review.googlesource.com/c/go/+/578375
+# Patched version released in Ubuntu archive
+# https://ubuntu.com/security/CVE-2024-24788
 CVE-2024-24788
 
 # Golang CVE fixed in upstream PR
 # https://go-review.googlesource.com/c/go/+/590296
+# Patched version released in Ubuntu archive
+# https://ubuntu.com/security/CVE-2024-24790
 CVE-2024-24790
 
 # Golang CVE fixed in upstream PR
 # https://go-review.googlesource.com/c/go/+/611239
+# Patched version released in Ubuntu archive
+# https://ubuntu.com/security/CVE-2024-34156
 CVE-2024-34156


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR adds a `.trivyignore` file to the MySQL OCI Factory so that the false-positive vulnerabilities preventing the automatic publishing of the image are ignored (see [CI run](https://github.com/canonical/oci-factory/actions/runs/16118774952/)).
