### PR TITLE
feat: Add pyroscope 1.14.1 with trivyignore

### DIFF
--- a/oci/pyroscope/.trivyignore
+++ b/oci/pyroscope/.trivyignore
@@ -1,0 +1,4 @@
+# Upstream CVEs
+
+# stdlib: Incorrect results returned from Rows.Scan in database/sql - not affected
+CVE-2025-47907

--- a/oci/pyroscope/image.yaml
+++ b/oci/pyroscope/image.yaml
@@ -1,18 +1,18 @@
 version: 1
 upload:
   - source: canonical/pyroscope-rock
-    commit: a1a3d7e7f4aa071e5c20ed4f5a7f5ca7ce6b799c
-    directory: 1.14.0
+    commit: 3874bd23f9fc2cb27ab59c71a020bfd9954eb52d
+    directory: 1.14.1
     release:
       1-24.04:
-        end-of-life: '2025-09-27T00:00:00Z'
+        end-of-life: '2025-12-02T00:00:00Z'
         risks:
           - edge
       1.14-24.04:
-        end-of-life: '2025-09-27T00:00:00Z'
+        end-of-life: '2025-12-02T00:00:00Z'
         risks:
           - edge
-      1.14.0-24.04:
-        end-of-life: '2025-07-10T00:00:00Z'
+      1.14.1-24.04:
+        end-of-life: '2025-09-04T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
Release Pyroscope 1.14.1 with trivyignore. I used `govulncheck` to verify this is a golang upstream CVE on the components of stdlib this application doesn't use.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

#568 and #576 can be closed.

---

*Picture of a cool rock:*

<img width="1324" height="993" alt="image" src="https://github.com/user-attachments/assets/384ea898-3563-4954-911e-e64900b34369" />

