### PR TITLE
chore: add JRE 25 chiselled rock

### DIFF
--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -2,6 +2,17 @@ version: 1
 
 upload:
   - source: canonical/jre-rock
+    commit: c6932150d71be1b2cf383656bb1b3e746f7edac3
+    directory: jre/ubuntu-24.04-headless
+    release:
+      25-24.04:
+        end-of-life: "2032-01-30T00:00:00Z"
+        risks:
+          - stable
+          - candidate
+          - beta
+          - edge
+  - source: canonical/jre-rock
     commit: 780f339ce89bc764d439acfb3b71d3f57bdfe14b
     directory: jre/ubuntu-24.04-headless
     release:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

This PR adds 25-24.04 rock that will provide OpenJDK 25 Noble-based chiselled JRE image

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
