### PR TITLE
fix(ci): Test-Rock: condition file non-empty

### DIFF
--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -297,7 +297,7 @@ jobs:
             trivyignore_path="${{ env.ROCK_REPO_DIR }}/${trivyignore_path}"
           fi
 
-          if [[ -z "${trivyignore_path}" ]]; then
+          if [[ ! -s "${trivyignore_path}" ]]; then
             trivyignore_path=.trivyignore
             echo "${{ inputs.ignored-vulnerabilities }}" | tr ' ' '\n' > "$trivyignore_path"
           fi


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR fixes the wrongly used condition option that asserts a file is non-empty.


### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

https://github.com/canonical/oci-factory/actions/runs/19894716878/job/57025236353#step:7:238

---

*Picture of a cool rock:*
