### PR TITLE
chore(rust): promote rust-1.75-24.04 to stable

### DIFF
--- a/oci/rust/image.yaml
+++ b/oci/rust/image.yaml
@@ -15,4 +15,7 @@ upload:
       1.75-24.04:
         end-of-life: "2029-05-31T00:00:00Z"
         risks:
+          - stable
+          - candidate
+          - beta
           - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description

following the long-time stability of rust-1.84, and due to the fast-track of the noble work, promote rust-1.75-24.04 to `stable`. rust-1.84 will be EOL soon, but should therefore also be promoted after the 25.04 slices are merged into `chisel_releases`

### Related issues

- https://github.com/canonical/oci-factory/pull/705
