### PR TITLE
chore: update ignored cves for go

### DIFF
--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -21,10 +21,12 @@ upload:
       - CVE-2025-58186  # Needs evaluation. https://ubuntu.com/security/CVE-2025-58186
       - CVE-2025-58187  # Needs evaluation. https://ubuntu.com/security/CVE-2025-58187
       - CVE-2025-61729  # Not triaged for golang 1.22 yet. https://ubuntu.com/security/CVE-2025-61729
-      - CVE-2025-68121  # Need evaluation. https://ubuntu.com/security/CVE-2025-68121
-      - CVE-2025-61726  # Need evaluation. https://ubuntu.com/security/CVE-2025-61726
-      - CVE-2025-61728  # Need evaluation. https://ubuntu.com/security/CVE-2025-61728
+      - CVE-2025-68121  # Needs evaluation. https://ubuntu.com/security/CVE-2025-68121
+      - CVE-2025-61726  # Needs evaluation. https://ubuntu.com/security/CVE-2025-61726
+      - CVE-2025-61728  # Needs evaluation. https://ubuntu.com/security/CVE-2025-61728
       - CVE-2026-25679  # Not triaged for golang 1.22 yet. https://ubuntu.com/security/CVE-2026-25679
+      - CVE-2026-32280  # Needs evaluation. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32282  # Needs evaluation. https://ubuntu.com/security/CVE-2026-32282
 
   - source: canonical/golang-rock
     directory: go-rock/1.25-26.04
@@ -39,3 +41,5 @@ upload:
       - CVE-2025-61726  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2025-61726
       - CVE-2025-61728  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2025-61728
       - CVE-2026-25679  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-25679
+      - CVE-2026-32280  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32282  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-32282

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -26,7 +26,9 @@ upload:
       - CVE-2025-61728  # Needs evaluation. https://ubuntu.com/security/CVE-2025-61728
       - CVE-2026-25679  # Not triaged for golang 1.22 yet. https://ubuntu.com/security/CVE-2026-25679
       - CVE-2026-32280  # Needs evaluation. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32281  # Needs evaluation. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Needs evaluation. https://ubuntu.com/security/CVE-2026-32282
+      - CVE-2026-32283  # Needs evaluation. https://ubuntu.com/security/CVE-2026-32283
 
   - source: canonical/golang-rock
     directory: go-rock/1.25-26.04
@@ -42,4 +44,6 @@ upload:
       - CVE-2025-61728  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2025-61728
       - CVE-2026-25679  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-25679
       - CVE-2026-32280  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32281  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-32282
+      - CVE-2026-32283  # Not triaged for golang 1.25 yet. https://ubuntu.com/security/CVE-2026-32283


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR adds the CVE's that are captured by our security notice, but aren't fixed yet.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
