### PR TITLE
feat(ci): enable self-hosted ppc64el runners

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -38,7 +38,8 @@ on:
         default: '{
           "amd64": ["self-hosted", "linux", "X64", "large", "noble"],
           "arm64": ["self-hosted", "linux", "ARM64", "medium", "noble"],
-          "s390x": ["self-hosted", "linux", "s390x", "noble"]
+          "s390x": ["self-hosted", "linux", "s390x", "noble"],
+          "ppc64el": ["self-hosted", "linux", "ppc64le", "noble"]
           }'
       lpci-fallback:
         description: "Enable fallback to Launchpad build when runners for target arch are not available."


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR enables the `ppc64el` self-hosted GitHub Action runners.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

https://bugs.launchpad.net/ubuntu-docker-images/+bug/2130719

### Related workflow run

https://github.com/canonical/oci-factory/actions/runs/19107067545

---

*Picture of a cool rock:*
