### PR TITLE
chore: return legacy 3.9.1-22.04 tag

### DIFF
--- a/oci/kafka/image.yaml
+++ b/oci/kafka/image.yaml
@@ -17,3 +17,8 @@ upload:
         end-of-life: "2027-06-01T00:00:00Z"
         risks:
           - edge
+      # Legacy tag, as it was released once before.
+      3.9.1-22.04:
+        end-of-life: "2027-06-01T00:00:00Z"
+        risks:
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Since we can not remove tags from docker hub, this PR returns the old `3.9.1` tag from before, which got removed previously due to the policy not to include patch versions in the tags.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

https://github.com/canonical/kafka-rock/issues/12
