### PR TITLE
chore: enable renovate for 25.10 and 26.04

### DIFF
--- a/.github/base_digests/25.10
+++ b/.github/base_digests/25.10
@@ -1,0 +1,2 @@
+public.ecr.aws/ubuntu/ubuntu:questing@sha256:70c941f44c475633b5968e549eea587e78de9d60166408c4ffcd87a3e30ec713
+

--- a/.github/base_digests/26.04
+++ b/.github/base_digests/26.04
@@ -1,0 +1,1 @@
+public.ecr.aws/ubuntu/ubuntu:resolute@sha256:7ad0926092b4e45abc5acf33c5cdc9a6de52d5b0e12ed87dd82e5c79a8167f9f


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR sets up the renovation for 25.10 and 26.04 build-bases.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
