### PR TITLE
ci: replace third-party tag/release actions with gh calls

### DIFF
--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -3,6 +3,13 @@ run-name: "Image - ${{ inputs.oci-image-name || github.triggering_actor }} - ${{
 
 on:
   push:
+    # Tag pushes are not a valid trigger for this workflow -- it expects an
+    # oci-image-name input (workflow_dispatch/workflow_call) which tag pushes
+    # cannot supply, so prepare-build would always fail. The Release workflow
+    # creates release tags via the REST API / git push as part of normal
+    # operation; without this filter those pushes spuriously retrigger Image.
+    tags-ignore:
+      - '*'
     paths:
       - "oci/*/image.y*ml"
       - "!oci/mock*"

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -259,10 +259,17 @@ jobs:
             -f "tagger[email]=${GITHUB_ACTOR}@users.noreply.github.com" \
             -f "tagger[date]=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --jq .sha)
-          # Create the tag ref (previous step deleted any existing tag via --cleanup-tag)
-          gh api "repos/${REPO}/git/refs" \
-            -f ref="refs/tags/${TAG}" \
-            -f sha="${tag_sha}"
+          # Preserve the prior force-push-tag behaviour: update the ref when
+          # it already exists, otherwise create it.
+          if gh api "repos/${REPO}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${REPO}/git/refs/tags/${TAG}" \
+              -f sha="${tag_sha}" \
+              -F force=true
+          else
+            gh api "repos/${REPO}/git/refs" \
+              -f ref="refs/tags/${TAG}" \
+              -f sha="${tag_sha}"
+          fi
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -245,31 +245,34 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          # NOTE: using the git CLI rather than `gh api git/{tags,refs}`.
-          # A git-push of a tag pointing at an existing commit produces a
-          # webhook event with an empty `commits` list, so downstream
-          # workflows that filter `on.push` by `paths` (e.g. Image.yaml)
-          # don't retrigger. REST-API ref creation, by contrast, produces
-          # an event that does match those filters.
+
+          # NOTE: using the git CLI rather than `gh api git/{tags,refs}` since creasting refs
+          # with `gh` triggers webhook events which can re-trigger workflows. `git` actions do not.
+
           # Tagger comes from git config at tag-creation time.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
           # Passing TARGET_REF (itself an annotated tag) without peeling
           # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
-          # Push with ROCKSBOT_TOKEN. actions/checkout installed a
-          # GITHUB_TOKEN-based extraheader on `origin`; replace it so the
-          # push is authenticated as ROCKsBot. `--replace-all` is needed
-          # because `http.<url>.extraheader` is a multi-valued key, so an
-          # inline `git -c key=val` would append a second header rather
-          # than override.
+
+          # `actions/checkout` installs a GITHUB_TOKEN-based extraheader
+          # on `origin`; swap it for one carrying our token for the push,
+          # then restore the original so the rest of the job sees the
+          # same git config it started with.
+          prev_extraheader=$(git config --local --get "http.https://github.com/.extraheader" || true)
           git config --local --replace-all \
             "http.https://github.com/.extraheader" \
             "AUTHORIZATION: bearer ${GH_TOKEN}"
           git push --force origin "refs/tags/${TAG}"
-          # Drop the ROCKSBOT_TOKEN header so it doesn't sit in .git/config
-          # for the rest of the job.
-          git config --local --unset-all "http.https://github.com/.extraheader"
+          if [ -n "${prev_extraheader}" ]; then
+            git config --local --replace-all \
+              "http.https://github.com/.extraheader" \
+              "${prev_extraheader}"
+          else
+            git config --local --unset-all "http.https://github.com/.extraheader"
+          fi
 
       - name: Create GitHub release
         env:
@@ -280,9 +283,10 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          # Match softprops' default `fail_on_unmatched_files: false`:
+
           # unmatched glob -> empty file list, release still created.
           shopt -s nullglob
