### PR TITLE
chore(ci/deps): bump actions to node.js 24

### DIFF
--- a/.github/actions/crypt-artifact/action.yaml
+++ b/.github/actions/crypt-artifact/action.yaml
@@ -24,7 +24,7 @@ runs:
   steps:
 
     - name: Cloning OCI Factory
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         repository: canonical/oci-factory
         path: oci-factory

--- a/.github/actions/fetch-releases-json/action.yaml
+++ b/.github/actions/fetch-releases-json/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Fetch _releases.json
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         repository: canonical/oci-factory
         path: ${{ inputs.directory }}

--- a/.github/actions/upload-rock/action.yml
+++ b/.github/actions/upload-rock/action.yml
@@ -38,7 +38,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Rock
-      uses: actions/download-artifact@484a0b528fb4d7bd804637ccb632e47a0e638317
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
       with:
         name: ${{ inputs.artifact_name }}
         run-id: ${{ inputs.run-id }}

--- a/.github/workflows/Announcements.yaml
+++ b/.github/workflows/Announcements.yaml
@@ -18,7 +18,7 @@ jobs:
       mattermost-channels: ${{ steps.get-contacts.outputs.mattermost-channels }}
       oci-img-name: ${{ steps.get-image-name.outputs.img-name }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Get image name
         id: get-image-name
@@ -55,7 +55,7 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Build release summary
         id: get-summary
@@ -65,7 +65,7 @@ jobs:
 
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -93,7 +93,7 @@ jobs:
     needs: [get-contacts]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Build package summary
         id: get-summary
@@ -104,7 +104,7 @@ jobs:
 
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           # Here we clone the oci-factory repo using the default ref of the checkout action.
           # It will be set to a ref that triggered this workflow if the workflow is run within the oci-factory repo,
@@ -128,7 +128,7 @@ jobs:
           lfs-include: ${{ inputs.lfs-include }}
 
       - name: Installing Python 
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -156,7 +156,7 @@ jobs:
     steps:
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
@@ -215,7 +215,7 @@ jobs:
           preserve-original: false
 
       - name: Uploading Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ inputs.oci-archive-name }}-${{ steps.collect-artifacts.outputs.filename }}
           path: ${{ env.ROCK_CI_FOLDER }}
@@ -236,7 +236,7 @@ jobs:
     steps:
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
@@ -252,7 +252,7 @@ jobs:
 
       - name: Building Target
         # TODO: Replace this retry action with bash equivalent for better testing
-        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
         id: lpci-build
         with:
           timeout_minutes: 180
@@ -266,7 +266,7 @@ jobs:
 
       - name: Upload Build Logs
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: lpci-build-logs-${{ matrix.architecture }}
           path: ${{ steps.lpci-build.outputs.build-log }}
@@ -278,7 +278,7 @@ jobs:
           echo "filename=${{ matrix.rock-name }}_${{ matrix.architecture }}" >> $GITHUB_OUTPUT
 
       - name: Uploading Artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ inputs.oci-archive-name }}-${{ steps.collect-artifacts.outputs.filename }}
           path: ${{ env.ROCK_CI_FOLDER }}
@@ -295,14 +295,14 @@ jobs:
     steps:
       # Job Setup
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
 
       - run: src/build_rock/assemble_rock/requirements.sh
       - name: Downloading Single Arch rocks
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         id: download
         with:
           path: ${{ env.ROCK_CI_FOLDER }}
@@ -349,7 +349,7 @@ jobs:
           preserve-original: false
 
       - name: Uploading Multi Arch rock
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ inputs.oci-archive-name }}
           path: ${{ steps.final-artifact.outputs.name }}

--- a/.github/workflows/CLA-Check.yaml
+++ b/.github/workflows/CLA-Check.yaml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
         with:
           message: |
             @${{ github.actor }} please make sure all PR contributors have signed the CLA.

