### PR TITLE
chore(ruby): promote to stable

### DIFF
--- a/oci/ruby/image.yaml
+++ b/oci/ruby/image.yaml
@@ -1,12 +1,13 @@
 version: 1
 upload:
   - source: canonical/ruby-rock
-    commit: d1a053e45476f7a16fac220f8faaaa72044b7f70
+    commit: 79ca0043dc3715051b130d32d7a26b19e6092a88
     directory: ruby/3.3-25.04
     release:
       3.3-25.04:
         end-of-life: '2026-01-15T00:00:00Z'
         risks:
+          - stable
           - candidate
           - beta
           - edge


### PR DESCRIPTION
Promote Ruby to `stable`.