### PR TITLE
fix: use --latest when --devel is outdated

### DIFF
--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -40,7 +40,7 @@ def get_base_and_track(rockcraft_yaml) -> tuple[str, str]:
                     "devel is outdated. Using the latest release instead."
                 )
                 distro_info = subprocess.check_output(
-                    ["ubuntu-distro-info", "--latest", "--codename"], universal_newlines=True
+                    ["ubuntu-distro-info", "--latest", "--release"], universal_newlines=True
                 )
             else:
                 raise e

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -32,7 +32,9 @@ def get_base_and_track(rockcraft_yaml) -> tuple[str, str]:
     if rock_base == "devel":
         try:
             distro_info = subprocess.check_output(
-                ["ubuntu-distro-info", "--devel", "--release"], universal_newlines=True
+                ["ubuntu-distro-info", "--devel", "--release"],
+                universal_newlines=True,
+                stderr=subprocess.STDOUT,
             )
         except subprocess.CalledProcessError as e:
             if e.returncode == 1 and "Distribution data outdated" in e.output:

--- a/src/uploads/infer_image_track.py
+++ b/src/uploads/infer_image_track.py
@@ -30,9 +30,21 @@ def get_base_and_track(rockcraft_yaml) -> tuple[str, str]:
     )
 
     if rock_base == "devel":
-        rock_base = subprocess.check_output(
-            ["ubuntu-distro-info", "--devel", "--release"], universal_newlines=True
-        ).split()[0]
+        try:
+            distro_info = subprocess.check_output(
+                ["ubuntu-distro-info", "--devel", "--release"], universal_newlines=True
+            )
+        except subprocess.CalledProcessError as e:
+            if e.returncode == 1 and "Distribution data outdated" in e.output:
+                logger.warning(
+                    "devel is outdated. Using the latest release instead."
+                )
+                distro_info = subprocess.check_output(
+                    ["ubuntu-distro-info", "--latest", "--codename"], universal_newlines=True
+                )
+            else:
+                raise e
+        rock_base = distro_info.split()[0]
 
     try:
         base_release = float(rock_base.replace(":", "@").split("@")[-1])


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Since 26.04 is released,  there's nothing in `devel` until `26.10` is opened. So to prevent build failures, we use `--latest` in this situation, since is where `devel` should point to.