+
           files=(sbom/*.sbom_preview.spdx.json)
           gh release create "${TAG}" \
             --title "${TAG}" \

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -239,20 +239,21 @@ jobs:
           GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
           TAG: ${{ matrix.release-name }}
           MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
-          SHA: ${{ matrix.canonical-tag }}
+          TARGET_REF: ${{ matrix.canonical-tag }}
           REPO: ${{ github.repository }}
         run: |
           set -e
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
+          commit_sha=$(git rev-parse "${TARGET_REF}^{commit}")
           # Create annotated tag object. Set tagger explicitly to match the
           # prior rickstaa/action-create-tag behaviour, which used
           # user.name=$GITHUB_ACTOR and user.email=$GITHUB_ACTOR@users.noreply.github.com.
           tag_sha=$(gh api "repos/${REPO}/git/tags" \
             -f tag="${TAG}" \
             -f message="${MSG}" \
-            -f object="${SHA}" \
+            -f object="${commit_sha}" \
             -f type=commit \
             -f "tagger[name]=${GITHUB_ACTOR}" \
             -f "tagger[email]=${GITHUB_ACTOR}@users.noreply.github.com" \

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -235,17 +235,43 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Create Git tag
-        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
-        with:
-          tag: "${{ matrix.release-name }}"
-          message: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
-          github_token: ${{ secrets.ROCKSBOT_TOKEN }}
-          commit_sha: ${{ matrix.canonical-tag }}
-          force_push_tag: true
+        env:
+          GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
+          TAG: ${{ matrix.release-name }}
+          MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
+          SHA: ${{ matrix.canonical-tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
+          # Create annotated tag object
+          tag_sha=$(gh api "repos/${REPO}/git/tags" \
+            -f tag="${TAG}" \
+            -f message="${MSG}" \
+            -f object="${SHA}" \
+            -f type=commit \
+            --jq .sha)
+          # Create the tag ref (previous step deleted any existing tag via --cleanup-tag)
+          gh api "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${tag_sha}"
 
-      - uses: "softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda"  # v3.0.0
-        with:
-          name: "${{ matrix.release-name }}"
-          tag_name: "${{ matrix.release-name }}"
-          token: "${{ secrets.ROCKSBOT_TOKEN }}"
-          files: "sbom/*.sbom_preview.spdx.json"
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
+          TAG: ${{ matrix.release-name }}
+        run: |
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
+          # Match softprops' default `fail_on_unmatched_files: false`:
+          # unmatched glob -> empty file list, release still created.
+          shopt -s nullglob
+          files=(sbom/*.sbom_preview.spdx.json)
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --notes "" \
+            "${files[@]}"

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -244,28 +244,18 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          # NOTE: the tag is created and pushed via the git CLI rather than
-          # `gh api repos/.../git/{tags,refs}`. Empirically, tag refs created
-          # via the REST API fire push-event triggers on workflows like
-          # Image.yaml (causing spurious failing runs), while runner-side
-          # `git push` of the same ref does not. Using git here preserves
-          # the prior rickstaa/action-create-tag behaviour.
-          # Match the prior tagger identity set by rickstaa/action-create-tag:
-          # user.name=$GITHUB_ACTOR, user.email=$GITHUB_ACTOR@users.noreply.github.com.
-          # The tagger of the annotated tag object is taken from git config at
-          # `git tag -a` time, independent of which token is used for the push.
+          # NOTE: using the git CLI rather than `gh api git/{tags,refs}`.
+          # REST-API-created tag refs fire push-event triggers on workflows
+          # like Image.yaml; runner-side `git push` of the same ref does not.
+          # Tagger comes from git config at tag-creation time, matching the
+          # prior rickstaa/action-create-tag identity.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          # -f to force-update an existing tag (preserves force_push_tag: true),
-          # -a for annotated, -m for the tag message.
-          # TARGET_REF is the canonical-tag (an annotated tag itself). Passing
-          # it without peeling preserves the prior tag-of-tag chain, so the
-          # new release tag retains a back-reference to the underlying
-          # upload/canonical tag (which records the revision number).
+          # Passing TARGET_REF (itself an annotated tag) without peeling
+          # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
-          # Push uses the GITHUB_TOKEN-based auth header that actions/checkout
-          # already wired up on `origin`; the job grants `contents: write`,
-          # which is enough to push (and force-update) a tag ref.
+          # Push uses the GITHUB_TOKEN auth header wired up by actions/checkout;
+          # the job grants `contents: write`, enough for tag (force-)pushes.
           git push --force origin "refs/tags/${TAG}"
 
       - name: Create GitHub release

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -246,12 +246,17 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          # Create annotated tag object
+          # Create annotated tag object. Set tagger explicitly to match the
+          # prior rickstaa/action-create-tag behaviour, which used
+          # user.name=$GITHUB_ACTOR and user.email=$GITHUB_ACTOR@users.noreply.github.com.
           tag_sha=$(gh api "repos/${REPO}/git/tags" \
             -f tag="${TAG}" \
             -f message="${MSG}" \
             -f object="${SHA}" \
             -f type=commit \
+            -f "tagger[name]=${GITHUB_ACTOR}" \
+            -f "tagger[email]=${GITHUB_ACTOR}@users.noreply.github.com" \
+            -f "tagger[date]=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --jq .sha)
           # Create the tag ref (previous step deleted any existing tag via --cleanup-tag)
           gh api "repos/${REPO}/git/refs" \

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -257,14 +257,22 @@ jobs:
           # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
 
-          # Clear every inherited http.*.extraheader (actions/checkout's
-          # exact key varies by version) and install ours for the push,
-          # else GitHub rejects with HTTP 400 on duplicate Authorization.
-          git config --local --name-only --get-regexp '^http\..*\.extraheader$' \
-            | xargs -r -n1 git config --local --unset-all
+          # Stash, clear, swap-in ours, push, drop ours, restore. Sweeping
+          # is required because actions/checkout's exact extraheader key
+          # varies by version; replacing a single fixed key can leave the
+          # inherited header in place and GitHub then rejects the push
+          # with HTTP 400 on duplicate Authorization.
+          declare -A _prev_hdrs=()
+          for _k in $(git config --local --name-only --get-regexp '^http\..*\.extraheader$' || true); do
+            _prev_hdrs["$_k"]=$(git config --local --get "$_k")
+            git config --local --unset-all "$_k"
+          done
           git config --local --add "http.https://github.com/.extraheader" "AUTHORIZATION: bearer ${GH_TOKEN}"
           git push --force origin "refs/tags/${TAG}"
           git config --local --unset-all "http.https://github.com/.extraheader"
+          for _k in "${!_prev_hdrs[@]}"; do
+            git config --local --add "$_k" "${_prev_hdrs[$_k]}"
+          done
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -267,6 +267,9 @@ jobs:
             "http.https://github.com/.extraheader" \
             "AUTHORIZATION: bearer ${GH_TOKEN}"
           git push --force origin "refs/tags/${TAG}"
+          # Drop the ROCKSBOT_TOKEN header so it doesn't sit in .git/config
+          # for the rest of the job.
+          git config --local --unset-all "http.https://github.com/.extraheader"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -247,8 +247,7 @@ jobs:
           # NOTE: using the git CLI rather than `gh api git/{tags,refs}`.
           # REST-API-created tag refs fire push-event triggers on workflows
           # like Image.yaml; runner-side `git push` of the same ref does not.
-          # Tagger comes from git config at tag-creation time, matching the
-          # prior rickstaa/action-create-tag identity.
+          # Tagger comes from git config at tag-creation time.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           # Passing TARGET_REF (itself an annotated tag) without peeling

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -212,6 +212,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ matrix.canonical-tag }}
+          # Drop checkout's auth state after the clone so it doesn't merge
+          # with the auth we install for the `git push` below (which would
+          # send two Authorization headers and trigger HTTP 400).
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -237,6 +241,7 @@ jobs:
       - name: Create Git tag
         env:
           GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
+          REPO: ${{ github.repository }}
           TAG: ${{ matrix.release-name }}
           MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
           TARGET_REF: ${{ matrix.canonical-tag }}
@@ -246,8 +251,10 @@ jobs:
             set -x
           fi
 
-          # NOTE: using the git CLI rather than `gh api git/{tags,refs}` since creasting refs
-          # with `gh` triggers webhook events which can re-trigger workflows. `git` actions do not.
+          # NOTE: using the git CLI rather than `gh api git/{tags,refs}` since
+          # creating refs via the REST API fires push-event triggers on
+          # workflows like Image.yaml; runner-side `git push` of the same ref
+          # does not.
 
           # Tagger comes from git config at tag-creation time.
           git config user.name "${GITHUB_ACTOR}"
@@ -257,22 +264,12 @@ jobs:
           # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
 
-          # Stash, clear, swap-in ours, push, drop ours, restore. Sweeping
-          # is required because actions/checkout's exact extraheader key
-          # varies by version; replacing a single fixed key can leave the
-          # inherited header in place and GitHub then rejects the push
-          # with HTTP 400 on duplicate Authorization.
-          declare -A _prev_hdrs=()
-          for _k in $(git config --local --name-only --get-regexp '^http\..*\.extraheader$' || true); do
-            _prev_hdrs["$_k"]=$(git config --local --get "$_k")
-            git config --local --unset-all "$_k"
-          done
-          git config --local --add "http.https://github.com/.extraheader" "AUTHORIZATION: bearer ${GH_TOKEN}"
-          git push --force origin "refs/tags/${TAG}"
-          git config --local --unset-all "http.https://github.com/.extraheader"
-          for _k in "${!_prev_hdrs[@]}"; do
-            git config --local --add "$_k" "${_prev_hdrs[$_k]}"
-          done
+          # Push with ROCKSBOT_TOKEN via URL-embedded basic auth. The
+          # checkout step is configured with persist-credentials: false,
+          # so no inherited Authorization header would collide here.
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+            "refs/tags/${TAG}"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -240,7 +240,10 @@ jobs:
           MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
           TARGET_REF: ${{ matrix.canonical-tag }}
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           # NOTE: the tag is created and pushed via the git CLI rather than
           # `gh api repos/.../git/{tags,refs}`. Empirically, tag refs created
           # via the REST API fire push-event triggers on workflows like
@@ -270,7 +273,10 @@ jobs:
           GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
           TAG: ${{ matrix.release-name }}
         run: |
-          set -ex
+          set -e
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
           # Match softprops' default `fail_on_unmatched_files: false`:
           # unmatched glob -> empty file list, release still created.
           shopt -s nullglob

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -236,37 +236,31 @@ jobs:
           
       - name: Create Git tag
         env:
-          GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
           TAG: ${{ matrix.release-name }}
           MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
           TARGET_REF: ${{ matrix.canonical-tag }}
-          REPO: ${{ github.repository }}
         run: |
           set -ex
+          # NOTE: the tag is created and pushed via the git CLI rather than
+          # `gh api repos/.../git/{tags,refs}`. Empirically, tag refs created
+          # via the REST API fire push-event triggers on workflows like
+          # Image.yaml (causing spurious failing runs), while runner-side
+          # `git push` of the same ref does not. Using git here preserves
+          # the prior rickstaa/action-create-tag behaviour.
           commit_sha=$(git rev-parse "${TARGET_REF}^{commit}")
-          # Create annotated tag object. Set tagger explicitly to match the
-          # prior rickstaa/action-create-tag behaviour, which used
-          # user.name=$GITHUB_ACTOR and user.email=$GITHUB_ACTOR@users.noreply.github.com.
-          tag_sha=$(gh api "repos/${REPO}/git/tags" \
-            -f tag="${TAG}" \
-            -f message="${MSG}" \
-            -f object="${commit_sha}" \
-            -f type=commit \
-            -f "tagger[name]=${GITHUB_ACTOR}" \
-            -f "tagger[email]=${GITHUB_ACTOR}@users.noreply.github.com" \
-            -f "tagger[date]=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --jq .sha)
-          # Preserve the prior force-push-tag behaviour: update the ref when
-          # it already exists, otherwise create it.
-          if gh api "repos/${REPO}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
-            gh api --method PATCH "repos/${REPO}/git/refs/tags/${TAG}" \
-              -f sha="${tag_sha}" \
-              -F force=true
-          else
-            gh api "repos/${REPO}/git/refs" \
-              -f ref="refs/tags/${TAG}" \
-              -f sha="${tag_sha}"
-          fi
+          # Match the prior tagger identity set by rickstaa/action-create-tag:
+          # user.name=$GITHUB_ACTOR, user.email=$GITHUB_ACTOR@users.noreply.github.com.
+          # The tagger of the annotated tag object is taken from git config at
+          # `git tag -a` time, independent of which token is used for the push.
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          # -f to force-update an existing tag (preserves force_push_tag: true),
+          # -a for annotated, -m for the tag message.
+          git tag -fa "${TAG}" -m "${MSG}" "${commit_sha}"
+          # Push uses the GITHUB_TOKEN-based auth header that actions/checkout
+          # already wired up on `origin`; the job grants `contents: write`,
+          # which is enough to push (and force-update) a tag ref.
+          git push --force origin "refs/tags/${TAG}"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -257,22 +257,14 @@ jobs:
           # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
 
-          # `actions/checkout` installs a GITHUB_TOKEN-based extraheader
-          # on `origin`; swap it for one carrying our token for the push,
-          # then restore the original so the rest of the job sees the
-          # same git config it started with.
-          prev_extraheader=$(git config --local --get "http.https://github.com/.extraheader" || true)
-          git config --local --replace-all \
-            "http.https://github.com/.extraheader" \
-            "AUTHORIZATION: bearer ${GH_TOKEN}"
+          # Clear every inherited http.*.extraheader (actions/checkout's
+          # exact key varies by version) and install ours for the push,
+          # else GitHub rejects with HTTP 400 on duplicate Authorization.
+          git config --local --name-only --get-regexp '^http\..*\.extraheader$' \
+            | xargs -r -n1 git config --local --unset-all
+          git config --local --add "http.https://github.com/.extraheader" "AUTHORIZATION: bearer ${GH_TOKEN}"
           git push --force origin "refs/tags/${TAG}"
-          if [ -n "${prev_extraheader}" ]; then
-            git config --local --replace-all \
-              "http.https://github.com/.extraheader" \
-              "${prev_extraheader}"
-          else
-            git config --local --unset-all "http.https://github.com/.extraheader"
-          fi
+          git config --local --unset-all "http.https://github.com/.extraheader"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -236,6 +236,7 @@ jobs:
           
       - name: Create Git tag
         env:
+          GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
           TAG: ${{ matrix.release-name }}
           MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
           TARGET_REF: ${{ matrix.canonical-tag }}
@@ -245,16 +246,26 @@ jobs:
             set -x
           fi
           # NOTE: using the git CLI rather than `gh api git/{tags,refs}`.
-          # REST-API-created tag refs fire push-event triggers on workflows
-          # like Image.yaml; runner-side `git push` of the same ref does not.
+          # A git-push of a tag pointing at an existing commit produces a
+          # webhook event with an empty `commits` list, so downstream
+          # workflows that filter `on.push` by `paths` (e.g. Image.yaml)
+          # don't retrigger. REST-API ref creation, by contrast, produces
+          # an event that does match those filters.
           # Tagger comes from git config at tag-creation time.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           # Passing TARGET_REF (itself an annotated tag) without peeling
           # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
-          # Push uses the GITHUB_TOKEN auth header wired up by actions/checkout;
-          # the job grants `contents: write`, enough for tag (force-)pushes.
+          # Push with ROCKSBOT_TOKEN. actions/checkout installed a
+          # GITHUB_TOKEN-based extraheader on `origin`; replace it so the
+          # push is authenticated as ROCKsBot. `--replace-all` is needed
+          # because `http.<url>.extraheader` is a multi-valued key, so an
+          # inline `git -c key=val` would append a second header rather
+          # than override.
+          git config --local --replace-all \
+            "http.https://github.com/.extraheader" \
+            "AUTHORIZATION: bearer ${GH_TOKEN}"
           git push --force origin "refs/tags/${TAG}"
 
       - name: Create GitHub release

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -242,10 +242,7 @@ jobs:
           TARGET_REF: ${{ matrix.canonical-tag }}
           REPO: ${{ github.repository }}
         run: |
-          set -e
-          if [[ "$RUNNER_DEBUG" == "1" ]]; then
-            set -x
-          fi
+          set -ex
           commit_sha=$(git rev-parse "${TARGET_REF}^{commit}")
           # Create annotated tag object. Set tagger explicitly to match the
           # prior rickstaa/action-create-tag behaviour, which used
@@ -276,10 +273,7 @@ jobs:
           GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
           TAG: ${{ matrix.release-name }}
         run: |
-          set -e
-          if [[ "$RUNNER_DEBUG" == "1" ]]; then
-            set -x
-          fi
+          set -ex
           # Match softprops' default `fail_on_unmatched_files: false`:
           # unmatched glob -> empty file list, release still created.
           shopt -s nullglob

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -212,10 +212,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ matrix.canonical-tag }}
-          # Drop checkout's auth state after the clone so it doesn't merge
-          # with the auth we install for the `git push` below (which would
-          # send two Authorization headers and trigger HTTP 400).
-          persist-credentials: false
+          # Keep the GITHUB_TOKEN-based auth header that checkout installs on
+          # `origin` to push the new release tag (see below)
+          persist-credentials: true
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -240,8 +239,6 @@ jobs:
           
       - name: Create Git tag
         env:
-          GH_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
-          REPO: ${{ github.repository }}
           TAG: ${{ matrix.release-name }}
           MSG: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
           TARGET_REF: ${{ matrix.canonical-tag }}
@@ -251,12 +248,8 @@ jobs:
             set -x
           fi
 
-          # NOTE: using the git CLI rather than `gh api git/{tags,refs}` since
-          # creating refs via the REST API fires push-event triggers on
-          # workflows like Image.yaml; runner-side `git push` of the same ref
-          # does not.
-
-          # Tagger comes from git config at tag-creation time.
+          # The tag's tagger field comes from git config below, so the tag
+          # object still records ROCKsBot regardless of the push token.
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
@@ -264,12 +257,16 @@ jobs:
           # preserves the prior tag-of-tag chain back to the upload tag.
           git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
 
-          # Push with ROCKSBOT_TOKEN via URL-embedded basic auth. The
-          # checkout step is configured with persist-credentials: false,
-          # so no inherited Authorization header would collide here.
-          git push --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
-            "refs/tags/${TAG}"
+          # NOTE: the tag push below relies on the GITHUB_TOKEN-based auth
+          # header that actions/checkout (persist-credentials: true) wires up
+          # on `origin`. GITHUB_TOKEN-driven pushes are treated specially:
+          # they do NOT trigger downstream workflow runs, so every release
+          # tag we push will not retrigger Image.yaml on the push event.
+          # See: https://docs.github.com/en/actions/concepts/security/github_token
+          # Authenticating with a PAT (e.g. ROCKSBOT_TOKEN) or a GitHub App
+          # installation token would re-enable retriggering -- don't do that.
+
+          git push --force origin "refs/tags/${TAG}"
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -247,7 +247,6 @@ jobs:
           # Image.yaml (causing spurious failing runs), while runner-side
           # `git push` of the same ref does not. Using git here preserves
           # the prior rickstaa/action-create-tag behaviour.
-          commit_sha=$(git rev-parse "${TARGET_REF}^{commit}")
           # Match the prior tagger identity set by rickstaa/action-create-tag:
           # user.name=$GITHUB_ACTOR, user.email=$GITHUB_ACTOR@users.noreply.github.com.
           # The tagger of the annotated tag object is taken from git config at
@@ -256,7 +255,11 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           # -f to force-update an existing tag (preserves force_push_tag: true),
           # -a for annotated, -m for the tag message.
-          git tag -fa "${TAG}" -m "${MSG}" "${commit_sha}"
+          # TARGET_REF is the canonical-tag (an annotated tag itself). Passing
+          # it without peeling preserves the prior tag-of-tag chain, so the
+          # new release tag retains a back-reference to the underlying
+          # upload/canonical tag (which records the revision number).
+          git tag -fa "${TAG}" -m "${MSG}" "${TARGET_REF}"
           # Push uses the GITHUB_TOKEN-based auth header that actions/checkout
           # already wired up on `origin`; the job grants `contents: write`,
           # which is enough to push (and force-update) a tag ref.


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description

attempt at replacing `rickstaa/action-create-tag` and `softprops/action-gh-release` with `gh` equivalents.

### Related issues

closes(?) #1024