### PR TITLE
chore: update airflow rock to include git provider python dependencies

### DIFF
--- a/oci/airflow/image.yaml
+++ b/oci/airflow/image.yaml
@@ -1,7 +1,7 @@
 version: 1
 upload:
   - source: canonical/airflow-rocks
-    commit: 164d17047bb685e4eb6fa2fec42cea05fba6c9ed # 3.1.8
+    commit: be4c91f3380d6f0a72e618d8bc3cc7bbe907216c # 3.1.8
     directory: 3.1
     release:
       3.1-24.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->
We have a new change introduced to the Airflow rock that now includes 2 python packages (`GitPython` and `aiohttp`) that are needed to manage git Airflow connections. This PR updates the commit hash from which the Airflow image is built and published to include the aforementioned changes.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
