### PR TITLE
fix: GHSA-72hv-8253-57qq in Kafka

### DIFF
--- a/oci/kafka/image.yaml
+++ b/oci/kafka/image.yaml
@@ -1,8 +1,8 @@
 version: 1
-    
-upload:  
+
+upload:
   - source: "canonical/kafka-rock"
-    commit: aad63c2e9209a31818daead25bd68de9a0673a0e
+    commit: 95fd725d5b21f7ccd1366431d49d34ad545e8df7
     directory: .
     release:
       4.1-24.04:
@@ -10,7 +10,7 @@ upload:
         risks:
           - edge
   - source: "canonical/kafka-rock"
-    commit: a4c7dd466d6f25a66de1f9ed192ec3239ba07f76
+    commit: ff319e1f8f967a47f9bef8de873b27a9609994a2
     directory: .
     release:
       3.9-22.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

Fixes GHSA-72hv-8253-57qq security issue in Apache Kafka 3 & 4.

### Related issues
https://github.com/canonical/kafka-rock/issues/13
https://github.com/canonical/kafka-rock/issues/14
