### PR TITLE
feat: add lfs support to Build-Rock.yaml

### DIFF
--- a/.github/actions/checkout/action.yaml
+++ b/.github/actions/checkout/action.yaml
@@ -19,9 +19,13 @@ inputs:
     description: "Github token for pulling from private repositories"
     default: ''
     required: false
-  lfs: 
-    description: 'Whether to pull Git LFS files.'
+  lfs:
+    description: 'Whether to download Git LFS files.'
     default: 'false'
+    required: false
+  lfs-include:
+    description: "Value to provide to git lfs pull --include when downloading LFS files. If this is not provided then all LFS files are pulled"
+    default: ''
     required: false
 
 runs:
@@ -65,5 +69,9 @@ runs:
         # pull lfs files if required
         if ${{ inputs.lfs == 'true' }}
         then
-          git lfs pull
+          if ! [[ -z "${{ inputs.lfs-include }}" ]]; then
+            git lfs pull --include="${{ inputs.lfs-include }}"
+          else
+            git lfs pull
+          fi
         fi

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -33,6 +33,10 @@ on:
         description: "Whether to download Git LFS files from target repo."
         type: boolean
         default: false
+      lfs-include:
+        description: "Value to provide to git lfs pull --include when downloading LFS files. If this is not provided then all LFS files are pulled"
+        type: string
+        default: ''
 
       # Parameters for multi-arch builds
       # specifying the runners with size label to prevent from running on private/tiobe runners
@@ -95,6 +99,7 @@ jobs:
           submodules: "recursive"
           token: ${{ secrets.source-github-token }}
           lfs: ${{ inputs.lfs }}
+          lfs-include: ${{ inputs.lfs-include }}
 
       - name: Installing Python 
         uses: actions/setup-python@v5
@@ -139,6 +144,7 @@ jobs:
           submodules: "recursive"
           token: ${{ secrets.source-github-token }}
           lfs: ${{ inputs.lfs }}
+          lfs-include: ${{ inputs.lfs-include }}
 
       - name: Building Target
         id: rockcraft
@@ -189,7 +195,6 @@ jobs:
           ref: ${{ inputs.rock-repo-commit }}
           submodules: "recursive"
           token: ${{ secrets.source-github-token }}
-
 
       - name: Building Target
         # TODO: Replace this retry action with bash equivalent for better testing


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

@canonical/rocks 

---

## Description
This adds support for two new parameters:
* lfs: true or false. defaults to false
* lfs-pull-pattern: string pattern for which lfs files to pull. defaults to empty (signifying pull all)

these parameters are expected to be set in ci.yaml and flow through to the checkout for building the rock Build-Rock.yaml.

this has been tested in a private repo, but only for the single arch support variants. i excluded lcpi as i don't know if the builder supports extending the package set at run time - happy to add it if so

### Related issues
Fixes: #718 
Depends on: canonical/rocks-template-actions#14

---

![cool-rock](https://github.com/user-attachments/assets/8efdeaa6-68d7-4b25-960b-efdc1a993985)
