### PR TITLE
chore: update dive image tag

### DIFF
--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -67,7 +67,7 @@ env:
   SKOPEO_IMAGE: "quay.io/skopeo/stable:v1.20.0"
   UMOCI_VERSION: "v0.4.7"
   UMOCI_BINARY: "umoci.amd64"
-  DIVE_IMAGE: "wagoodman/dive:v0.12"
+  DIVE_IMAGE: "wagoodman/dive:v0.13.1"
   TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
   TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
 


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
The `dive` image is outdated and causing issues on efficiency tests: https://github.com/canonical/python-rock/actions/runs/21952739189/job/63497819015?pr=39

Passing run: https://github.com/alesancor1/template-test/actions/runs/21980298055?pr=1
