### PR TITLE
chore: update Valkey to 7.2.11

### DIFF
--- a/oci/valkey/image.yaml
+++ b/oci/valkey/image.yaml
@@ -2,10 +2,10 @@ version: 1
 
 upload:
   - source: "canonical/charmed-valkey-rock"
-    commit: 2bf0144b094e61e0c1bd8d0ae797cdbcf36a0b33
+    commit: 916eff983d28129053093a560ff2e4a48e207ffc
     directory: .
     release:
-      7.2.10-24.04:
+      7.2.11-24.04:
         end-of-life: "2029-04-01T00:00:00Z"
         risks:
           - stable


### PR DESCRIPTION
- [X] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Update the Valkey image to the new release `7.2.11`.

### Related issues
Fixes vulnerability reported in https://github.com/canonical/charmed-valkey-rock/issues/14