### PR TITLE
feat(ci): support legacy images in documentation for proper EOL

### DIFF
--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -5,12 +5,10 @@ for OCI images within the oci-factory
 """
 
 import argparse
-import base64
 import json
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -357,6 +355,10 @@ class OCIDocumentationData:
         all_tracks = self.get_all_tracks(
             all_revision_tags, releases_file=f"{self.image_path}/_releases.json"
         )
+
+        override_tracks = base_doc_yaml.get("override_tracks", {})
+        logger.info(f"Override tracks from documentation.yaml: {override_tracks}")
+        all_tracks.update({k: v["end_of_life"] for k, v in override_tracks.items()})
 
         # Get all the published OCI tags from ECR
         all_ecr_tags = {"imageTagDetails": []}


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
This PR adds the feature to generate the documentation with the correct EOL dates for legacy images and for images having mismatched build-base and tracks (e.g., for `dotnet:9.0-25.04`, which is built on `24.04` as a build-base).

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A
---

*Picture of a cool rock:*
