### PR TITLE
chore: always allow rocks team trigger workflow

### DIFF
--- a/.github/actions/validate-actor/test-validate-actor.bats
+++ b/.github/actions/validate-actor/test-validate-actor.bats
@@ -44,3 +44,8 @@ setup() {
   output=$(${BATS_TEST_DIRNAME}/validate-actor.sh "ROCKsBot" "true" $workdir "img")
   [[ $(echo "${output}" | tail -n 1) =~ "The workflow is triggered by ROCKsBot as the code owner" ]]
 }
+
+@test "always allow rocks team members" {
+  output=$(${BATS_TEST_DIRNAME}/validate-actor.sh "ROCKsBot" "true" $workdir "img")
+  [[ $(echo "${output}" | tail -n 1) =~ "The workflow is triggered by ROCKsBot as the code owner" ]]
+}

--- a/.github/actions/validate-actor/validate-actor.sh
+++ b/.github/actions/validate-actor/validate-actor.sh
@@ -7,6 +7,8 @@ admin_only=$2
 workspace=$3
 image_path=$4
 
+ROCKS_TEAM="@canonical/rocks"
+
 log_debug "github.actor: ${actor}"
 actor=$(echo "$actor" | sed 's/\[/\\[/g;s/\]/\\]/g') # Escape square brackets for actors like renovate[bot]
 log_debug "admin-only: ${admin_only}"
@@ -15,6 +17,7 @@ if [[ ${admin_only} == true ]]; then
     log_debug "Expanding team mentions in the CODEOWNERS file"
     codeowners_file=$(mktemp)
     cp ${workspace}/CODEOWNERS ${codeowners_file}
+    echo -e "\n*\t@${ROCKS_TEAM}" >> ${codeowners_file}
     teams=$(grep -oE '@[[:alnum:]_.-]+\/[[:alnum:]_.-]+' ${codeowners_file} || true | sort | uniq)
 
     for team in ${teams}; do

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @zhijie-yang @alesancor1 @ROCKsBot
+*       @zhijie-yang @alesancor1


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR allows the team member of @canoincal/rocks to trigger workflows for all the images inside this repo, but without actually adding the whole team to the `CODEWONERS` file.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

N/A
---

*Picture of a cool rock:*
