### PR TITLE
fix(istio-pilot): ignore BSD-only vuln

### DIFF
--- a/oci/istio-pilot/.trivyignore
+++ b/oci/istio-pilot/.trivyignore
@@ -12,6 +12,12 @@ CVE-2026-33186
 # The rock runs exclusively on Linux, so this CVE is not applicable.
 CVE-2026-24051
 
+# go.opentelemetry.io/otel/sdk - PATH hijacking of the "kenv" command in
+# sdk/resource/host_id_bsd.go. This is exploitable only on BSD/Solaris platforms.
+# The rock runs exclusively on Linux, so this CVE is not applicable.
+# Fixed in otel/sdk v1.43.0. Remove once Istio bumps to >= v1.43.0.
+CVE-2026-39883
+
 # github.com/docker/cli - Local Privilege Escalation via uncontrolled search path in
 # Docker CLI plugin directory (C:\ProgramData\Docker\cli-plugins). This vulnerability
 # is Windows-only. The rock runs exclusively on Linux, so this CVE is not applicable.


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
Apparently a new vuln showed up between the PR and the merge time window of the `istio-pilot` rock. https://github.com/canonical/oci-factory/actions/runs/24180973049

It is nonetheless a BSD only vulnerability that doesnt affect the linux kernel. Hence its added to the ignore.

---

*Picture of a cool rock:*
<img width="777" height="518" alt="image" src="https://github.com/user-attachments/assets/bd8e5f07-2d39-42cc-ad78-4c1f9d68fcc1" />

