### PR TITLE
feat(ci): allow vuln scan in non-public repo

### DIFF
--- a/.github/actions/upload-rock/action.yml
+++ b/.github/actions/upload-rock/action.yml
@@ -59,6 +59,7 @@ runs:
           --dest-username "${{ inputs.username }}" \
           --dest-password "${{ inputs.password }}" \
           --multi-arch all \
+          --preserve-digests \
           oci-archive:${{ inputs.artifact_name }} \
           docker://${{ inputs.registry }}/${{ inputs.name }}:$tag
         done

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -57,7 +57,9 @@ jobs:
             -v $PWD:/workdir -w /workdir \
             ${{ env.SKOPEO_IMAGE }} \
             copy docker://${{ inputs.oci-image-name }} \
-            oci-archive:$oci_filename
+            oci-archive:$oci_filename \
+            --src-username "${{ github.actor }}" \
+            --src-password "${{ secrets.GITHUB_TOKEN }}"
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
@@ -78,6 +80,8 @@ jobs:
       test-efficiency: false
       test-malware: false
       test-oci-compliance: false
+    permissions:
+      contents: read
 
   parse-results:
     name: "parse-results ${{ inputs.oci-image-name != '' && format('| {0}', inputs.oci-image-name) || ' '}}"


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR enable the OCI-Factory's reusable vulnerability scan workflow to scan images from GHCR associated with non-public repositories.

## Related Workflow Run

https://github.com/canonical/rocks-template-test-rock/actions/runs/17833871186