### PR TITLE
fix(ci): use tracks from releases

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -115,20 +115,6 @@ jobs:
       - name: Setup environment
         run: pip install -r ./src/image/requirements.txt -r ./src/docs/requirements.txt
 
-      - name: Get all revisions per track
-        id: get-all-canonical-tags
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          OS_USERNAME: ${{ secrets.SWIFT_OS_USERNAME }}
-          OS_TENANT_NAME: ${{ secrets.SWIFT_OS_TENANT_NAME }}
-          OS_PASSWORD: ${{ secrets.SWIFT_OS_PASSWORD }}
-          OS_REGION_NAME: ${{ secrets.SWIFT_OS_REGION_NAME }}
-          OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL }}
-          IMAGE_NAME: "${{ needs.validate-documentation-request.outputs.oci-img-name }}"
-          SWIFT_CONTAINER_NAME: ${{ vars.SWIFT_CONTAINER_NAME }}
-        run: |
-          ./src/image/get_canonical_tags_from_swift.sh
-
       - name: Generate documentation for ${{ needs.validate-documentation-request.outputs.oci-img-name }}
         id: generate-documentation
         env:
@@ -142,7 +128,6 @@ jobs:
             set -x
           fi
           python3 -m src.docs.generate_oci_doc_yaml \
-            --all-revision-tags "${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}" \
             --ecr-api-key "${ECR_CREDS_USR}" \
             --ecr-api-secret "${ECR_CREDS_PSW}" \
             --oci-image-path "${{ needs.validate-documentation-request.outputs.oci-img-path }}" \

--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -71,12 +71,6 @@ def cli_args() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "--all-revision-tags",
-        help="File w/ comma-separated list of all revision (<track>_<rev>) tags",
-        required=True,
-    )
-
-    parser.add_argument(
         "--ecr-api-secret",
         dest="password",
         help="password/token on ECR",
@@ -125,7 +119,6 @@ class OCIDocumentationData:
         password,
         image_path,
         repository,
-        all_revision_tags,
         dry_run=False,
     ):
         self.username = username
@@ -133,7 +126,6 @@ class OCIDocumentationData:
         self.image_name = image_path.rstrip("/").split("/")[-1]
         self.repository = repository
         self.password = password
-        self.all_revision_tags = all_revision_tags
         self.dry_run = dry_run
         if not self.dry_run:
             self.ecr_client = self._ecr_connect(self.username, self.password)
@@ -367,16 +359,13 @@ class OCIDocumentationData:
             yaml.dump(content, fp, sort_keys=False)
 
     @staticmethod
-    def get_all_tracks(
-        all_revision_tags: list, releases_file: str = ""
-    ) -> Dict[str, str]:
+    def get_all_tracks(releases_file: str = "") -> Dict[str, str]:
         """
         Given a list of all the existing revision tags for a rock, get the
         corresponding track names and their end-of-life dates.
 
         It returns a Dict {"track": "eol", ...}.
 
-        :param all_revision_tags: all existing revision tags for a rock
         :param release_file: the path to the _releases.json file for that rock
         """
         _releases = {}
@@ -385,12 +374,13 @@ class OCIDocumentationData:
                 with open(releases_file) as rf:
                     _releases = json.load(rf)
             except FileNotFoundError:
-                logger.warning(f"Unable to load _releases.json and EOL dates")
+                logger.warning("Unable to load _releases.json and EOL dates")
                 pass
 
-        all_tracks = {}
-        for track in set(map(lambda t: t.rsplit("_", 1)[0], all_revision_tags)):
-            all_tracks[track] = _releases.get(track, {}).get("end-of-life")
+        all_tracks = {
+            track: track_entry.get("end-of-life")
+            for track, track_entry in _releases.items()
+        }
 
         return all_tracks
 
@@ -403,12 +393,9 @@ class OCIDocumentationData:
         )
 
         if not self.dry_run:
-            # Get a list of all revision tags, eg. ["1.0-22.04_1", "1.1-23.04_42", ...]
-            all_revision_tags = shared.get_all_revision_tags(self.all_revision_tags)
-
             # Extract a unique set of tracks, and their EOL, from that list
             all_tracks = self.get_all_tracks(
-                all_revision_tags, releases_file=f"{self.image_path}/_releases.json"
+                releases_file=f"{self.image_path}/_releases.json"
             )
 
             override_tracks = base_doc_yaml.get("override_tracks") or {}