--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -12,8 +12,8 @@ jobs:
       released-revisions-matrix: ${{ steps.prepare-test-matrix.outputs.released-revisions-matrix }}
       last-scan: ${{ steps.last-scan.outputs.date }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
       - run: pip install -r src/tests/requirements.txt

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -51,7 +51,7 @@ jobs:
           github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
       - name: Infer images to document
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         id: changed-files
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         with:
@@ -95,10 +95,10 @@ jobs:
     env:
       IS_PROD: ${{ ! startsWith(needs.validate-documentation-request.outputs.oci-img-name, 'mock-') }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # This is needed to ensure that this workflow can run when called by workflows in external repositories
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           path: oci-factory
@@ -108,7 +108,7 @@ jobs:
         with:
           image-name: ${{ needs.validate-documentation-request.outputs.oci-img-name }}
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -151,7 +151,7 @@ jobs:
             ${DRY_RUN_FLAG}
 
       - name: Upload documentation data YAML
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: '${{ needs.validate-documentation-request.outputs.oci-img-name }}-doc-data'
           path: "${{ steps.generate-documentation.outputs.image_doc_folder }}/*.y*ml"
@@ -191,9 +191,9 @@ jobs:
     needs: [validate-documentation-request, do-documentation]
     if: ${{ !cancelled() && contains(needs.*.result, 'failure') && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.x'
 

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -59,10 +59,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Infer number of image triggers
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         id: changed-files
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call'
         with:
@@ -112,7 +112,7 @@ jobs:
         if: ${{ inputs.b64-image-trigger != '' }}
         run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ steps.validate-image.outputs.img-path }}/image.yaml
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -140,7 +140,7 @@ jobs:
     steps:
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
 
@@ -212,13 +212,13 @@ jobs:
       build-matrix: ${{ steps.prepare-matrix.outputs.build-matrix }}
       revision-data-cache-key: ${{ steps.prepare-matrix.outputs.revision-data-cache-key }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Use custom image trigger
         if: ${{ inputs.b64-image-trigger != '' }}
         run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -271,7 +271,7 @@ jobs:
           ./src/uploads/swift_lockfile_unlock.sh \
             ${{ needs.prepare-build.outputs.oci-img-name }}
 
-      - uses: actions/cache/save@36f1e144e1c8edb0a652766b484448563d8baf46
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ steps.prepare-matrix.outputs.revision-data-dir }}
           key: ${{ steps.prepare-matrix.outputs.revision-data-cache-key }}
@@ -290,9 +290,9 @@ jobs:
     outputs:
       artefacts-hashes: ${{ steps.artefacts-hashes.outputs.hashes }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
 
@@ -309,7 +309,7 @@ jobs:
           ./src/uploads/requirements.sh
           pip install -r src/uploads/requirements.txt -r src/image/requirements.txt
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ env.OCI_ARCHIVE_NAME }}
 
@@ -324,13 +324,13 @@ jobs:
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "canonical-tag=${canonical_tag}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/cache/save@36f1e144e1c8edb0a652766b484448563d8baf46
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ steps.rename-oci-archive.outputs.name }}
           key: ${{ github.run_id }}-${{ steps.rename-oci-archive.outputs.name }}
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@57aae528053a48a3f6235f2d9461b05fbcb7366d
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
         with:
           syft-version: "v0.75.0"
 
@@ -350,7 +350,7 @@ jobs:
           log_info "Detected architectures: ${arches}"
           echo "arches='${arches}'" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: '1.24'
     
@@ -407,7 +407,7 @@ jobs:
 
           echo "sboms=${all_sboms_zip}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ env.OCI_ARCHIVE_NAME }}${{ env.VULNERABILITY_REPORT_SUFFIX }}
 
@@ -426,21 +426,21 @@ jobs:
           echo "hashes=$(sha256sum ${{ env.VULN_REPORT }} ${{ env.OCI_IMAGE_ARCHIVE }} ${{ env.SBOMS }} | base64 -w0)"
 
       - name: Login to GHCR
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SBOM
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ steps.generate-sboms.outputs.sboms }}
           path: ${{ steps.generate-sboms.outputs.sboms }}
           if-no-files-found: error
 
       - name: Upload image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ steps.rename-oci-archive.outputs.name }}
           path: ${{ steps.rename-oci-archive.outputs.name }}
@@ -502,11 +502,11 @@ jobs:
     env:
       REVISION_DATA_DIR: revision-data
     steps:
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -514,7 +514,7 @@ jobs:
         if: ${{ inputs.b64-image-trigger != '' }}
         run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
 
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.REVISION_DATA_DIR }}
           key: ${{ needs.prepare-upload.outputs.revision-data-cache-key }}
