### PR TITLE
feat: add rabbitmq:3.9-22.04

### DIFF
--- a/oci/rabbitmq/documentation.yaml
+++ b/oci/rabbitmq/documentation.yaml
@@ -45,9 +45,3 @@ debug:
     ```bash
     curl -u guest:guest http://localhost:15672/api/healthchecks/node
     ```
-
-    To get an interactive shell:
-
-    ```bash
-    docker exec -it rabbitmq-container /bin/bash
-    ```

--- a/oci/rabbitmq/image.yaml
+++ b/oci/rabbitmq/image.yaml
@@ -1,14 +1,26 @@
 version: 1
 upload:
   - source: canonical/rabbitmq-rock
-    commit: 45ffe2a96edf7e4020656cc30eb903bbe4ed55b4
+    commit: 944a90eb40bebe6c278b055be75ae969d54bcd45
     directory: 3.12-24.04
     release:
       3.12-24.04:
-        end-of-life: '2029-05-01T00:00:00Z'
+        end-of-life: '2029-05-31T00:00:00Z'
+        risks:
+          - edge
+      3-24.04:
+        end-of-life: '2029-05-31T00:00:00Z'
+        risks:
+          - edge
+  - source: canonical/rabbitmq-rock
+    commit: 944a90eb40bebe6c278b055be75ae969d54bcd45
+    directory: 3.9-22.04
+    release:
+      3.9-22.04:
+        end-of-life: '2027-06-01T00:00:00Z'
         risks:
           - edge
       3-22.04:
-        end-of-life: '2029-05-01T00:00:00Z'
+        end-of-life: '2027-06-01T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR adds the rabbitmq version `3.9-22.04` to the OCi Factory to fix the erroneous tag for `3-22.04`.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A
---

*Picture of a cool rock:*

<img width="736" height="981" alt="image" src="https://github.com/user-attachments/assets/c837f695-df25-45ce-8982-aa81c85018f0" />
cr: https://www.pinterest.com/pin/504825439501934742/
