### PR TITLE
feat(ci): remove get workflow version action

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -62,6 +62,13 @@ jobs:
       oci-factory-ref: ${{ steps.workflow-version.outputs.sha }}
     name: "configure-build ${{ inputs.build-id != '' && format('| {0}', inputs.build-id) || ' '}}"
     steps:
+      - name: Warn deprecated secret
+        env: 
+          HOST_GITHUB_TOKEN: ${{ secrets.host-github-token }}
+        if: ${{ env.HOST_GITHUB_TOKEN != '' }}
+        run: |
+          echo "Warning: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
+
       - name: Cloning OCI Factory
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -43,8 +43,6 @@ on:
     
     secrets:
       # authentication parameters
-      host-github-token:
-        description: "Deprecated: GitHub token from repository executing this workflow."
       source-github-token:
         description: "GitHub token for pulling a Rockcraft project from a private repository."
 env:

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -43,6 +43,8 @@ on:
     
     secrets:
       # authentication parameters
+      host-github-token:
+        description: "Deprecated: GitHub token from repository executing this workflow."
       source-github-token:
         description: "GitHub token for pulling a Rockcraft project from a private repository."
 env:

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -44,7 +44,7 @@ on:
     secrets:
       # authentication parameters
       host-github-token:
-        description: "GitHub token from repository executing this workflow."
+        description: "Deprecated: GitHub token from repository executing this workflow."
       source-github-token:
         description: "GitHub token for pulling a Rockcraft project from a private repository."
 env:
@@ -62,20 +62,13 @@ jobs:
       oci-factory-ref: ${{ steps.workflow-version.outputs.sha }}
     name: "configure-build ${{ inputs.build-id != '' && format('| {0}', inputs.build-id) || ' '}}"
     steps:
-
-      - name: Get Workflow Version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/oci-factory
-          file-name: Build-Rock.yaml
-          github-token: ${{ secrets.host-github-token }}
-
       - name: Cloning OCI Factory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
+          # Here we clone the oci-factory repo using the default ref of the checkout action.
+          # It will be set to a ref that triggered this workflow if the workflow is run within the oci-factory repo,
+          # or to the default branch of the oci-factory repo if the workflow is called from another repo.
           repository: canonical/oci-factory
-          ref: ${{ steps.workflow-version.outputs.sha }}
           fetch-depth: 1
 
       - name: Cloning Target Repo

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -67,7 +67,7 @@ jobs:
           HOST_GITHUB_TOKEN: ${{ secrets.host-github-token }}
         if: ${{ env.HOST_GITHUB_TOKEN != '' }}
         run: |
-          echo "Warning: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
+          echo "::warning:: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
 
       - name: Cloning OCI Factory
         uses: actions/checkout@v5

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -59,7 +59,6 @@ jobs:
     outputs:
       runner-build-matrix: ${{ steps.configure.outputs.runner-build-matrix }}
       lpci-build-matrix: ${{ steps.configure.outputs.lpci-build-matrix }}
-      oci-factory-ref: ${{ steps.workflow-version.outputs.sha }}
     name: "configure-build ${{ inputs.build-id != '' && format('| {0}', inputs.build-id) || ' '}}"
     steps:
       - name: Warn deprecated secret
@@ -119,7 +118,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-build.outputs.oci-factory-ref }}
           fetch-depth: 1
 
       - name: Cloning Target Repo
@@ -170,7 +168,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-build.outputs.oci-factory-ref }}
           fetch-depth: 1
 
       - name: Cloning Target Repo
@@ -222,7 +219,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-build.outputs.oci-factory-ref }}
           fetch-depth: 1
 
       - run: src/build_rock/assemble_rock/requirements.sh

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -45,6 +45,10 @@ on:
         default: true
         type: boolean
 
+    secrets:
+      # authentication parameters
+      host-github-token:
+        description: "Deprecated: GitHub token from repository executing this workflow."
 
 env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"  # TODO: inherit string from caller

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -45,10 +45,6 @@ on:
         default: true
         type: boolean
 
-    secrets:
-      # authentication parameters
-      host-github-token:
-        description: "Deprecated: GitHub token from repository executing this workflow."
 
 env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"  # TODO: inherit string from caller

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -74,7 +74,7 @@ jobs:
           HOST_GITHUB_TOKEN: ${{ secrets.host-github-token }}
         if: ${{ env.HOST_GITHUB_TOKEN != '' }}
         run: |
