### PR TITLE
chore: Add another litellm cve for airflow to trivyignore (patched in upstream)

### DIFF
--- a/oci/airflow/.trivyignore
+++ b/oci/airflow/.trivyignore
@@ -212,11 +212,15 @@ CVE-2026-31958
 # This is a dependency for breeze (an Airflow dev tool) that is not included in the image
 CVE-2026-30922
 
-# (litellm): LiteLLM: Authentication bypass via OIDC userinfo cache key collision
 # Bump to patched version (1.83.0) merged upstream in `main`
 # Upstream PR: https://github.com/apache/airflow/pull/64701
+
+# (litellm): Authentication bypass via OIDC userinfo cache key collision
 CVE-2026-35030
+# (litellm): Privilege escalation via unrestricted proxy configuration endpoint
 CVE-2026-35029
+# (litellm): Password hash exposure and pass-the-hash authentication bypass
+GHSA-69x8-hrgq-fjj8
 
 # (tornado): Tornado has cookie attribute injection via .RequestHandler.set_cookie
 # upstream `main` branch already updated tornado to 6.5.5 (where CVE is patched)


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->
The trivy scan of build for airflow-rock (3.1.8) found a new CVE: https://github.com/canonical/oci-factory/actions/runs/24136135570/attempts/1#summary-70427044805

The CVE stems from usage of litellm python package < 1.83.0
The upstream has patched to 1.83.0 (which is no affected by the vulnerability due to a fix), so this PR adds the discovered CVE to trivyignore to unblock build+publish of Airflwo image 3.1.8

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
