### PR TITLE
chore: remove ping instruction for canonical/rocks team

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 - [ ] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
 - [ ] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines
 
-*Ping the @canonical/rocks team.*
-
 ---
 
 ## Description


### PR DESCRIPTION
The project now has 2 well-defined maintainers, there's no need to ping the whole team on every PR