### PR TITLE
chore: update .trivyignore for grafana 9.5.x

### DIFF
--- a/oci/grafana/.trivyignore
+++ b/oci/grafana/.trivyignore
@@ -59,3 +59,15 @@ CVE-2023-2801
 CVE-2023-3128
 # github.com/grafana/grafana - grafana: Cross Site Scripting in Grafana
 CVE-2025-6023
+# github.com/grafana/grafana-plugin-sdk-go - grafana-plugin-sdk-go: Information Leakage in grafana-plugin-sdk-go
+CVE-2024-8986
+# github.com/go-git/go-git/v5 - go-git: argument injection via the URL field
+CVE-2025-21613
+# github.com/go-git/go-git/v5 - go-git: go-git clients vulnerable to DoS via maliciously crafted Git server replies
+CVE-2025-21614
+# golang.org/x/oauth2 - golang.org/x/oauth2/jws: Unexpected memory consumption during token parsing in golang.org/x/oauth2/jws
+CVE-2025-22868
+# golang.org/x/crypto - golang.org/x/crypto/ssh: Denial of Service in the Key Exchange of golang.org/x/crypto/ssh
+CVE-2025-22869
+# github.com/golang-jwt/jwt/v4 - golang-jwt/jwt: jwt-go allows excessive memory allocation during header parsing
+CVE-2025-30204


### PR DESCRIPTION
- [ ] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
In #650 we get false-positives, confirmed using govulncheck:
```
$ git clone https://github.com/grafana/grafana --depth=1 --branch=v9.5.x
$ cd grafana
$ govulncheck
No vulnerabilities found.
```

In this PR they are added to .trivyignore.


### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
![20220709_IUI_Red-Sea_Coral-Reef_IMG_2982_16bit-final-scaled](https://github.com/user-attachments/assets/7e9194a4-3cbb-41ec-b303-a37adbff7e93)