-          echo "Warning: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
+          echo "::warning:: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
 
       - name: Cloning OCI Factory
         uses: actions/checkout@v5

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -121,7 +121,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-tests.outputs.oci-factory-ref }}
           fetch-depth: 1
 
       - uses: actions/cache/restore@v4
@@ -191,7 +190,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-tests.outputs.oci-factory-ref }}
           fetch-depth: 1
 
       - uses: actions/cache/restore@v4
@@ -245,7 +243,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-tests.outputs.oci-factory-ref }}
           fetch-depth: 1
       
       - name: Checkout Rock Repo
@@ -365,7 +362,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: canonical/oci-factory
-          ref: ${{ needs.configure-tests.outputs.oci-factory-ref }}
           fetch-depth: 1
 
       - uses: actions/cache/restore@v4

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -48,7 +48,7 @@ on:
     secrets:
       # authentication parameters
       host-github-token:
-        description: "GitHub token from repository executing this workflow."
+        description: "Deprecated: GitHub token from repository executing this workflow."
 
 env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"  # TODO: inherit string from caller
@@ -65,24 +65,17 @@ jobs:
   configure-tests:
     runs-on: ubuntu-22.04
     outputs:
-      oci-factory-ref: ${{ steps.workflow-version.outputs.sha }}
       cache-key: ${{ steps.set-cache.outputs.key }}
     name: "configure-tests ${{ inputs.oci-archive-name != '' && format('| {0}', inputs.oci-archive-name) || ' '}}"
 
     steps:
-      - name: Get Workflow Version
-        id: workflow-version
-        uses: canonical/get-workflow-version-action@v1
-        with:
-          repository-name: canonical/oci-factory
-          file-name: Test-Rock.yaml
-          github-token: ${{ secrets.host-github-token }}
-
       - name: Cloning OCI Factory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
+          # Here we clone the oci-factory repo using the default ref of the checkout action.
+          # It will be set to a ref that triggered this workflow if the workflow is run within the oci-factory repo,
+          # or to the default branch of the oci-factory repo if the workflow is called from another repo.
           repository: canonical/oci-factory
-          ref: ${{ steps.workflow-version.outputs.sha }}
           fetch-depth: 1
 
       # download and unpack the image under test, then store it under a common cache key. 

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -69,6 +69,13 @@ jobs:
     name: "configure-tests ${{ inputs.oci-archive-name != '' && format('| {0}', inputs.oci-archive-name) || ' '}}"
 
     steps:
+      - name: Warn deprecated secret
+        env: 
+          HOST_GITHUB_TOKEN: ${{ secrets.host-github-token }}
+        if: ${{ env.HOST_GITHUB_TOKEN != '' }}
+        run: |
+          echo "Warning: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
+
       - name: Cloning OCI Factory
         uses: actions/checkout@v5
         with:

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ _See Note on Private Repositories._
 | Property | Required | Description |
 |---|---|---|
 | `source-github-token` | False | GitHub token for pulling a Rockcraft project from a private repository. |
-| `host-github-token` | False | GitHub token from repository executing this workflow. |
+| `host-github-token` | False | (Deprecated) GitHub token from repository executing this workflow. |
 
 ### Test-Rock Workflow
 
@@ -495,4 +495,4 @@ needed.
 _See Note on Private Repositories._
 | Property | Required | Description |
 |---|---|---|
-| `host-github-token` | False  | GitHub token from repository executing this workflow. |
+| `host-github-token` | False  | (Deprecated) GitHub token from repository executing this workflow. |


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR removes the calling into `get-workflow-version-action,` in order to limit the calls into GH API, which often causes the rate limit to be exceeded.

Note: We have to keep the security input of `host-github-token` for now, but mark it as deprecated for now to continue supporting the other repos that pass the `host-github-token` secret into the corresponding workflows.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

N/A

### Test workflow runs:

[Workflow run a private repo](https://github.com/canonical/test-private-templated-rock/actions/runs/17496210544) demonstrates that the `host-github-token`  is not needed anymore, and the workflow runs correctly without the `get-workflow-version-action` being called.


---

*Picture of a cool rock:*