@@ -550,7 +550,7 @@ jobs:
               --revision-data-file "${{ env.REVISION_DATA_DIR }}/${revision_file}"
           done
 
-      - uses: actions/cache/save@36f1e144e1c8edb0a652766b484448563d8baf46
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
           key: ${{ github.run_id }}-image-trigger
@@ -569,7 +569,7 @@ jobs:
     needs: [upload]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         id: download
         with:
           path: artifacts
@@ -596,7 +596,7 @@ jobs:
       #     cosign sign-blob --key cosign.key --output-signature provenance.json.sig provenance.json
 
       # - name: Upload verification keys
-      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
       #   with:
       #     name: verify
       #     path: |
@@ -609,14 +609,14 @@ jobs:
       #   run: sha256sum * > SHA256SUMS || true
 
       # - name: Upload SHA256SUMS file
-      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
       #   with:
       #     name: SHA256SUMS
       #     path: SHA256SUMS
       #     if-no-files-found: error
 
       - name: Upload provenance file
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: provenance
           path: provenance.json
@@ -640,9 +640,9 @@ jobs:
       [prepare-build, validate-matrix, build-rock, test-rock, prepare-upload, upload, prepare-releases, release, generate-provenance]
     if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
   

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -12,11 +12,11 @@ jobs:
       changed-files-matrix: ${{ steps.changed-files-matrix.outputs.matrix }}
       image-name: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           json: true
           files: |
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get image name
         id: changed-files-dir-names
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           dir_names: "true"
           files: |
@@ -56,16 +56,16 @@ jobs:
     # temporarily continue on error, until the Notification and Doc update jobs are set
     continue-on-error: true
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Check if documentation.yaml exists
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
         with:
           files: "${{ needs.get-submitted-files.outputs.image-name }}/documentation.yaml"
           fail: true
 
       - name: Check if contacts.yaml exists
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
         with:
           files: "${{ needs.get-submitted-files.outputs.image-name }}/contacts.yaml"
           fail: true
@@ -78,9 +78,9 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.get-submitted-files.outputs.changed-files-matrix) }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: Comment PR if repo does not exist
         if: ${{ steps.validate-registry-has-repo.outputs.docker-repo-exists == 'false' }}
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
         with:
           message: |
             The Docker repository for this image does not exist yet. Merging of this repo is blocked.
@@ -147,10 +147,10 @@ jobs:
     permissions: 
       pull-requests: write 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
         with:
           message: |
             One or more files in this PR are not valid! :grimacing:

--- a/.github/workflows/Rebuild-Images.yaml
+++ b/.github/workflows/Rebuild-Images.yaml
@@ -15,9 +15,9 @@ jobs:
         name: Rebuild images
         steps:
         - name: Checkout
-          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
     
-        - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
           with:
             python-version: "3.x"
   

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: ${{ inputs.external_ref_id }}  # (2)
         run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
         
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -48,7 +48,7 @@ jobs:
           github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
       - name: Infer number of image triggers
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         id: changed-files
         with:
           dir_names: "true"
@@ -84,7 +84,7 @@ jobs:
       RELEASES_BRANCH: _releases
       RELEASE_REPO_DIR: oci-factory-releases
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Fetch _releases.json
         uses: ./.github/actions/fetch-releases-json
