### PR TITLE
fix: CVE-2026-1605 in Kafka 4

### DIFF
--- a/oci/kafka/image.yaml
+++ b/oci/kafka/image.yaml
@@ -2,7 +2,7 @@ version: 1
 
 upload:
   - source: "canonical/kafka-rock"
-    commit: 95fd725d5b21f7ccd1366431d49d34ad545e8df7
+    commit: 8efeeb4639be3d4e812e63185fd41a4d7f65f999
     directory: .
     release:
       4.1-24.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Fixes  CVE-2026-1605 in Kafka 4

### Related issues

https://github.com/canonical/kafka-rock/issues/17