### PR TITLE
chore: Add CVE-2025-22869 to trivyignore for blackbox-exporter

### DIFF
--- a/oci/blackbox-exporter/.trivyignore
+++ b/oci/blackbox-exporter/.trivyignore
@@ -1,0 +1,4 @@
+# Upstream CVEs
+
+# golang.org/x/crypto - tested with govulncheck - not affected
+CVE-2025-22869


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
Add a .trivyignore to blackbox-exporter image, containing [CVE-2025-22869](https://github.com/advisories/GHSA-hcg3-q754-cr77). We tested the codebase using govulncheck to verify the vulnerability is not present in its codebase.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
https://github.com/canonical/blackbox-exporter-rock/issues/4

---

*Picture of a cool rock:*
<img width="1281" height="961" alt="image" src="https://github.com/user-attachments/assets/46288830-7045-4055-9348-fcf2e755c7d8" />
