### PR TITLE
feat(ci): auto close issue for out release vuln findings

### DIFF
--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -290,7 +290,7 @@ jobs:
               --body-file "${{ steps.create-markdown.outputs.issue-body-file }}"
           fi
 
-      - name: Close issue
+      - name: Close issue with resolved vulnerabilities
         if: |
           needs.test-vulnerabilities.result == 'success' && 
           steps.issue-exists.outputs.issue-exists == 'true' && 
@@ -298,3 +298,16 @@ jobs:
           inputs.create-issue
         run: |
           gh issue close ${{ steps.issue-exists.outputs.issue-number }} --repo ${{ steps.get-image-repo.outputs.img-repo }}
+
+      - name: Close issues for images out of release
+        if: |
+          github.repository == 'canonical/oci-factory'
+        run: |
+          issues_json=$(gh issue list --repo ${{ steps.get-image-repo.outputs.img-repo }} --json "number,title")
+          issues_to_close=$(python3 -m src.notifications.find_out_release_issues \
+            "${{ inputs.oci-image-path }}/_releases.json" \
+            "$issues_json" \
+          )
+          for issue_number in $issues_to_close; do
+            gh issue close $issue_number --repo ${{ steps.get-image-repo.outputs.img-repo }}
+          done

--- a/src/notifications/find_out_release_issues.py
+++ b/src/notifications/find_out_release_issues.py
@@ -1,0 +1,61 @@
+import argparse
+import json
+import sys
+
+from ..shared.release_info import get_revision_to_released_tags
+
+
+def get_issues_not_in_released_tracks(
+    revision_to_released_tags: dict, issue_list: list
+) -> list:
+    """
+    Compares the list of released tracks with the issue titles and returns a list of issue numbers that do not contain any of the released tracks in their title.
+    """
+    released_tracks = set()
+    for revision, tags in revision_to_released_tags.items():
+        for tag in tags:
+            track = tag.split("_")[0]
+            released_tracks.add(f"{track}_{revision}")
+
+    issues_not_in_released_tracks = []
+    for issue in issue_list:
+        issue_number = issue["number"]
+        issue_title = issue["title"]
+        if not any(track in issue_title for track in released_tracks):
+            issues_not_in_released_tracks.append(issue_number)
+
+    return issues_not_in_released_tracks
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "releases_json",
+        help="Path to the _releases.json file",
+    )
+    parser.add_argument(
+        "issue_list_json",
+        help="JSON string of the issue list obtained from 'gh issue list --json number,title'",
+    )
+
+    args = parser.parse_args()
+
+    with open(args.releases_json, "r") as f:
+        all_releases = json.load(f)
+
+    if not args.issue_list_json:
+        return
+
+    issue_list = json.loads(args.issue_list_json)
+
+    revision_to_released_tags = get_revision_to_released_tags(all_releases)
+
+    issues_not_in_released_tracks = get_issues_not_in_released_tracks(
+        revision_to_released_tags, issue_list
+    )
+    for issue_number in issues_not_in_released_tracks:
+        print(issue_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_find_out_release_issues.py
+++ b/tests/unit/test_find_out_release_issues.py
@@ -1,0 +1,51 @@
+import pytest
+
+from src.notifications.find_out_release_issues import \
+    get_issues_not_in_released_tracks
+
+
+@pytest.mark.parametrize(
+    "revision_to_released_tags, issue_list, issues_to_close",
+    [
+        (
+            {
+                143: ["3-24.04_edge", "3.5-24.04_edge", "3.5.8-24.04_edge"],
+            },
+            [
+                {
+                    "number": 1,
+                    "title": "Vulnerabilities found for mock-rock:3.5.8-24.04_143",
+                },
+                {
+                    "number": 2,
+                    "title": "Vulnerabilities found for mock-rock:2.1-24.04_159",
+                },
+            ],
+            [2],
+        ),
+        (
+            {
+                143: ["3-24.04_edge", "3.5-24.04_edge", "3.5.8-24.04_edge"],
+                159: ["2.1-24.04_edge"],
+            },
+            [
+                {
+                    "number": 1,
+                    "title": "Vulnerabilities found for mock-rock:3.5.8-24.04_143",
+                },
+                {
+                    "number": 2,
+                    "title": "Vulnerabilities found for mock-rock:2.1-24.04_159",
+                },
+            ],
+            [],
+        ),
+    ],
+)
+def test_get_issues_not_in_released_tracks(
+    revision_to_released_tags, issue_list, issues_to_close
+):
+    issues_not_in_released_tracks = get_issues_not_in_released_tracks(
+        revision_to_released_tags, issue_list
+    )
+    assert issues_not_in_released_tracks == issues_to_close


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR introduces the automation mechanism to close the issues raised in the rock repos that are no longer associated with in-release revisions.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