@@ -459,7 +446,6 @@ if __name__ == "__main__":
         args.password,
         args.image_path,
         args.repository,
-        args.all_revision_tags,
         args.dry_run,
     )
     runner.main(args.doc_data_dir)

--- a/tests/unit/test_generate_oci_doc_yaml.py
+++ b/tests/unit/test_generate_oci_doc_yaml.py
@@ -20,7 +20,7 @@ def mock_get_arches(monkeypatch):
 
 @pytest.fixture
 def releases_json():
-    f = tempfile.NamedTemporaryFile(delete_on_close=False)
+    f = tempfile.NamedTemporaryFile(delete=False)
     json_content = dedent(
         """\
         {
@@ -50,7 +50,7 @@ def releases_json():
 
 @pytest.fixture
 def release_json_track_has_alias():
-    f = tempfile.NamedTemporaryFile(delete_on_close=False)
+    f = tempfile.NamedTemporaryFile(delete=False)
     json_content = dedent(
         """\
         {
@@ -78,9 +78,11 @@ def release_json_track_has_alias():
     return f.name
 
 
+# TODO: This test case won't be used in this PR for now, as this is pending
+# the feature of grouping the tags by sha and eol.
 @pytest.fixture
 def release_json_same_target_has_different_eol():
-    f = tempfile.NamedTemporaryFile(delete_on_close=False)
+    f = tempfile.NamedTemporaryFile(delete=False)
     json_content = dedent(
         """\
         {
@@ -109,14 +111,38 @@ def release_json_same_target_has_different_eol():
 
 
 @pytest.mark.parametrize(
-    "releases_file",
+    ("releases_file", "expected_releases"),
     [
-        "releases_json",
-        "release_json_track_has_alias",
-        "release_json_same_target_has_different_eol",
+        (
+            "releases_json",
+            [
+                {
+                    "risk": "beta",
+                    "track": "3.1",
+                    "base": "24.04",
+                    "tags": ["3-24.04_edge", "3.1-24.04_edge"],
+                    "architectures": ["amd64", "arm64"],
+                    "support": {"until": "03/2099"},
+                }
+            ],
+        ),
+        (
+            "release_json_track_has_alias",
+            [
+                {
+                    "risk": "beta",
+                    "track": "3.1",
+                    "base": "24.04",
+                    "tags": ["3-24.04_edge", "3.1-24.04_edge"],
+                    "architectures": ["amd64", "arm64"],
+                    "support": {"until": "03/2099"},
+                }
+            ],
+        ),
     ],
 )
-def test_get_oci_doc_yaml_data(releases_file):
+def test_get_oci_doc_yaml_data(releases_file, request, expected_releases):
+    releases_file = request.getfixturevalue(releases_file)
     all_tracks = OCIDocumentationData.get_all_tracks(releases_file)
 
     all_ecr_tags = {
@@ -146,12 +172,4 @@ def test_get_oci_doc_yaml_data(releases_file):
 
     releases = runner.build_releases_data(all_tracks, all_ecr_tags)
 
-    assert releases == [
-        {
-            "risk": "beta",
-            "track": "3.1",
-            "base": "24.04",
-            "tags": ["3-24.04_edge", "3.1-24.04_edge"],
-            "architectures": ["amd64", "arm64"],
-        }
-    ]
+    assert releases == expected_releases

--- a/tests/unit/test_generate_oci_doc_yaml.py
+++ b/tests/unit/test_generate_oci_doc_yaml.py
@@ -1,0 +1,157 @@
+import pytest
+
+import tempfile
+from textwrap import dedent
+
+from src.docs.generate_oci_doc_yaml import OCIDocumentationData
+
+
+REVISION_TAGS = ["3.1.0-24.04_1", "3.1.0-24.04_2", "3.1.0-24.04_3"]
+
+
+# Mock the OCIDocumentationData.get_arches to return ["amd64", "arm64"] for testing purposes using pytest's monkeypatch fixture
+@pytest.fixture(autouse=True)
+def mock_get_arches(monkeypatch):
+    def mock_get_arches(self, _):
+        return ["amd64", "arm64"]
+
+    monkeypatch.setattr(OCIDocumentationData, "get_arches", mock_get_arches)
+
+
+@pytest.fixture
+def releases_json():
+    f = tempfile.NamedTemporaryFile(delete_on_close=False)
+    json_content = dedent(
+        """\
+        {
+            "3-24.04": {
+                "end-of-life": "2099-03-25T00:00:00Z",
+                "edge": {
+                    "target": "3"
+                }
+            },
+            "3.1-24.04": {
+                "end-of-life": "2099-03-25T00:00:00Z",
+                "edge": {
+                    "target": "3"
+                },
+                "beta": {
+                    "target": "3"
+                }
+            }
+        }
+        """
+    )
+    f.write(json_content.encode())
+    f.flush()
+    f.close()
+    return f.name
+
+
+@pytest.fixture
+def release_json_track_has_alias():
+    f = tempfile.NamedTemporaryFile(delete_on_close=False)
+    json_content = dedent(
+        """\
+        {
+            "3-24.04": {
+                "end-of-life": "2099-03-25T00:00:00Z",
+                "edge": {
+                    "target": "3"
+                }
+            },
+            "3.1-24.04": {
+                "end-of-life": "2099-03-25T00:00:00Z",
+                "edge": {
+                    "target": "3-24.04"
+                },
+                "beta": {
+                    "target": "3-24.04"
+                }
+            }
+        }
+        """
+    )
+    f.write(json_content.encode())
+    f.flush()
+    f.close()
+    return f.name
+
+
+@pytest.fixture
+def release_json_same_target_has_different_eol():
+    f = tempfile.NamedTemporaryFile(delete_on_close=False)
+    json_content = dedent(
+        """\
+        {
+            "3-24.04": {
+                "end-of-life": "2099-03-25T00:00:00Z",
+                "edge": {
+                    "target": "3"
+                }
+            },
+            "3.1-24.04": {
+                "end-of-life": "2098-03-25T00:00:00Z",
+                "edge": {
+                    "target": "3"
+                },
+                "beta": {
+                    "target": "3"
+                }
+            }
+        }
+        """
+    )
+    f.write(json_content.encode())
+    f.flush()
+    f.close()
+    return f.name
+
+
+@pytest.mark.parametrize(
+    "releases_file",
+    [
+        "releases_json",
+        "release_json_track_has_alias",
+        "release_json_same_target_has_different_eol",
+    ],
+)
+def test_get_oci_doc_yaml_data(releases_file):
+    all_tracks = OCIDocumentationData.get_all_tracks(releases_file)
+
+    all_ecr_tags = {
+        "imageTagDetails": [
+            {
+                "imageDetail": {"imageDigest": "sha256:abc"},
+                "imageTag": "3-24.04_edge",
+            },
+            {
+                "imageDetail": {"imageDigest": "sha256:abc"},
+                "imageTag": "3.1-24.04_beta",
+            },
+            {
+                "imageDetail": {"imageDigest": "sha256:abc"},
+                "imageTag": "3.1-24.04_edge",
+            },
+        ]
+    }
+
+    runner = OCIDocumentationData(
+        username="test_user",
+        password="test_password",
+        image_path="test/image/path",
+        repository="test_repository",
+        dry_run=True,
+    )
+
+    releases = runner.build_releases_data(all_tracks, all_ecr_tags)
+
+    assert releases == [
+        {
+            "risk": "beta",
+            "track": "3.1",
+            "base": "24.04",
+            "tags": ["3-24.04_edge", "3.1-24.04_edge"],
+            "architectures": ["amd64", "arm64"],
+        }
+    ]


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->
This PR fixes the issue that the EOL field is missing in the generated documentation when the `<version>-<[build-]base>` duplet from the `rockcraft.yaml` of the rock mismatches the released track by removing the intersection operation of the `canonical-revision-tags` with the tracks in the `_releases.json`. 

**Testing improvements:**

* Added a new unit test file `test_generate_oci_doc_yaml.py` with fixtures and parameterized tests to validate the new logic for extracting track and EOL information from various `_releases.json` scenarios.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
