### PR TITLE
chore: Add new litmuschaos-server releases

### DIFF
--- a/oci/litmuschaos-server/.trivyignore
+++ b/oci/litmuschaos-server/.trivyignore
@@ -7,3 +7,6 @@ CVE-2025-22869
 # Improper Validation of Syntactic Correctness of Input in golang.org/x/oauth2
 # Not in use as show by govulncheck
 CVE-2025-22868
+
+# stdlib: Incorrect results returned from Rows.Scan in database/sql - not affected
+CVE-2025-47907

--- a/oci/litmuschaos-server/image.yaml
+++ b/oci/litmuschaos-server/image.yaml
@@ -1,14 +1,14 @@
 version: 1
 upload:
   - source: canonical/litmuschaos-server-rock
-    commit: 82d71a048a74afbdeefe2503b37394ba9dc53875
-    directory: 3.19.0
+    commit: 5e89dfcc539e1f3dc91e8e32a3aae2d5f4e17314
+    directory: 3.20.0
     release:
       3-24.04:
-        end-of-life: '2025-10-30T00:00:00Z'
+        end-of-life: '2025-12-10T00:00:00Z'
         risks:
           - edge
-      3.19-24.04:
-        end-of-life: '2025-10-30T00:00:00Z'
+      3.20-24.04:
+        end-of-life: '2025-12-10T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
- Add a new 3.20.0 release.
- Add vuln to .trivyignore after validating with govulncheck

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
