### PR TITLE
feat: stabilize pro feature

### DIFF
--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -185,13 +185,9 @@ jobs:
         uses: canonical/craft-actions/rockcraft-pack@main
         with:
           path: "${{ env.ROCK_REPO_DIR }}/${{ inputs.rockfile-directory }}"
-          # TODO Change back to the following line once the pro feature is merged to stable
-          # test: "${{ inputs.rockcraft-test }}"
-          test: "${{ needs.configure-build.outputs.pro-build == 'true' && 'false' || inputs.rockcraft-test }}"
+          test: "${{ inputs.rockcraft-test }}"
           pro: "${{ inputs.pro-services }}"
           verbosity: debug
-          # TODO remove once the pro feature is merged to stable
-          rockcraft-channel: ${{ needs.configure-build.outputs.pro-build == 'true' && 'edge/pro-sources' || '' }}
       
       - name: Detaching Pro Token
         if: always() && steps.attach_pro.outcome == 'success'


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Pro feature is in rockcraft stable now, so once the craft actions PR below is merged we can use the stable channel.

A workflow run can be found [here](https://github.com/alesancor1/template-test/actions/runs/25386973047/job/74450871406)

Depends on: https://github.com/canonical/craft-actions/pull/58