### PR TITLE
feat: add prometheus 3.11.1

### DIFF
--- a/oci/prometheus/.trivyignore
+++ b/oci/prometheus/.trivyignore
@@ -30,3 +30,9 @@ CVE-2024-34156
 CVE-2024-45338
 # pkg:golang/stdlib@1.23.11 - database/sql: Postgres Scan Race Condition
 CVE-2025-47907
+# github.com/buger/jsonparser - jsonparser: DoS via malformed JSON causing runtime panic in Delete function
+CVE-2026-32285
+# github.com/docker/docker - moby: Authorization plugin (AuthZ) bypass
+CVE-2026-34040
+# go.opentelemetry.io/otel/sdk - opentelemetry-go: PATH hijacking via untrusted kenv command on BSD/Solaris
+CVE-2026-39883

--- a/oci/prometheus/image.yaml
+++ b/oci/prometheus/image.yaml
@@ -1,18 +1,18 @@
 version: 1
 upload:
   - source: canonical/prometheus-rock
-    commit: 3a0ffc49350dd2ccde8c6868c53d65a885a7a0ac
-    directory: 3.4.1
+    commit: c7696b18c348b3a2831d13253586b38d971966dc
+    directory: 3.11.1
     release:
       3-24.04:
-        end-of-life: '2025-11-08T00:00:00Z'
+        end-of-life: '2026-07-11T00:00:00Z'
         risks:
           - stable
-      3.4-24.04:
-        end-of-life: '2025-08-08T00:00:00Z'
+      3.11-24.04:
+        end-of-life: '2026-07-11T00:00:00Z'
         risks:
           - stable
-      3.4.1-24.04:
-        end-of-life: '2025-08-08T00:00:00Z'
+      3.11.1-24.04:
+        end-of-life: '2026-04-10T00:00:00Z'
         risks:
           - stable


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->
Adds the Prometheus 3.11.1 rock. It supercedes #890. In the run in #890, there were four vulnerabilities reported. I checked the source code using `govulncheck` and they came back as false positives, so I added them to the ignore file.
### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/73b8eba5-b577-4133-b3e0-f8da0b5670ea" />
