### PR TITLE
chore: add various CVEs to .trivyignore and update EOL date

### DIFF
--- a/oci/airflow/.trivyignore
+++ b/oci/airflow/.trivyignore
@@ -226,5 +226,23 @@ GHSA-69x8-hrgq-fjj8
 # upstream `main` branch already updated tornado to 6.5.5 (where CVE is patched)
 CVE-2026-35536
 
-# Apache Airflow (pip), fixed in <3.2.0
+# Apache Airflow (pip), Auth Bypass Vulnerability, fixed in <3.2.0
 CVE-2025-57735
+
+#  (Apache Airflow): RCE by race condition in example_xcom dag, fixed in <3.2.0
+CVE-2025-54550
+
+#  (Apache Airflow): Unsafe Deserialization via Legacy Serialization Keys (__type/__var) Bypass in XCom API, fixed in <3.2.0 
+CVE-2026-33858
+
+#  (Apache Airflow): allows code execution through crafted XCom payloads, fixed in <3.2.0
+CVE-2026-25917
+
+#  (Apache Airflow): allows users with asset materialize permissions to trigger DAGs outside of their permissions, fixed in <3.2.0
+CVE-2026-32228
+
+# (LiteLLM): Server-Side Template Injection in /prompts/test endpoint
+GHSA-xqmj-j6mv-4862
+
+# (lxml): Default configuration of iterparse() and ETCompatXMLParser() allows XXE to local files
+CVE-2026-41066

--- a/oci/airflow/.trivyignore
+++ b/oci/airflow/.trivyignore
@@ -225,3 +225,6 @@ GHSA-69x8-hrgq-fjj8
 # (tornado): Tornado has cookie attribute injection via .RequestHandler.set_cookie
 # upstream `main` branch already updated tornado to 6.5.5 (where CVE is patched)
 CVE-2026-35536
+
+# Apache Airflow (pip), fixed in <3.2.0
+CVE-2025-57735

--- a/oci/airflow/image.yaml
+++ b/oci/airflow/image.yaml
@@ -5,6 +5,6 @@ upload:
     directory: 3.1
     release:
       3.1-24.04:
-        end-of-life: "2026-04-14T00:00:00Z"
+        end-of-life: "2026-10-30T00:00:00Z"
         risks:
           - edge


### PR DESCRIPTION


- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

The Airflow version we are currently using in the rock is 3.1, which has CVE-2025-57735. The resolution is to upgrade to 3.2, which is not compatible with our plans for release, so we are adding this CVE to the .trivyignore file so the image can be built.

This commit also updates the EOL so the image keeps being built until the end of the 26.10 cycle.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
