### PR TITLE
docs: migrate to v2 temporal-ui

### DIFF
--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -1,38 +1,34 @@
-version: 1
-
+version: 2
 application: temporal-ui
 description: >
-  The Temporal UI provides a browser-based user interface for Temporal, allowing users to view Workflow Execution state, metadata, and debug their Temporal applications.
+  The Temporal UI provides a browser-based user interface for Temporal, allowing users to view Workflow Execution
+  state, metadata, and debug their Temporal applications.
+website: https://github.com/temporalio/ui
+issues: https://github.com/canonical/temporal-rocks/issues
+source-code: https://github.com/canonical/temporal-rocks
 
 docker:
-  parameters:
+  parameters: >-
     - -p 8081:8081
-  access: |
-    ### New entrypoint `pebble`
+  run_conclusion: |
+    temporal-ui starts under Pebble and serves the UI on port 8081.
 
-    Please note that the entrypoint of the images in this repository is [Pebble](https://documentation.ubuntu.com/pebble/), a lightweight service manager. The pebble process launches and supervises the temporal ui server process.
-
-    #### Temporal UI Server Configuration
-
-    Temporal UI server must be provided with a configuration file to start up sucessfully. We do not include any default configurations in the image. Instead, we expect the user to either add a configuration file in the deployed container or mount a volume with the config file in the container.
-
-    Some development configuration files can be found in [the temporal ui repository](https://github.com/temporalio/ui/tree/main/server/config).
-
-    The following outlines steps to mount the development configuration files while launching a container:
-
-    ```sh
-    $ git clone https://github.com/temporalio/ui
-
-    $ docker run -d --name temporal-ui-container -p 8081:8081 -v ./ui/server/config:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development ubuntu/temporal-ui:2.39.0-24.04_edge
-    ```
-
-parameters:
-  - type: -e
-    value: 'TEMPORAL_ROOT=/home/ui-server'
-    description: Root directory of execution environment
-  - type: -e
-    value: 'TEMPORAL_CONFIG_DIR=config'
-    description: Config directory path relative to the root
-  - type: -e
-    value: 'TEMPORAL_ENVIRONMENT=development'
-    description: Runtime environment
+config:
+  TEMPORAL_ROOT:
+    type: env
+    description: temporal-ui is configurable with the root directory of the execution environment.
+    default: /home/ui-server
+  TEMPORAL_CONFIG_DIR:
+    type: env
+    description: temporal-ui is configurable with a config directory path relative to the root directory.
+    default: config
+  TEMPORAL_ENVIRONMENT:
+    type: env
+    description: temporal-ui is configurable with a runtime environment name.
+    default: development
+  '`-v <path>:/home/ui-server/config`':
+    type: mount
+    description: temporal-ui is configurable with a mounted UI server configuration directory.
+  '`-p <port>:8081`':
+    type: port
+    description: temporal-ui is configurable to expose the web interface on localhost.

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -17,12 +17,15 @@ source-code: https://github.com/canonical/temporal-rocks
 docker:
   parameters: >-
     -p 8081:8081
+    -v <path>:/home/ui-server/config
+    -e TEMPORAL_ROOT=/home/ui-server
+    -e TEMPORAL_ENVIRONMENT=production
   run_cmd: >-
-    -d -v <path>:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=production
+    -d
   run_conclusion: |
     The Temporal UI is started by Pebble and serves the UI on port 8081.
     
-    To obtain a runnable configuration, clone https://github.com/temporalio/ui.
+    To obtain a runnable configuration, refer to the [official repository](https://github.com/temporalio/ui).
     
     
 

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -18,8 +18,7 @@ docker:
   parameters: >-
     -p 8081:8081
   run_cmd: >-
-    -d --name temporal-ui-container -v <path>:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=production ubuntu/temporal-ui:2.39.0-24.04_edge
-  run_conclusion: |
+    -d -v <path>:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=production
     To obtain a runnable configuration, clone https://github.com/temporalio/ui.
     
     The temporal UI service is started by Pebble and serves the UI on port 8081.

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -9,14 +9,6 @@ description: >
   Temporal UI server must be provided with a configuration file to start up successfully. We do not include any default configurations in the image. Instead, we expect the user to either add a configuration file in the deployed container or mount a volume with the config file in the container.
 
   Some development configuration files can be found in [the temporal ui repository](https://github.com/temporalio/ui/tree/main/server/config).
-
-  The following outlines steps to mount the development configuration files while launching a container:
-
-  ```sh
-  $ git clone https://github.com/temporalio/ui
-
-  $ docker run -d --name temporal-ui-container -p 8081:8081 -v ./ui/server/config:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development ubuntu/temporal-ui:2.39.0-24.04_edge
-  ```
   
 website: https://github.com/temporalio/ui
 issues: https://github.com/canonical/temporal-rocks/issues
@@ -25,7 +17,11 @@ source-code: https://github.com/canonical/temporal-rocks
 docker:
   parameters: >-
     -p 8081:8081
+  run_cmd: >-
+    -d --name temporal-ui-container -v <path>:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=production ubuntu/temporal-ui:2.39.0-24.04_edge
   run_conclusion: |
+    To obtain a runnable configuration, clone https://github.com/temporalio/ui.
+    
     The temporal UI service is started by Pebble and serves the UI on port 8081.
 
 config:

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -4,7 +4,7 @@ description: >
   The Temporal UI provides a browser-based user interface for Temporal, allowing users to view Workflow Execution
   state, metadata, and debug their Temporal applications.
 
-  #### Temporal UI Server Configuration
+  ## Temporal UI Server Configuration
 
   Temporal UI server must be provided with a configuration file to start up successfully. We do not include any default configurations in the image. Instead, we expect the user to either add a configuration file in the deployed container or mount a volume with the config file in the container.
 

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -9,26 +9,25 @@ source-code: https://github.com/canonical/temporal-rocks
 
 docker:
   parameters: >-
-    - -p 8081:8081
+    -p 8081:8081
   run_conclusion: |
-    temporal-ui starts under Pebble and serves the UI on port 8081.
+    The temporal UI service is started by Pebble and serves the UI on port 8081.
 
 config:
   TEMPORAL_ROOT:
     type: env
-    description: temporal-ui is configurable with the root directory of the execution environment.
-    default: /home/ui-server
+    description: Root directory of execution environment.
   TEMPORAL_CONFIG_DIR:
     type: env
-    description: temporal-ui is configurable with a config directory path relative to the root directory.
-    default: config
+    description: Config directory path relative to `TMEMPORAL_ROOT`.
   TEMPORAL_ENVIRONMENT:
     type: env
-    description: temporal-ui is configurable with a runtime environment name.
-    default: development
+    description: Runtime environment.
   '`-v <path>:/home/ui-server/config`':
     type: mount
-    description: temporal-ui is configurable with a mounted UI server configuration directory.
+    description: >-
+      Temporal UI server configuration directory.
+      Replace the target path if `TEMPORAL_ROOT` and `TEMPORAL_CONFIG_DIR` are set to different values from `/home/ui-server` and `config`.
   '`-p <port>:8081`':
     type: port
     description: temporal-ui is configurable to expose the web interface on localhost.

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -8,7 +8,7 @@ description: >
 
   Temporal UI server must be provided with a configuration file to start up successfully. We do not include any default configurations in the image. Instead, we expect the user to either add a configuration file in the deployed container or mount a volume with the config file in the container.
 
-  Some development configuration files can be found in [the temporal ui repository](https://github.com/temporalio/ui/tree/main/server/config).
+  Some development configuration files can be found in [the Temporal UI repository](https://github.com/temporalio/ui/tree/main/server/config).
   
 website: https://github.com/temporalio/ui
 issues: https://github.com/canonical/temporal-rocks/issues
@@ -20,9 +20,11 @@ docker:
   run_cmd: >-
     -d -v <path>:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=production
   run_conclusion: |
+    The Temporal UI is started by Pebble and serves the UI on port 8081.
+    
     To obtain a runnable configuration, clone https://github.com/temporalio/ui.
     
-    The temporal UI service is started by Pebble and serves the UI on port 8081.
+    
 
 config:
   TEMPORAL_ROOT:
@@ -41,4 +43,4 @@ config:
       Replace the target path if `TEMPORAL_ROOT` and `TEMPORAL_CONFIG_DIR` are set to different values from `/home/ui-server` and `config`.
   '`-p <port>:8081`':
     type: port
-    description: temporal-ui is configurable to expose the web interface on localhost.
+    description: Temporal UI is configurable to expose the web interface on localhost.

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -3,6 +3,21 @@ application: temporal-ui
 description: >
   The Temporal UI provides a browser-based user interface for Temporal, allowing users to view Workflow Execution
   state, metadata, and debug their Temporal applications.
+
+  #### Temporal UI Server Configuration
+
+  Temporal UI server must be provided with a configuration file to start up successfully. We do not include any default configurations in the image. Instead, we expect the user to either add a configuration file in the deployed container or mount a volume with the config file in the container.
+
+  Some development configuration files can be found in [the temporal ui repository](https://github.com/temporalio/ui/tree/main/server/config).
+
+  The following outlines steps to mount the development configuration files while launching a container:
+
+  ```sh
+  $ git clone https://github.com/temporalio/ui
+
+  $ docker run -d --name temporal-ui-container -p 8081:8081 -v ./ui/server/config:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=development ubuntu/temporal-ui:2.39.0-24.04_edge
+  ```
+  
 website: https://github.com/temporalio/ui
 issues: https://github.com/canonical/temporal-rocks/issues
 source-code: https://github.com/canonical/temporal-rocks
@@ -19,7 +34,7 @@ config:
     description: Root directory of execution environment.
   TEMPORAL_CONFIG_DIR:
     type: env
-    description: Config directory path relative to `TMEMPORAL_ROOT`.
+    description: Config directory path relative to `TEMPORAL_ROOT`.
   TEMPORAL_ENVIRONMENT:
     type: env
     description: Runtime environment.

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -19,6 +19,7 @@ docker:
     -p 8081:8081
   run_cmd: >-
     -d -v <path>:/home/ui-server/config -e TEMPORAL_ROOT=/home/ui-server -e TEMPORAL_ENVIRONMENT=production
+  run_conclusion: |
     To obtain a runnable configuration, clone https://github.com/temporalio/ui.
     
     The temporal UI service is started by Pebble and serves the UI on port 8081.

--- a/oci/temporal-ui/documentation.yaml
+++ b/oci/temporal-ui/documentation.yaml
@@ -16,12 +16,11 @@ source-code: https://github.com/canonical/temporal-rocks
 
 docker:
   parameters: >-
+    -d
     -p 8081:8081
     -v <path>:/home/ui-server/config
     -e TEMPORAL_ROOT=/home/ui-server
     -e TEMPORAL_ENVIRONMENT=production
-  run_cmd: >-
-    -d
   run_conclusion: |
     The Temporal UI is started by Pebble and serves the UI on port 8081.
     


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Update docs to v2.
