### PR TITLE
fix(ci): bypass actor validation upon scheduled vuln scan

### DIFF
--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -96,7 +96,9 @@ jobs:
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
-        if: ${{ github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork }}
+        if: 
+          github.repository == 'canonical/oci-factory' && !github.event.pull_request.head.repo.fork &&
+          github.event_name != 'schedule'
         with:
           admin-only: true
           image-path: ${{ inputs.oci-image-path }}


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR allows the OCI Factory to bypass the actor validation in the scheduled vulnerability scanning in order to prevent failures when the head of the `main` branch has a non-code-owner committer.

