### PR TITLE
Add CODEOWNERS file to o11y rocks

### DIFF
--- a/oci/alertmanager/CODEOWNERS
+++ b/oci/alertmanager/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/blackbox-exporter/CODEOWNERS
+++ b/oci/blackbox-exporter/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/git-sync/CODEOWNERS
+++ b/oci/git-sync/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/grafana-agent/CODEOWNERS
+++ b/oci/grafana-agent/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/grafana/CODEOWNERS
+++ b/oci/grafana/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/karma/CODEOWNERS
+++ b/oci/karma/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/loki/CODEOWNERS
+++ b/oci/loki/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/mimir/CODEOWNERS
+++ b/oci/mimir/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/node-exporter/CODEOWNERS
+++ b/oci/node-exporter/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/opentelemetry-collector/CODEOWNERS
+++ b/oci/opentelemetry-collector/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/prometheus-pushgateway/CODEOWNERS
+++ b/oci/prometheus-pushgateway/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/prometheus/CODEOWNERS
+++ b/oci/prometheus/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/tempo/CODEOWNERS
+++ b/oci/tempo/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability

--- a/oci/xk6/CODEOWNERS
+++ b/oci/xk6/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/Observability


### PR DESCRIPTION
- [ ] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
This PR adds CODEOWNERS files to observability rocks.
This is helpful to avoid creating our own branches with new PRs for fixing rock builds. The most common scenario is adding a line to trivyignore.

### Related issues
Here are some examples to PRs I had to create because I couldn't push into existing PRs:
- #768
- #767
- #765