### PR TITLE
chore: enroll jre 25 rock

### DIFF
--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -41,7 +41,4 @@ upload:
       25-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
         risks:
-          - stable
-          - candidate
-          - beta
           - edge

--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -35,12 +35,13 @@ upload:
           - beta
           - edge
   - source: canonical/jre-rock
-    commit: 0e4921c76ba309871b634be3b2ad7b5ac08774d0
+    commit: 1575335eae6ae353360802ca716b78618de14dc5
     directory: jre/25-jre-26.04
     release:
       25-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
-        # Use only edge risk until stable rockcraft supports
-        # ubuntu@26.04 base
         risks:
+          - stable
+          - candidate
+          - beta
           - edge

--- a/oci/jre/image.yaml
+++ b/oci/jre/image.yaml
@@ -34,3 +34,13 @@ upload:
           - candidate
           - beta
           - edge
+  - source: canonical/jre-rock
+    commit: 0e4921c76ba309871b634be3b2ad7b5ac08774d0
+    directory: jre/25-jre-26.04
+    release:
+      25-26.04:
+        end-of-life: "2031-05-29T00:00:00Z"
+        # Use only edge risk until stable rockcraft supports
+        # ubuntu@26.04 base
+        risks:
+          - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
This MR enrolls Java 25 JRE rock for resolute which is the default Java in 26.04.

Note: documentation update will be done in separate PR, blocked on https://github.com/canonical/oci-factory/pull/953

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
