### PR TITLE
chore(ci): change labels to avoid fips runners

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -48,10 +48,10 @@ on:
         description: "JSON string mapping target architecture to runners."
         type: string
         default: '{
-          "amd64": ["self-hosted", "linux", "X64", "large", "noble"],
-          "arm64": ["self-hosted", "linux", "ARM64", "medium", "noble"],
-          "s390x": ["self-hosted", "linux", "s390x", "noble"],
-          "ppc64el": ["self-hosted", "linux", "ppc64le", "noble"]
+          "amd64": ["self-hosted-linux-amd64-noble-large"],
+          "arm64": ["self-hosted-linux-arm64-noble-medium"],
+          "s390x": ["self-hosted-linux-s390x-noble-medium"],
+          "ppc64el": ["self-hosted-linux-ppc64el-noble-edge"]
           }'
       lpci-fallback:
         description: "Enable fallback to Launchpad build when runners for target arch are not available."

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -56,7 +56,7 @@ upload:
       - "CVE-2023-1234"
       - "CVE-2023-5678"
   - source: "canonical/rocks-toolbox"
-    commit: eee5f5ebeff62848903156fb3fe93c5d37174085
+    commit: bb9138fbe81f893b4303a0e29df7cf9581069de0
     directory: mock_rock/devel
     release:
       devel:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR changes the way we specify labels for the self-hosted runners to avoid picking up runners having the `fips` label, which are unable to pack rock normally due to the `resolved` service errors.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

N/A
---

*Picture of a cool rock:*

