### PR TITLE
feat: update litmuschaos-server .trivyignore with new CVEs

### DIFF
--- a/oci/litmuschaos-server/.trivyignore
+++ b/oci/litmuschaos-server/.trivyignore
@@ -25,3 +25,8 @@ CVE-2026-23960
 
 # stdlib for Go < 1.25.7 - During session resumption in crypto/tls, if the...
 CVE-2025-68121
+
+## Upstream won't fix these
+# github.com/argoproj/argo-workflows/v3
+CVE-2026-28229
+CVE-2026-31892


### PR DESCRIPTION
Closes https://github.com/canonical/litmuschaos-server-rock/issues/32

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Add new CVEs to `.trivyignore`.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*  🪨 
