### PR TITLE
fix: trivyignore CVE-2025-68973 in litmuschaos-authserver

### DIFF
--- a/oci/litmuschaos-authserver/.trivyignore
+++ b/oci/litmuschaos-authserver/.trivyignore
@@ -4,7 +4,10 @@
 # Not in use as shown by govulncheck 
 CVE-2025-22869
 # Improper Validation of Syntactic Correctness of Input in golang.org/x/oauth2
-# Not in use as show by govulncheck
+# Not in use as shown by govulncheck
 CVE-2025-22868
 # stdlib: Incorrect results returned from Rows.Scan in database/sql - not affected
 CVE-2025-47907
+# gpgv: out-of-bounds write
+# Not in use as shown by govulncheck
+CVE-2025-68973


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Add trivyignore config to resolve https://github.com/canonical/litmuschaos-authserver-rock/issues/42

*Picture of a cool rock:*
<img width="364" height="408" alt="image" src="https://github.com/user-attachments/assets/4bec14e0-dc27-44d7-8dd0-524f9cc3d0c3" />