@@ -93,14 +93,14 @@ jobs:
           releases-branch: ${{ env.RELEASES_BRANCH }}
           directory: ${{ env.RELEASE_REPO_DIR }}
 
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         if: ${{ inputs.image-trigger-cache-key != '' }}
         with:
           path: oci/${{ inputs.oci-image-name }}/image.yaml
           key: ${{ inputs.image-trigger-cache-key }}
           fail-on-cache-miss: true
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -206,12 +206,12 @@ jobs:
       fail-fast: true
       matrix: ${{ fromJSON(needs.do-releases.outputs.gh-releases-matrix) }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           ref: ${{ matrix.canonical-tag }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: '*.sbom_preview.spdx.zip'
           path: sbom

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -224,14 +224,13 @@ jobs:
           sbom_target_dir="$(pwd)/sbom"
           find sbom -type f -name '*.spdx.zip' -exec unzip {} -d ${sbom_target_dir} \;
 
-      - uses: dev-drprasad/delete-tag-and-release@7550ea180f81ca0a875ee3c135b1f72ef66ff4b1
-        # We force delete an existing tag because otherwise we won't get
-        # an email notification and the GH release will have the date from when
-        # it was created the first time (i.e. force-push won't update the date)
+      # We force delete an existing tag because otherwise we won't get
+      # an email notification and the GH release will have the date from when
+      # it was created the first time (i.e. force-push won't update the date)
+      - run: gh release delete ${{ matrix.release-name }} --yes --cleanup-tag
         continue-on-error: true
-        with:
-          tag_name: ${{ matrix.release-name }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Create Git tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
@@ -242,7 +241,7 @@ jobs:
           commit_sha: ${{ matrix.canonical-tag }}
           force_push_tag: true
 
-      - uses: "softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844"
+      - uses: "softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
         with:
           name: "${{ matrix.release-name }}"
           tag_name: "${{ matrix.release-name }}"

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -333,6 +333,7 @@ jobs:
           echo "report-name=${{ inputs.oci-archive-name }}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
 
       - name: Scan for vulnerabilities
+        # TODO: bump trivy-action version once a newer version is released that uses v5 or later tags for actions/cache.
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
           # NOTE: we're allowing images with vulnerabilities to be published

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -87,7 +87,7 @@ jobs:
           echo "::warning:: 'host-github-token' is unused and deprecated. Please remove this secret from the caller workflow."
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           # Here we clone the oci-factory repo using the default ref of the checkout action.
           # It will be set to a ref that triggered this workflow if the workflow is run within the oci-factory repo,
@@ -98,7 +98,7 @@ jobs:
       # download and unpack the image under test, then store it under a common cache key. 
       # This unpacked image is used in test-oci-compliance, test-black-box and test-malware jobs
       - name: Download Rock
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ inputs.oci-archive-name }}
 
@@ -128,7 +128,7 @@ jobs:
           echo "key=${{ github.run_id }}-${{ inputs.oci-archive-name }}"  >> $GITHUB_OUTPUT
 
       - name: Cache Rock
-        uses: actions/cache/save@36f1e144e1c8edb0a652766b484448563d8baf46
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.TEST_IMAGE_NAME }}
           key: ${{ steps.set-cache.outputs.key }}
@@ -140,12 +140,12 @@ jobs:
     if: inputs.test-oci-compliance
     steps:
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
 
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.TEST_IMAGE_NAME }}
           key: ${{ needs.configure-tests.outputs.cache-key }}
@@ -173,7 +173,7 @@ jobs:
     needs: [configure-tests]
     if: inputs.test-black-box
     steps:
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.TEST_IMAGE_NAME }}
           key: ${{ needs.configure-tests.outputs.cache-key }}
@@ -209,12 +209,12 @@ jobs:
     steps:
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
 
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.TEST_IMAGE_NAME }}
           key: ${{ needs.configure-tests.outputs.cache-key }}
@@ -268,19 +268,19 @@ jobs:
           fi
 
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
       
       - name: Checkout Rock Repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: github.repository != 'canonical/oci-factory' && inputs.trivyignore-path != ''
         with:
           path: ${{ env.ROCK_REPO_DIR }}
 
       - name: Download Rock
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ inputs.oci-archive-name }}
       
@@ -348,7 +348,7 @@ jobs:
           output: "${{ steps.configure-trivy.outputs.report-name }}"
           image-ref: "${{ steps.configure-trivy.outputs.docker-image }}"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         if: ${{ !cancelled() }}
         with:
           name: ${{ inputs.vulnerability-report-artifact-name || steps.configure-trivy.outputs.report-name }}
@@ -399,12 +399,12 @@ jobs:
     if: inputs.test-malware
     steps:
       - name: Cloning OCI Factory
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
 
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
+      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.TEST_IMAGE_NAME }}
           key: ${{ needs.configure-tests.outputs.cache-key }}
@@ -425,7 +425,7 @@ jobs:
             --image ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
             --rootless raw
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
 

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -61,7 +61,7 @@ jobs:
             --src-username "${{ github.actor }}" \
             --src-password "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         if: ${{ !cancelled() }}
         with:
           name: ${{ steps.configure.outputs.oci-filename }}
