### PR TITLE
fix: parse 25.10 bases with two decimal

### DIFF
--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -41,7 +41,7 @@ def get_base_and_track(rockcraft_yaml) -> tuple[str, str]:
 
     version = rockcraft_yaml["version"]
 
-    return base_release, f"{version}-{base_release}"
+    return f"{base_release:.2f}", f"{version}-{base_release:.2f}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Found a bug while trying to upload python 3.13 for `25.10` See workflow run [here](https://github.com/canonical/oci-factory/actions/runs/21998379658/job/63566141007?pr=775) -- The `25.10` base is being parsed as `25.1` due to float conversion.

Modified the return function to output a `tuple[str,str]` (according to the type hint) with two decimal places.

---
