### PR TITLE
fix: update .trivyignore for grafana 12.4.2

### DIFF
--- a/oci/grafana/.trivyignore
+++ b/oci/grafana/.trivyignore
@@ -62,3 +62,5 @@ CVE-2026-34986
 CVE-2026-34040
 # go.opentelemetry.io/otel/sdk - opentelemetry-go: Path Hijacking via untrusted search path on macOS/Darwin
 CVE-2026-24051
+# go.opentelemetry.io/otel - opentelemetry-go: PATH hijacking via bare kenv command on BSD/Solaris platforms
+CVE-2026-39883


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->
After PR #867 went through, a new vulnerability was reported upstream for Opentelemetry GO: CVE-2026-39883, [failing CI](https://github.com/canonical/oci-factory/actions/runs/24180205948) on merge to main. My checks with `govulncheck` revealed that this CVE is not on the call paths of this rock. Hence, I'm adding it to the ignore file.
### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
<img width="500" height="666" alt="image" src="https://github.com/user-attachments/assets/50579e64-15fc-435f-8054-8de5d640919e" />
