### PR TITLE
chore: enroll jdk 25 rock

### DIFF
--- a/oci/jdk/image.yaml
+++ b/oci/jdk/image.yaml
@@ -24,12 +24,13 @@ upload:
           - beta
           - edge
   - source: canonical/jdk-rock
-    commit: 29c8c0d605617acc318d4f253b37b486739a9f90
+    commit: d8577dc136c240b00d3933b96a4887e1d7b8d5e3
     directory: jdk/25-26.04
     release:
       25-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
-        # Use only edge risk until stable rockcraft supports
-        # ubuntu@26.04 base
         risks:
+          - stable
+          - candidate
+          - beta
           - edge

--- a/oci/jdk/image.yaml
+++ b/oci/jdk/image.yaml
@@ -29,10 +29,7 @@ upload:
     release:
       25-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
+        # Use only edge risk until stable rockcraft supports
+        # ubuntu@26.04 base
         risks:
-# Use only edge risk, as ubuntu@26.04 is not yet supported by
-# the stable rockcraft
-#          - stable
-#          - candidate
-#          - beta
           - edge

--- a/oci/jdk/image.yaml
+++ b/oci/jdk/image.yaml
@@ -30,7 +30,4 @@ upload:
       25-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
         risks:
-          - stable
-          - candidate
-          - beta
           - edge

--- a/oci/jdk/image.yaml
+++ b/oci/jdk/image.yaml
@@ -23,3 +23,16 @@ upload:
           - candidate
           - beta
           - edge
+  - source: canonical/jdk-rock
+    commit: 29c8c0d605617acc318d4f253b37b486739a9f90
+    directory: jdk/25-26.04
+    release:
+      25-26.04:
+        end-of-life: "2031-05-29T00:00:00Z"
+        risks:
+# Use only edge risk, as ubuntu@26.04 is not yet supported by
+# the stable rockcraft
+#          - stable
+#          - candidate
+#          - beta
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description

This MR enrolls Java 25 JDK rock for resolute which is the default Java in 26.04.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
