### PR TITLE
fix(ci/doc): null when source-code empty

### DIFF
--- a/src/docs/schema/v2/DocSchema.py
+++ b/src/docs/schema/v2/DocSchema.py
@@ -128,5 +128,5 @@ class DocSchema(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     @field_serializer("website", "issues", "source_code")
-    def serialize_url(self, url: AnyUrl) -> str:
-        return str(url)
+    def serialize_url(self, url: AnyUrl | None) -> str | None:
+        return str(url) if url else url


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This fixes the `source_code` inside the generated data yaml, such that it won't be `'None'` when the `source-code` is not given from the documentation trigger.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
