### PR TITLE
feat: update nginx-prometheus-exporter .trivyignore

### DIFF
--- a/oci/nginx-prometheus-exporter/.trivyignore
+++ b/oci/nginx-prometheus-exporter/.trivyignore
@@ -3,3 +3,5 @@
 # Potential denial of service in golang.org/x/crypto
 # only applies to ssh module, which is not in use as shown by govulncheck 
 CVE-2025-22869
+# Vulnerabilities not affeccting the rock, as confirmed by `govulncheck`
+CVE-2025-68973


### PR DESCRIPTION
Added CVE-2025-68973 to .trivyignore for confirmed non-impact.

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Adding a vulnerability ignore, as `govulncheck` shows none of the vulnerable code paths are used by the project.

---

*Picture of a cool rock:* 🪨
