### PR TITLE
docs: migrate to v2 alert-manager

### DIFF
--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -18,7 +18,7 @@ docker:
     -p 9093:9093
   run_conclusion: |
     Alertmanager starts on port 9093.
-    Access your Alertmanager instance at http://localhost:9093 after running with the required mappings.
+    Access your Alertmanager instance at `http://localhost:9093`.
 
 config:
   TZ:

--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -7,8 +7,6 @@ description: |
   many other mechanisms thanks to the webhook receiver. It also takes care of
   silencing and inhibition of alerts.
 
-  Please note that this repository is now holding a rock, not a
-  Dockerfile-based image. As such the entrypoint is now Pebble.
 website: https://prometheus.io/docs/alerting/latest/alertmanager/
 issues: https://github.com/canonical/alertmanager-rock/issues
 source-code: https://github.com/canonical/alertmanager-rock

--- a/oci/alertmanager/documentation.yaml
+++ b/oci/alertmanager/documentation.yaml
@@ -1,52 +1,36 @@
-version: 1
-# --- OVERVIEW INFORMATION ---
+version: 2
 application: alertmanager
-description: >
+description: |
   The Alertmanager handles alerts sent by client applications such as the
   Prometheus server. It takes care of deduplicating, grouping, and routing them
   to the correct receiver integrations such as email, PagerDuty, OpSGenie, or
   many other mechanisms thanks to the webhook receiver. It also takes care of
   silencing and inhibition of alerts.
-  Read more on the [official documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
   Please note that this repository is now holding a rock, not a
-  Dockerfile-based image. As such the entrypoint is now Pebble. Read more on
-  the [Rockcraft docs](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/).
-# --- USAGE INFORMATION ---
+  Dockerfile-based image. As such the entrypoint is now Pebble.
+website: https://prometheus.io/docs/alerting/latest/alertmanager/
+issues: https://github.com/canonical/alertmanager-rock/issues
+source-code: https://github.com/canonical/alertmanager-rock
+
 docker:
-  parameters:
-    - -p 9093:9093
-  access: Access your Alertmanager instance at `http://localhost:9093`.
-parameters:
-  - type: -e
-    value: 'TZ=UTC'
+  parameters: >-
+    -p 9093:9093
+  run_conclusion: |
+    Alertmanager starts on port 9093.
+    Access your Alertmanager instance at http://localhost:9093 after running with the required mappings.
+
+config:
+  TZ:
+    type: env
     description: Timezone.
-  - type: -p
-    value: '9093:9093'
-    description: Expose Alertmanager on `localhost:9093`.
-  - type: -v 
-    value: "/path/to/alertmanager.yml:/etc/prometheus/alertmanager.yml"
-    description: Local configuration file `alertmanager.yml`.
-  - type: -v
-    value: "/path/to/persisted/data:/alertmaanger"
-    description: >
-      Persist data instead of initializing a new database for each newly
-      launched container. **Important note**: the directory you will be using
-      to persist the data needs to belong to `nogroup:nobody`. You can run
-      `chown nogroup:nobody <path_to_persist_data>` before launching your
-      container.
-debug:
-  text: |
-    ### Debugging
-    
-    To debug the container:
-
-    ```bash
-    docker logs -f alertmanager-container
-    ```
-
-    To get an interactive shell:
-
-    ```bash
-    docker exec -it alertmanager-container exec /bin/bash
-    ```
+    default: 'UTC'
+  '`-v <path>:/etc/prometheus/alertmanager.yml`':
+    type: mount
+    description: Local configuration file alertmanager.yml.
+  '`-v <path>:/alertmanager`':
+    type: mount
+    description: Persist data instead of initializing a new database for each newly launched container. The host data directory should belong to nogroup:nobody.
+  '`-p <port>:9093`':
+    type: port
+    description: Expose port 9093 on the host.


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Migrate docs to v2.