### PR TITLE
fix(lfs): install git-lfs if not present

### DIFF
--- a/.github/actions/checkout/action.yaml
+++ b/.github/actions/checkout/action.yaml
@@ -69,6 +69,9 @@ runs:
         # pull lfs files if required
         if ${{ inputs.lfs == 'true' }}
         then
+          if ! command -v git-lfs &> /dev/null; then
+            sudo apt-get update && sudo apt-get install git-lfs -y
+          fi
           if ! [[ -z "${{ inputs.lfs-include }}" ]]; then
             git lfs pull --include="${{ inputs.lfs-include }}"
           else


### PR DESCRIPTION
a build environment may or may not have git-lfs installed. this ensures the binary is present or installs it if necessary.

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

@canonical/rocks 

---

## Description
this installs git-lfs if its not already present. the original implementation showed in several cases that the tooling was already available, but this is not consistent across runs. 

### Related issues

- https://github.com/canonical/oci-factory/pull/725

---

cool-rock.png