@@ -92,7 +92,7 @@ jobs:
       notify: ${{ steps.check-report.outputs.notify }}
       vulnerabilities: ${{ steps.check-report.outputs.vulnerabilities }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -105,7 +105,7 @@ jobs:
           github-token: ${{ secrets.ROCKSBOT_TOKEN }}
 
       - name: Download Vulnerability Report
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: '${{ needs.configure-scan.outputs.vulnerability-report }}'
 
@@ -149,9 +149,9 @@ jobs:
     needs: [parse-results]
     if: ${{ !cancelled() && github.repository == 'canonical/oci-factory' && needs.parse-results.outputs.notify == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.x'
   
@@ -187,9 +187,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.x'
 

--- a/.github/workflows/_Auto-updates.yaml
+++ b/.github/workflows/_Auto-updates.yaml
@@ -14,10 +14,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Get updated filenames
-        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         id: changed-files
         with:
           json: true
@@ -37,9 +37,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 

--- a/.github/workflows/_CLI-Client.yaml
+++ b/.github/workflows/_CLI-Client.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Test
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Go 1.22
-        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: 1.22
       - name: Test
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Snap build
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79
         id: snapcraft
         with:
           path: tools/cli-client
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Validate access to mock-rock
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/validate-actor
         with:
           admin-only: true
@@ -42,11 +42,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Job Setup
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.x"
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload pytest Result
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ env.PYTEST_RESULT_PATH }}
           path: ${{ env.PYTEST_RESULT_PATH }}
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Job Setup
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

*Ping the @canonical/rocks team.*

---

## Description
<!--- Describe your changes in detail -->

This PR bumps the action versions to node.js 24 to suppress the warnings emitted by GH workflow enginge.

---
Following summary is generated by CoPilot

### Actions bumped to node24
Action | Old version (node20) | New version (node24) | Files affected
-- | -- | -- | --
actions/checkout | v4.3.1, v5.0.1, v4.x | v6.0.2 | 15 workflow files + 2 action files
actions/upload-artifact | v4.6.2 | v7.0.0 | 6 workflow files
actions/download-artifact | v4.x (2 SHAs) | v8.0.1 | 4 workflow files + 1 action file
actions/setup-python | v5.6.0 | v6.2.0 | 10 workflow files + 1 action file
actions/cache/restore | v4.3.0 | v5.0.4 | 3 workflow files
actions/cache/save | v4.x | v5.0.4 | 3 workflow files
actions/setup-go | v5.6.0, v5.x | v6.4.0 | 2 workflow files
docker/login-action | v3.x | v4.1.0 | 1 workflow file
nick-fields/retry | v3.0.0 | v4.0.0 | 1 workflow file
tj-actions/changed-files | v46.x | v47.0.5 | 4 workflow files
thollander/actions-comment-pull-request | v2.5.0 | v3.0.1 | 2 workflow files
andstor/file-existence-action | v2.0.0 | v3.1.0 | 1 workflow file
anchore/sbom-action/download-syft | v0.23.1 | v0.24.0 | 1 workflow file
softprops/action-gh-release | v0.1.15 | v3.0.0| 1 workflow file

### Actions with no node24 version available (cannot be bumped)
Action | Current version | Node version | Notes
-- | -- | -- | --
snapcore/action-build | v1.3.0 | node20 | Latest version, no node24 release
dev-drprasad/delete-tag-and-release | v1.0 | node16 | Repository archived, changed the impl to use `gh` instead
rickstaa/action-create-tag | v1.7.2 | docker | Uses Docker, not Node.js — no change needed
canonical/has-signed-canonical-cla | v2 | node 20 | Latest major tag, no node24 release
canonical/craft-actions/rockcraft-pack | main | node 20 | Latest, no node24 release
aquasecurity/trivy-action | v0.35.0 | node20* | *: Calls `actions/cache@0400d5f`, which uses node 20. No new version available, `TODO` left in code.

### Actions already using composite runners (no Node.js dependency)
* `abatilo/actions-poetry` — composite (shell)
* `aquasecurity/setup-trivy` — composite
* `philips-labs/slsa-provenance-action` — composite


### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
