### PR TITLE
chore: update rust 1.75-24.04 commit

### DIFF
--- a/oci/rust/image.yaml
+++ b/oci/rust/image.yaml
@@ -9,7 +9,7 @@ upload:
         risks:
           - edge
   - source: canonical/rust-rock
-    commit: 0c5ef23806cb4a9c0dce9a6f066a989914a06fc8
+    commit: 81552f9d7113cd20e972a0c1d860b13113a918d8
     directory: rust/1.75-24.04
     release:
       1.75-24.04:
@@ -18,11 +18,4 @@ upload:
           - stable
           - candidate
           - beta
-  - source: canonical/rust-rock
-    commit: 81552f9d7113cd20e972a0c1d860b13113a918d8
-    directory: rust/1.75-24.04
-    release:
-      1.75-24.04:
-        end-of-life: "2029-05-31T00:00:00Z"
-        risks:
           - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description

update commit sha of rust 1.75-24.04 following https://github.com/canonical/rust-rock/pull/12. rust 1.84-25.04 is EOL so no update needed.

not 100% sure this is the correct way of updating the image for just one channel, but i'm sure i'll be told off if it's not ;)


**NOTE**

```diff
-    commit: 98516fe632e3b6db13f42ad9482f7e35028b7397
+    commit: 0c5ef23806cb4a9c0dce9a6f066a989914a06fc8
```

i've had to patch the tests on the current release. the diff is trivial: https://github.com/canonical/rust-rock/compare/98516fe632e3b6db13f42ad9482f7e35028b7397...0c5ef23806cb4a9c0dce9a6f066a989914a06fc8

### Related issues

- https://github.com/canonical/rust-rock/pull/12

---

*Picture of a cool rock:*

<img width="889" height="757" alt="2026-03-11_16-15-04" src="https://upload.wikimedia.org/wikipedia/commons/7/76/Ironstone_Breathitt.jpg" />

[https://en.wikipedia.org/wiki/Ironstone#/media/File:Ironstone_Breathitt.jpg](https://en.wikipedia.org/wiki/Ironstone#/media/File:Ironstone_Breathitt.jpg)

Ironstone (sandstone with iron oxides) from the Mississippian Breathitt Formation, Mile Marker 166, I-64, Kentucky. [Public Domain](https://commons.wikimedia.org/wiki/File:Ironstone_Breathitt.jpg?uselang=en#Licensing) image taken by [Jstuby](https://en.wikipedia.org/wiki/User:Jstuby)



