### PR TITLE
chore(ci): apply fixes from zizmor

### DIFF
--- a/.github/actions/upload-rock/action.yml
+++ b/.github/actions/upload-rock/action.yml
@@ -4,19 +4,15 @@ inputs:
   artifact_name:
     description: "The name of the artifact to download"
     required: true
-    type: string
   name:
     description: "The name of the image to upload. This should include the namespace if applicable."
     required: true
-    type: string
   tags:
     description: "The tags to use for the image"
     required: true
-    type: string
   registry:
     description: "The container registry URL"
     required: true
-    type: string
   username:
     description: "The username for the container registry"
     required: true

--- a/.github/workflows/Announcements.yaml
+++ b/.github/workflows/Announcements.yaml
@@ -19,17 +19,21 @@ jobs:
       oci-img-name: ${{ steps.get-image-name.outputs.img-name }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Get image name
         id: get-image-name
         run: |
-          all_images=`ls oci/`
-          for img in $all_images
+          for img in oci/*/
           do
-            if [[ "${{ env.NAME }}" == "${img}_"* ]] || [[ "${{ env.NAME }}" == "oci-factory/${img}"* ]]
+            img="${img%/}"   # strip trailing slash
+            img_name="${img#oci/}"  # strip leading oci/
+            # shellcheck disable=SC2193
+            if [[ "${NAME}" == "${img_name}_"* ]] || [[ "${NAME}" == "oci-factory/${img_name}"* ]]
             then
-              echo "Image name: ${img}" >> "$GITHUB_STEP_SUMMARY"
-              echo "img-name=${img}" >> "$GITHUB_OUTPUT"
+              echo "Image name: ${img_name}" >> "$GITHUB_STEP_SUMMARY"
+              echo "img-name=${img_name}" >> "$GITHUB_OUTPUT"
             fi
           done
 
@@ -56,14 +60,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Build release summary
         id: get-summary
         run: |
-          summary=":rocket: **${{ needs.get-contacts.outputs.oci-img-name }}** released to"
-          summary="${summary} [${{ env.NAME }}](${{ github.event.release.html_url }})"
+          summary=":rocket: **${NEEDS_GET_CONTACTS_OUTPUTS_OCI_IMG_NAME}** released to"
+          summary="${summary} [${NAME}](${GITHUB_EVENT_RELEASE_HTML_URL})"
 
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
+        env:
+          NEEDS_GET_CONTACTS_OUTPUTS_OCI_IMG_NAME: ${{ needs.get-contacts.outputs.oci-img-name }}
+          GITHUB_EVENT_RELEASE_HTML_URL: ${{ github.event.release.html_url }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -80,8 +89,9 @@ jobs:
           SUMMARY: "${{ steps.get-summary.outputs.summary }}"
           FOOTER: ''
           TITLE: ''
+          NEEDS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS: ${{ needs.get-contacts.outputs.mattermost-channels }}
         run: |
-          for channel in $(echo ${{ needs.get-contacts.outputs.mattermost-channels }} | tr ',' ' ')
+          for channel in $(echo ${NEEDS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS} | tr ',' ' ')
           do
             MM_CHANNEL_ID="${channel}" python3 -m src.notifications.mattermost_notifier send
           done
@@ -94,15 +104,22 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Build package summary
         id: get-summary
         run: |
-          summary=":package: **${{ needs.get-contacts.outputs.oci-img-name }}** built and uploaded to"
-          summary="${summary} GHCR on [${{ github.event.registry_package.package_version.package_url }}](${{ github.event.registry_package.package_version.html_url }})"
-          summary="${summary}\n"'```\n${{ github.event.registry_package.package_version.installation_command }}\n```'
+          summary=":package: **${NEEDS_GET_CONTACTS_OUTPUTS_OCI_IMG_NAME}** built and uploaded to"
+          summary="${summary} GHCR on [${GITHUB_EVENT_REGISTRY_PACKAGE_PACKAGE_VERSION_PACKAGE_URL}](${GITHUB_EVENT_REGISTRY_PACKAGE_PACKAGE_VERSION_HTML_URL})"
+          summary="${summary}\n\`\`\`\n${GITHUB_EVENT_REGISTRY_PACKAGE_PACKAGE_VERSION_INSTALLATION_COMMAND}\n\`\`\`"
 
           echo "summary=${summary}" >> "$GITHUB_OUTPUT"
+        env:
+          NEEDS_GET_CONTACTS_OUTPUTS_OCI_IMG_NAME: ${{ needs.get-contacts.outputs.oci-img-name }}
+          GITHUB_EVENT_REGISTRY_PACKAGE_PACKAGE_VERSION_PACKAGE_URL: ${{ github.event.registry_package.package_version.package_url }}
+          GITHUB_EVENT_REGISTRY_PACKAGE_PACKAGE_VERSION_HTML_URL: ${{ github.event.registry_package.package_version.html_url }}
+          GITHUB_EVENT_REGISTRY_PACKAGE_PACKAGE_VERSION_INSTALLATION_COMMAND: ${{ github.event.registry_package.package_version.installation_command }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -119,8 +136,9 @@ jobs:
           SUMMARY: '${{ steps.get-summary.outputs.summary }}'
           FOOTER: ''
           TITLE: ''
+          NEEDS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS: ${{ needs.get-contacts.outputs.mattermost-channels }}
         run: |
-          for channel in $(echo ${{ needs.get-contacts.outputs.mattermost-channels }} | tr ',' ' ')
+          for channel in $(echo ${NEEDS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS} | tr ',' ' ')
           do
             MM_CHANNEL_ID="${channel}" python3 -m src.notifications.mattermost_notifier send
           done

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Building Target
         id: rockcraft
-        uses: canonical/craft-actions/rockcraft-pack@210d55fa6cb7a1ab39e3194315d6a03249af3d34  # main (20260526)
+        uses: canonical/craft-actions/rockcraft-pack@67304fab78ef627dc3f2e72c8a6ad51a493a6070  # main (20260605)
         with:
           path: "${{ env.ROCK_REPO_DIR }}/${{ inputs.rockfile-directory }}"
           test: "${{ inputs.rockcraft-test }}"
@@ -277,7 +277,7 @@ jobs:
       - name: Collecting Artifacts
         id: collect-artifacts
         run: |
-          mkdir -p "${{ env.ROCK_CI_FOLDER }}" && cp "${{ env.ROCK_REPO_DIR }}/${INPUTS_ROCKFILE_DIRECTORY}"/*.rock "$_"
+          mkdir -p "${ROCK_CI_FOLDER}" && cp "${ROCK_REPO_DIR}/${INPUTS_ROCKFILE_DIRECTORY}"/*.rock "$_"
           echo "filename=${MATRIX_ROCK_NAME}_${MATRIX_ARCHITECTURE}" >> "$GITHUB_OUTPUT"
         env:
           INPUTS_ROCKFILE_DIRECTORY: ${{ inputs.rockfile-directory }}
@@ -335,7 +335,7 @@ jobs:
         run: |
           src/build_rock/assemble_rock/assemble.sh \
             -n "${INPUTS_OCI_ARCHIVE_NAME}" \
-            -d "${{ env.ROCK_CI_FOLDER }}"
+            -d "${ROCK_CI_FOLDER}"
         env:
           INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
       

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -64,6 +64,7 @@ on:
       pro-token:
         description: "The Ubuntu Pro token. Required for building Ubuntu Pro based rocks."
 
+
 env:
   ROCK_REPO_DIR: rock-repo  # path where the image repo is cloned into
   ROCK_CI_FOLDER: ci-rocks  # path of uploaded/downloaded artifacts
@@ -96,15 +97,16 @@ jobs:
         id: check-pro-build
         env:
           UBUNTU_PRO_TOKEN: ${{ secrets.pro-token }}
+          INPUTS_PRO_SERVICES: ${{ inputs.pro-services }}
         run: |
-          if [[ -n "${{ inputs.pro-services }}" ]]; then
+          if [[ -n "${INPUTS_PRO_SERVICES}" ]]; then
             if [[ -z "${UBUNTU_PRO_TOKEN:-}" ]]; then
               echo "Error: 'pro-token' must be provided in order to use 'pro-services'."
               exit 1
             fi
-            echo "pro-build=true" >> $GITHUB_OUTPUT
+            echo "pro-build=true" >> "$GITHUB_OUTPUT"
           else
-            echo "pro-build=false" >> $GITHUB_OUTPUT
+            echo "pro-build=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Cloning OCI Factory
@@ -115,6 +117,7 @@ jobs:
           # or to the default branch of the oci-factory repo if the workflow is called from another repo.
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Cloning Target Repo
         uses: ./.github/actions/checkout
@@ -140,9 +143,12 @@ jobs:
         id: configure
         run: |
           python3 -m src.build_rock.configure.generate_build_matrix \
-            --rockfile-directory "${{ env.ROCK_REPO_DIR }}/${{ inputs.rockfile-directory }}" \
+            --rockfile-directory "${{ env.ROCK_REPO_DIR }}/${INPUTS_ROCKFILE_DIRECTORY}" \
             --lpci-fallback "${{ toJSON(inputs.lpci-fallback) }}" \
-            --config ${{ toJSON(inputs.arch-map || env.DEFAULT_ARCH_MAP) }} # important: do not use quotes here
+            --config $INPUTS_ARCH_MAP # important: do not use quotes here
+        env:
+          INPUTS_ROCKFILE_DIRECTORY: ${{ inputs.rockfile-directory }}
+          INPUTS_ARCH_MAP: ${{ toJSON(inputs.arch-map || env.DEFAULT_ARCH_MAP) }}
 
   runner-build:
     # runner-build builds rocks per target architecture using pre configured runner images.
@@ -160,6 +166,7 @@ jobs:
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Cloning Target Repo
         uses: ./.github/actions/checkout
@@ -182,7 +189,7 @@ jobs:
 
       - name: Building Target
         id: rockcraft
-        uses: canonical/craft-actions/rockcraft-pack@main
+        uses: canonical/craft-actions/rockcraft-pack@210d55fa6cb7a1ab39e3194315d6a03249af3d34  # main (20260526)
         with:
           path: "${{ env.ROCK_REPO_DIR }}/${{ inputs.rockfile-directory }}"
           test: "${{ inputs.rockcraft-test }}"
@@ -197,8 +204,8 @@ jobs:
       - name: Collecting Artifacts
         id: collect-artifacts
         run: |
-          mkdir -p ${{ env.ROCK_CI_FOLDER }} && cp ${{ steps.rockcraft.outputs.rock }} "$_"
-          echo "filename=$(basename ${{ steps.rockcraft.outputs.rock }})" >> $GITHUB_OUTPUT
+          mkdir -p "${{ env.ROCK_CI_FOLDER }}" && cp "${{ steps.rockcraft.outputs.rock }}" "$_"
+          echo "filename=$(basename "${{ steps.rockcraft.outputs.rock }}")" >> "$GITHUB_OUTPUT"
 
       - name: Encrypting Single Arch Rock Artifacts
         if: ${{ needs.configure-build.outputs.pro-build == 'true' }}
@@ -236,6 +243,7 @@ jobs:
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Cloning Target Repo
         uses: ./.github/actions/checkout
@@ -270,8 +278,12 @@ jobs:
       - name: Collecting Artifacts
         id: collect-artifacts
         run: |
-          mkdir -p ${{ env.ROCK_CI_FOLDER }} && cp ${{ env.ROCK_REPO_DIR }}/${{ inputs.rockfile-directory }}/*.rock "$_"
-          echo "filename=${{ matrix.rock-name }}_${{ matrix.architecture }}" >> $GITHUB_OUTPUT
+          mkdir -p "${{ env.ROCK_CI_FOLDER }}" && cp "${{ env.ROCK_REPO_DIR }}/${INPUTS_ROCKFILE_DIRECTORY}"/*.rock "$_"
+          echo "filename=${MATRIX_ROCK_NAME}_${MATRIX_ARCHITECTURE}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_ROCKFILE_DIRECTORY: ${{ inputs.rockfile-directory }}
+          MATRIX_ROCK_NAME: ${{ matrix.rock-name }}
+          MATRIX_ARCHITECTURE: ${{ matrix.architecture }}
 
       - name: Uploading Artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
@@ -295,6 +307,7 @@ jobs:
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - run: src/build_rock/assemble_rock/requirements.sh
       - name: Downloading Single Arch rocks
@@ -322,17 +335,22 @@ jobs:
       - name: Assembling Multi Arch rock
         run: |
           src/build_rock/assemble_rock/assemble.sh \
-            -n "${{ inputs.oci-archive-name }}" \
+            -n "${INPUTS_OCI_ARCHIVE_NAME}" \
             -d "${{ env.ROCK_CI_FOLDER }}"
+        env:
+          INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
       
       - name: Get artifact name
         id: final-artifact
         run: |
-          name="${{ inputs.oci-archive-name }}"
-          if [[ ${{ needs.configure-build.outputs.pro-build }} == 'true' ]]; then
+          name="${INPUTS_OCI_ARCHIVE_NAME}"
+          if [[ ${NEEDS_CONFIGURE_BUILD_OUTPUTS_PRO_BUILD} == 'true' ]]; then
             name="${name}.gpg"
           fi
-          echo "name=$name" >> $GITHUB_OUTPUT
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
+          NEEDS_CONFIGURE_BUILD_OUTPUTS_PRO_BUILD: ${{ needs.configure-build.outputs.pro-build }}
 
       - name: Encrypting Multi Arch Rock Artifact
         if: ${{ needs.configure-build.outputs.pro-build == 'true' }}

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -145,10 +145,9 @@ jobs:
           python3 -m src.build_rock.configure.generate_build_matrix \
             --rockfile-directory "${{ env.ROCK_REPO_DIR }}/${INPUTS_ROCKFILE_DIRECTORY}" \
             --lpci-fallback "${{ toJSON(inputs.lpci-fallback) }}" \
-            --config $INPUTS_ARCH_MAP # important: do not use quotes here
+            --config ${{ toJSON(inputs.arch-map || env.DEFAULT_ARCH_MAP) }} # important: do not use quotes here
         env:
           INPUTS_ROCKFILE_DIRECTORY: ${{ inputs.rockfile-directory }}
-          INPUTS_ARCH_MAP: ${{ toJSON(inputs.arch-map || env.DEFAULT_ARCH_MAP) }}
 
   runner-build:
     # runner-build builds rocks per target architecture using pre configured runner images.

--- a/.github/workflows/CLA-Check.yaml
+++ b/.github/workflows/CLA-Check.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v2
+        uses: canonical/has-signed-canonical-cla@19bae73390fdbfdc1ef9a9bb9408d87a1de755f6  # v2 (20260526)
 
   update-pr:
     runs-on: ubuntu-22.04

--- a/.github/workflows/CLA-Check.yaml
+++ b/.github/workflows/CLA-Check.yaml
@@ -17,9 +17,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
-        with:
-          message: |
-            @${{ github.actor }} please make sure all PR contributors have signed the CLA.
-          comment_tag: cla-check
-          mode: recreate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          gh pr comment "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --body "@${ACTOR} please make sure all PR contributors have signed the CLA."

--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -13,6 +13,8 @@ jobs:
       last-scan: ${{ steps.last-scan.outputs.date }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
@@ -25,7 +27,7 @@ jobs:
 
       - name: Prepare test matrix
         id: prepare-test-matrix
-        run: python3 -m src.tests.get_released_revisions --oci-images-path $PWD/oci
+        run: python3 -m src.tests.get_released_revisions --oci-images-path "$PWD/oci"
 
       - name: Infer date of last scan
         id: last-scan

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -38,9 +38,13 @@ jobs:
     steps:
       - name: ${{ inputs.external_ref_id }}  # (2)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
+        run: echo 'Started by ${INPUTS_EXTERNAL_REF_ID}' >> "$GITHUB_STEP_SUMMARY"
+        env:
+          INPUTS_EXTERNAL_REF_ID: ${{ inputs.external_ref_id }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -71,11 +75,11 @@ jobs:
 
           # check if this is coming from a workflow dispatch/call
           # as checking github.event_name isn't reliable here
-          if [ "${{ inputs.oci-image-name }}" != "" ]
+          if [ "${INPUTS_OCI_IMAGE_NAME}" != "" ]
           then
-            img_path="oci/${{ inputs.oci-image-name }}"
+            img_path="oci/${INPUTS_OCI_IMAGE_NAME}"
           else
-            img_path="${{ steps.changed-files.outputs.all_changed_files }}"
+            img_path="${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
             occurrences="${img_path//[^,]}"
             if [ ${#occurrences} -ne 0 ]
             then
@@ -86,6 +90,9 @@ jobs:
           test -d "${img_path}"
           echo "img-name=$(basename ${img_path})" >> "$GITHUB_OUTPUT"
           echo "img-path=${img_path}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
 
   do-documentation:
@@ -96,12 +103,15 @@ jobs:
       IS_PROD: ${{ ! startsWith(needs.validate-documentation-request.outputs.oci-img-name, 'mock-') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       # This is needed to ensure that this workflow can run when called by workflows in external repositories
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           path: oci-factory
+          persist-credentials: false
 
       - name: Fetch _releases.json
         uses: ./oci-factory/.github/actions/fetch-releases-json
@@ -122,6 +132,7 @@ jobs:
           ECR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ECR_CREDS_PSW || secrets.ECR_CREDS_PSW_DEV }}
           ECR_NAMESPACE: ${{ env.IS_PROD == 'true' && 'ubuntu' || secrets.ECR_NAMESPACE_DEV }}
           DRY_RUN_FLAG: ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+          NEEDS_VALIDATE_DOCUMENTATION_REQUEST_OUTPUTS_OCI_IMG_PATH: ${{ needs.validate-documentation-request.outputs.oci-img-path }}
         run: |
           set -e
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
@@ -130,10 +141,10 @@ jobs:
           python3 -m src.docs.generate_oci_doc_yaml \
             --ecr-api-key "${ECR_CREDS_USR}" \
             --ecr-api-secret "${ECR_CREDS_PSW}" \
-            --oci-image-path "${{ needs.validate-documentation-request.outputs.oci-img-path }}" \
+            --oci-image-path "${NEEDS_VALIDATE_DOCUMENTATION_REQUEST_OUTPUTS_OCI_IMG_PATH}" \
             --repository "${ECR_NAMESPACE}" \
             --doc-data-dir data \
-            ${DRY_RUN_FLAG}
+            ${DRY_RUN_FLAG:+${DRY_RUN_FLAG}}
 
       - name: Upload documentation data YAML
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
@@ -156,18 +167,24 @@ jobs:
           ECR_REGISTRY_ID: ${{ env.IS_PROD == 'true' && secrets.ECR_REGISTRY_ID || secrets.ECR_REGISTRY_ID_DEV }}
           DOCKER_HUB_NAMESPACE: ${{ env.IS_PROD == 'true' && 'docker.io/ubuntu' || secrets.DOCKER_HUB_NAMESPACE_DEV }}
           DRY_RUN: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          NEEDS_VALIDATE_DOCUMENTATION_REQUEST_OUTPUTS_OCI_IMG_NAME: ${{ needs.validate-documentation-request.outputs.oci-img-name }}
+          STEPS_GENERATE_DOCUMENTATION_OUTPUTS_NAME_DOC_FILE: ${{ steps.generate-documentation.outputs.name_doc_file }}
+          STEPS_GENERATE_DOCUMENTATION_OUTPUTS_IMAGE_DOC_FOLDER: ${{ steps.generate-documentation.outputs.image_doc_folder }}
         run: |
           set -e
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          ./src/docs/publish_docs.sh "${{ needs.validate-documentation-request.outputs.oci-img-name }}" "${{ steps.generate-documentation.outputs.name_doc_file }}" "${{ steps.generate-documentation.outputs.image_doc_folder }}"
+          ./src/docs/publish_docs.sh "${NEEDS_VALIDATE_DOCUMENTATION_REQUEST_OUTPUTS_OCI_IMG_NAME}" "${STEPS_GENERATE_DOCUMENTATION_OUTPUTS_NAME_DOC_FILE}" "${STEPS_GENERATE_DOCUMENTATION_OUTPUTS_IMAGE_DOC_FOLDER}"
 
       - name: Write documentation preview to summary
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          echo "# Preview for ${{ needs.validate-documentation-request.outputs.oci-img-name }}" >> "$GITHUB_STEP_SUMMARY"
-          cat "${{ steps.generate-documentation.outputs.image_doc_folder }}/doc-preview.md" >> "$GITHUB_STEP_SUMMARY"
+          echo "# Preview for ${NEEDS_VALIDATE_DOCUMENTATION_REQUEST_OUTPUTS_OCI_IMG_NAME}" >> "$GITHUB_STEP_SUMMARY"
+          cat "${STEPS_GENERATE_DOCUMENTATION_OUTPUTS_IMAGE_DOC_FOLDER}/doc-preview.md" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          NEEDS_VALIDATE_DOCUMENTATION_REQUEST_OUTPUTS_OCI_IMG_NAME: ${{ needs.validate-documentation-request.outputs.oci-img-name }}
+          STEPS_GENERATE_DOCUMENTATION_OUTPUTS_IMAGE_DOC_FOLDER: ${{ steps.generate-documentation.outputs.image_doc_folder }}
 
 
   notify:
@@ -177,6 +194,8 @@ jobs:
     if: ${{ !cancelled() && contains(needs.*.result, 'failure') && github.event_name != 'workflow_dispatch' && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -206,8 +225,9 @@ jobs:
           SUMMARY: ${{ steps.get-summary.outputs.summary }}
           FOOTER: "Triggered by ${{ github.triggering_actor }}. Ref: ${{ github.ref }}. Attempts: ${{ github.run_attempt }}"
           TITLE: '${{ needs.validate-documentation-request.outputs.oci-img-name }}: failed to generate docs'
+          STEPS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS: ${{ steps.get-contacts.outputs.mattermost-channels }}
         run: |
-          for channel in $(echo ${{ steps.get-contacts.outputs.mattermost-channels }} | tr ',' ' ')
+          for channel in $(echo ${STEPS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS} | tr ',' ' ')
           do
             MM_CHANNEL_ID="${channel}" python3 -m src.notifications.mattermost_notifier send
           done

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -3,6 +3,10 @@ run-name: "Image - ${{ inputs.oci-image-name || github.triggering_actor }} - ${{
 
 on:
   push:
+    branches:
+      - main
+    tags-ignore:
+      - '*'
     paths:
       - "oci/*/image.y*ml"
       - "!oci/mock*"

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -37,7 +37,6 @@ on:
         required: true
       upload:
         description: "Upload image to GHCR"
-        required: true
         type: boolean
         default: false
 
@@ -57,9 +56,13 @@ jobs:
     steps:
       - name: ${{ inputs.external_ref_id }}  # (2)
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
+        run: echo 'Started by ${INPUTS_EXTERNAL_REF_ID}' >> "$GITHUB_STEP_SUMMARY"
+        env:
+          INPUTS_EXTERNAL_REF_ID: ${{ inputs.external_ref_id }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Infer number of image triggers
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
@@ -83,11 +86,11 @@ jobs:
 
           # check if this is coming from a workflow dispatch/call
           # as checking github.event_name isn't reliable here
-          if [ "${{ inputs.oci-image-name }}" != "" ]
+          if [ "${INPUTS_OCI_IMAGE_NAME}" != "" ]
           then
-            img_path="oci/${{ inputs.oci-image-name }}"
+            img_path="oci/${INPUTS_OCI_IMAGE_NAME}"
           else
-            img_path="${{ steps.changed-files.outputs.all_changed_files }}"
+            img_path="${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
             occurrences="${img_path//[^,]}"
             if [ ${#occurrences} -ne 0 ]
             then
@@ -99,6 +102,9 @@ jobs:
 
           echo "img-name=$(basename ${img_path})" >> "$GITHUB_OUTPUT"
           echo "img-path=${img_path}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -110,7 +116,10 @@ jobs:
 
       - name: Use custom image trigger
         if: ${{ inputs.b64-image-trigger != '' }}
-        run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ steps.validate-image.outputs.img-path }}/image.yaml
+        run: echo ${INPUTS_B64_IMAGE_TRIGGER} | base64 -d > ${STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH}/image.yaml
+        env:
+          INPUTS_B64_IMAGE_TRIGGER: ${{ inputs.b64-image-trigger }}
+          STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH: ${{ steps.validate-image.outputs.img-path }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -122,11 +131,12 @@ jobs:
         id: prepare-matrix
         env:
           DATA_DIR: "revision-data"
+          STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH: ${{ steps.validate-image.outputs.img-path }}
         run: |
           mkdir ${{ env.DATA_DIR }}
 
           python3 -m src.image.prepare_single_image_build_matrix \
-            --oci-path ${{ steps.validate-image.outputs.img-path }} \
+            --oci-path ${STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH} \
             --revision-data-dir ${{ env.DATA_DIR }} \
             --warn-image-eol-exceeds-base-eol
 
@@ -143,6 +153,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Clone GitHub image repository
         uses: ./.github/actions/checkout
@@ -158,13 +169,16 @@ jobs:
       - name: Validate image naming and base
         run: |
           source src/shared/logs.sh
-          rock_name=`cat "${{ env.ROCK_REPO_DIR }}/${{ matrix.directory }}"/rockcraft.y*ml | yq -r .name`
-          folder_name="${{ env.ROCK_REPO_DIR }}/${{ matrix.path }}"
+          rock_name=$(cat "${{ env.ROCK_REPO_DIR }}/${MATRIX_DIRECTORY}"/rockcraft.y*ml | yq -r .name)
+          folder_name="${{ env.ROCK_REPO_DIR }}/${MATRIX_PATH}"
           if [[ "${folder_name}" != *"${rock_name}"* ]]
           then
             log_error "the OCI folder name '${folder_name}', must contain the rock's name '${rock_name}'."
             exit 1
           fi
+        env:
+          MATRIX_DIRECTORY: ${{ matrix.directory }}
+          MATRIX_PATH: ${{ matrix.path }}
 
   build-rock:
     needs: [prepare-build, validate-matrix]
@@ -213,10 +227,15 @@ jobs:
       revision-data-cache-key: ${{ steps.prepare-matrix.outputs.revision-data-cache-key }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Use custom image trigger
         if: ${{ inputs.b64-image-trigger != '' }}
-        run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
+        run: echo ${INPUTS_B64_IMAGE_TRIGGER} | base64 -d > ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}/image.yaml
+        env:
+          INPUTS_B64_IMAGE_TRIGGER: ${{ inputs.b64-image-trigger }}
+          NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH: ${{ needs.prepare-build.outputs.oci-img-path }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -230,7 +249,9 @@ jobs:
         id: swift-lock
         run: |
           ./src/uploads/swift_lockfile_lock.sh \
-            ${{ needs.prepare-build.outputs.oci-img-name }}
+            ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME}
+        env:
+          NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME: ${{ needs.prepare-build.outputs.oci-img-name }}
 
       # Here starts the critical section, have to be executed in sequence outside of matrix.
       - name: Get next revision number
@@ -248,12 +269,15 @@ jobs:
           mkdir ${{ env.DATA_DIR }}
 
           python3 -m src.image.prepare_single_image_build_matrix \
-            --oci-path ${{ needs.prepare-build.outputs.oci-img-path }} \
+            --oci-path ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH} \
             --revision-data-dir ${{ env.DATA_DIR }} \
-            --next-revision ${{ steps.get-next-revision.outputs.revision }} \
+            --next-revision ${STEPS_GET_NEXT_REVISION_OUTPUTS_REVISION} \
             --infer-image-track
 
           echo "revision-data-cache-key=${{ github.run_id }}-${{ env.DATA_DIR }}-$(date +%s)" >> "$GITHUB_OUTPUT"
+        env:
+          NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH: ${{ needs.prepare-build.outputs.oci-img-path }}
+          STEPS_GET_NEXT_REVISION_OUTPUTS_REVISION: ${{ steps.get-next-revision.outputs.revision }}
 
       - name: Preempt Swift slot
         run: |
@@ -269,7 +293,9 @@ jobs:
         if: ${{ always() && steps.swift-lock.outcome != 'failure' }}
         run: |
           ./src/uploads/swift_lockfile_unlock.sh \
-            ${{ needs.prepare-build.outputs.oci-img-name }}
+            ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME}
+        env:
+          NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME: ${{ needs.prepare-build.outputs.oci-img-name }}
 
       - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
@@ -296,6 +322,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -322,12 +350,16 @@ jobs:
         id: rename-oci-archive
         run: |
           # Rename the OCI archive tarball
-          canonical_tag="${{ matrix.track }}_${{ matrix.revision }}"
-          name="${{ matrix.name }}_${canonical_tag}"
-          mv ${{ env.OCI_ARCHIVE_NAME }} $name
+          canonical_tag="${MATRIX_TRACK}_${MATRIX_REVISION}"
+          name="${MATRIX_NAME}_${canonical_tag}"
+          mv ${OCI_ARCHIVE_NAME} $name
 
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "canonical-tag=${canonical_tag}" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_TRACK: ${{ matrix.track }}
+          MATRIX_REVISION: ${{ matrix.revision }}
+          MATRIX_NAME: ${{ matrix.name }}
 
       - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
@@ -348,12 +380,14 @@ jobs:
           fi
           source src/shared/logs.sh
           arches=$(skopeo inspect --raw \
-            oci-archive:${{ steps.rename-oci-archive.outputs.name }} \
+            oci-archive:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME} \
             | jq -r 'if has("manifests") then .manifests[].platform.architecture else "${{ runner.arch }}" end' \
             | jq -nRcr '[inputs] | join(",")')
 
           log_info "Detected architectures: ${arches}"
           echo "arches='${arches}'" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME: ${{ steps.rename-oci-archive.outputs.name }}
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -377,9 +411,9 @@ jobs:
             set -x
           fi
           source src/shared/logs.sh
-          log_info "Generating SBOMs for ${{ steps.get-arches.outputs.arches }}"
+          log_info "Generating SBOMs for ${STEPS_GET_ARCHES_OUTPUTS_ARCHES}"
 
-          IFS=',' read -ra arch_list <<< ${{ steps.get-arches.outputs.arches }}
+          IFS=',' read -ra arch_list <<< "${STEPS_GET_ARCHES_OUTPUTS_ARCHES}"
           for arch in "${arch_list[@]}"; do
             if [[ "${arch}" == "unknown" ]]; then
               continue
@@ -387,30 +421,34 @@ jobs:
 
             log_info "Generate SBOM for ${arch}"
 
-            skopeo --override-arch $arch copy \
-              oci-archive:${{ steps.rename-oci-archive.outputs.name }} \
-              oci:${{ steps.rename-oci-archive.outputs.name }}.${arch}:${{ steps.rename-oci-archive.outputs.canonical-tag }} \
+            skopeo --override-arch "${arch}" copy \
+              "oci-archive:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}" \
+              "oci:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_CANONICAL_TAG}" \
 
-            syft oci-dir:${{ steps.rename-oci-archive.outputs.name }}.${arch} \
+            syft "oci-dir:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}" \
               -o spdx-json \
-              --file ${{ steps.rename-oci-archive.outputs.name }}.${arch}.sbom_preview.spdx.json
+              --file "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}.sbom_preview.spdx.json"
 
             umoci unpack \
               --keep-dirlinks --rootless \
-              --image ${{ steps.rename-oci-archive.outputs.name }}.${arch}:${{ steps.rename-oci-archive.outputs.canonical-tag }} \
-              ${{ steps.rename-oci-archive.outputs.name }}.${arch}-bundle
+              --image "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_CANONICAL_TAG}" \
+              "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}-bundle"
 
-            if [[ -f  "${{ steps.rename-oci-archive.outputs.name }}.${arch}-bundle/rootfs/var/lib/chisel/manifest.wall" ]]; then
-              ssbom ${{ steps.rename-oci-archive.outputs.name }}.${arch}-bundle/rootfs \
-                    ${{ steps.rename-oci-archive.outputs.name }}.${arch}.chiselled.sbom_preview.spdx.json
+            if [[ -f  "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}-bundle/rootfs/var/lib/chisel/manifest.wall" ]]; then
+              ssbom "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}-bundle/rootfs" \
+                    "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}.chiselled.sbom_preview.spdx.json"
             fi
 
           done
 
-          all_sboms_zip="${{ steps.rename-oci-archive.outputs.name }}.sbom_preview.spdx.zip"
-          zip "${all_sboms_zip}" ${{ steps.rename-oci-archive.outputs.name }}.*.sbom_preview.spdx.json
+          all_sboms_zip="${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.sbom_preview.spdx.zip"
+          zip "${all_sboms_zip}" "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}".*.sbom_preview.spdx.json
 
           echo "sboms=${all_sboms_zip}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_GET_ARCHES_OUTPUTS_ARCHES: ${{ steps.get-arches.outputs.arches }}
+          STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME: ${{ steps.rename-oci-archive.outputs.name }}
+          STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_CANONICAL_TAG: ${{ steps.rename-oci-archive.outputs.canonical-tag }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -428,7 +466,7 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          echo "hashes=$(sha256sum ${{ env.VULN_REPORT }} ${{ env.OCI_IMAGE_ARCHIVE }} ${{ env.SBOMS }} | base64 -w0)"
+          echo "hashes=$(sha256sum ${VULN_REPORT} ${OCI_IMAGE_ARCHIVE} ${SBOMS} | base64 -w0)"
 
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
@@ -471,19 +509,26 @@ jobs:
           OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL }}
           IMAGE_NAME: ${{ matrix.name }}
           SWIFT_CONTAINER_NAME: ${{ vars.SWIFT_CONTAINER_NAME }}
+          MATRIX_BASE: ${{ matrix.base }}
+          STEPS_UPLOAD_IMAGE_OUTPUTS_DIGEST: ${{ steps.upload-image.outputs.digest }}
+          MATRIX_IGNORED_VULNERABILITIES: ${{ matrix.ignored-vulnerabilities }}
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_TRACK: ${{ matrix.track }}
+          MATRIX_REVISION: ${{ matrix.revision }}
+          STEPS_GENERATE_SBOMS_OUTPUTS_SBOMS: ${{ steps.generate-sboms.outputs.sboms }}
         run: |
-          jq --arg base "${{ matrix.base }}" \
-            --arg digest "${{ steps.upload-image.outputs.digest }}" \
-            --arg ignored_vulnerabilities "${{ matrix.ignored-vulnerabilities }}" \
+          jq --arg base "${MATRIX_BASE}" \
+            --arg digest "${STEPS_UPLOAD_IMAGE_OUTPUTS_DIGEST}" \
+            --arg ignored_vulnerabilities "${MATRIX_IGNORED_VULNERABILITIES}" \
             '. + {base: $base, digest: $digest, "ignored-vulnerabilities": $ignored_vulnerabilities}' \
             <<< '${{ toJSON(matrix) }}' > build_metadata.json
           ./src/uploads/upload_to_swift.sh \
-            ${{ matrix.name }} \
-            ${{ matrix.track }} \
-            ${{ matrix.revision }} \
+            ${MATRIX_NAME} \
+            ${MATRIX_TRACK} \
+            ${MATRIX_REVISION} \
             build_metadata.json \
-            ${{ steps.generate-sboms.outputs.sboms }} \
-            ${{ env.OCI_ARCHIVE_NAME }}${{ env.VULNERABILITY_REPORT_SUFFIX }}
+            ${STEPS_GENERATE_SBOMS_OUTPUTS_SBOMS} \
+            ${OCI_ARCHIVE_NAME}${{ env.VULNERABILITY_REPORT_SUFFIX }}
 
       - name: Create Git tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
@@ -517,7 +562,10 @@ jobs:
 
       - name: Use custom image trigger
         if: ${{ inputs.b64-image-trigger != '' }}
-        run: echo ${{ inputs.b64-image-trigger }} | base64 -d > ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
+        run: echo ${INPUTS_B64_IMAGE_TRIGGER} | base64 -d > ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}/image.yaml
+        env:
+          INPUTS_B64_IMAGE_TRIGGER: ${{ inputs.b64-image-trigger }}
+          NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH: ${{ needs.prepare-build.outputs.oci-img-path }}
 
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
@@ -531,16 +579,18 @@ jobs:
         id: merge-release-requests
         env:
           PYTHONUNBUFFERED: 1
+          NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH: ${{ needs.prepare-build.outputs.oci-img-path }}
         run: |
           set -e
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
           source src/shared/logs.sh
-          for revision_file in `ls ${{ env.REVISION_DATA_DIR }}`
+          for revision_file in "${{ env.REVISION_DATA_DIR }}"/*
           do
+            revision_file="$(basename "${revision_file}")"
             ret=0
-            release=$(jq -er .release < ${{ env.REVISION_DATA_DIR }}/$revision_file) || ret=1
+            jq -er .release < "${{ env.REVISION_DATA_DIR }}/${revision_file}" > /dev/null || ret=1
 
             if [ $ret -eq 1 ]
             then
@@ -551,7 +601,7 @@ jobs:
             log_info "Merge revision $revision_file with requested releases"
 
             python3 -m src.image.merge_release_info \
-              --image-trigger "${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml" \
+              --image-trigger "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}/image.yaml" \
               --revision-data-file "${{ env.REVISION_DATA_DIR }}/${revision_file}"
           done
 
@@ -648,6 +698,8 @@ jobs:
     if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -677,8 +729,9 @@ jobs:
           SUMMARY: ${{ steps.get-summary.outputs.summary }}
           FOOTER: "Triggered by ${{ github.triggering_actor }}. Ref: ${{ github.ref }}. Attempts: ${{ github.run_attempt }}"
           TITLE: "${{ needs.prepare-build.outputs.oci-img-name }}: failed to build->upload->release"
+          STEPS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS: ${{ steps.get-contacts.outputs.mattermost-channels }}
         run: |
-          for channel in $(echo ${{ steps.get-contacts.outputs.mattermost-channels }} | tr ',' ' ')
+          for channel in $(echo ${STEPS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS} | tr ',' ' ')
           do
             MM_CHANNEL_ID="${channel}" python3 -m src.notifications.mattermost_notifier send
           done

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -540,7 +540,7 @@ jobs:
           tag: "${{ steps.rename-oci-archive.outputs.name }}"
           message: "upload(${{ matrix.name }}): Build and upload new image revision ${{ matrix.revision }}"
           force_push_tag: true
-          github_token: ${{ secrets.ROCKSBOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   # We need this job because we want to make the releases all in one go,
   # so that we know which revisions to release, and so that we can update

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -136,7 +136,7 @@ jobs:
           mkdir ${{ env.DATA_DIR }}
 
           python3 -m src.image.prepare_single_image_build_matrix \
-            --oci-path ${STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH} \
+            --oci-path "${STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH}" \
             --revision-data-dir ${{ env.DATA_DIR }} \
             --warn-image-eol-exceeds-base-eol
 
@@ -249,7 +249,7 @@ jobs:
         id: swift-lock
         run: |
           ./src/uploads/swift_lockfile_lock.sh \
-            ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME}
+            "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME}"
         env:
           NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME: ${{ needs.prepare-build.outputs.oci-img-name }}
 
@@ -269,9 +269,9 @@ jobs:
           mkdir ${{ env.DATA_DIR }}
 
           python3 -m src.image.prepare_single_image_build_matrix \
-            --oci-path ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH} \
+            --oci-path "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}" \
             --revision-data-dir ${{ env.DATA_DIR }} \
-            --next-revision ${STEPS_GET_NEXT_REVISION_OUTPUTS_REVISION} \
+            --next-revision "${STEPS_GET_NEXT_REVISION_OUTPUTS_REVISION}" \
             --infer-image-track
 
           echo "revision-data-cache-key=${{ github.run_id }}-${{ env.DATA_DIR }}-$(date +%s)" >> "$GITHUB_OUTPUT"
@@ -293,7 +293,7 @@ jobs:
         if: ${{ always() && steps.swift-lock.outcome != 'failure' }}
         run: |
           ./src/uploads/swift_lockfile_unlock.sh \
-            ${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME}
+            "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME}"
         env:
           NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_NAME: ${{ needs.prepare-build.outputs.oci-img-name }}
 
@@ -352,7 +352,7 @@ jobs:
           # Rename the OCI archive tarball
           canonical_tag="${MATRIX_TRACK}_${MATRIX_REVISION}"
           name="${MATRIX_NAME}_${canonical_tag}"
-          mv ${OCI_ARCHIVE_NAME} $name
+          mv "${OCI_ARCHIVE_NAME}" "$name"
 
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "canonical-tag=${canonical_tag}" >> "$GITHUB_OUTPUT"
@@ -385,7 +385,7 @@ jobs:
             | jq -nRcr '[inputs] | join(",")')
 
           log_info "Detected architectures: ${arches}"
-          echo "arches='${arches}'" >> "$GITHUB_OUTPUT"
+          echo "arches=${arches}" >> "$GITHUB_OUTPUT"
         env:
           STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME: ${{ steps.rename-oci-archive.outputs.name }}
 
@@ -523,12 +523,12 @@ jobs:
             '. + {base: $base, digest: $digest, "ignored-vulnerabilities": $ignored_vulnerabilities}' \
             <<< '${{ toJSON(matrix) }}' > build_metadata.json
           ./src/uploads/upload_to_swift.sh \
-            ${MATRIX_NAME} \
-            ${MATRIX_TRACK} \
-            ${MATRIX_REVISION} \
+            "${MATRIX_NAME}" \
+            "${MATRIX_TRACK}" \
+            "${MATRIX_REVISION}" \
             build_metadata.json \
-            ${STEPS_GENERATE_SBOMS_OUTPUTS_SBOMS} \
-            ${OCI_ARCHIVE_NAME}${{ env.VULNERABILITY_REPORT_SUFFIX }}
+            "${STEPS_GENERATE_SBOMS_OUTPUTS_SBOMS}" \
+            "${OCI_ARCHIVE_NAME}${{ env.VULNERABILITY_REPORT_SUFFIX }}"
 
       - name: Create Git tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -141,7 +141,7 @@ jobs:
 
           python3 -m src.image.prepare_single_image_build_matrix \
             --oci-path "${STEPS_VALIDATE_IMAGE_OUTPUTS_IMG_PATH}" \
-            --revision-data-dir ${{ env.DATA_DIR }} \
+            --revision-data-dir ${DATA_DIR} \
             --warn-image-eol-exceeds-base-eol
 
   validate-matrix:
@@ -270,15 +270,15 @@ jobs:
             set -x
           fi
 
-          mkdir ${{ env.DATA_DIR }}
+          mkdir ${DATA_DIR}
 
           python3 -m src.image.prepare_single_image_build_matrix \
             --oci-path "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}" \
-            --revision-data-dir ${{ env.DATA_DIR }} \
+            --revision-data-dir ${DATA_DIR} \
             --next-revision "${STEPS_GET_NEXT_REVISION_OUTPUTS_REVISION}" \
             --infer-image-track
 
-          echo "revision-data-cache-key=${{ github.run_id }}-${{ env.DATA_DIR }}-$(date +%s)" >> "$GITHUB_OUTPUT"
+          echo "revision-data-cache-key=${{ github.run_id }}-${DATA_DIR}-$(date +%s)" >> "$GITHUB_OUTPUT"
         env:
           NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH: ${{ needs.prepare-build.outputs.oci-img-path }}
           STEPS_GET_NEXT_REVISION_OUTPUTS_REVISION: ${{ steps.get-next-revision.outputs.revision }}
@@ -590,11 +590,11 @@ jobs:
             set -x
           fi
           source src/shared/logs.sh
-          for revision_file in "${{ env.REVISION_DATA_DIR }}"/*
+          for revision_file in "${REVISION_DATA_DIR}"/*
           do
             revision_file="$(basename "${revision_file}")"
             ret=0
-            jq -er .release < "${{ env.REVISION_DATA_DIR }}/${revision_file}" > /dev/null || ret=1
+            jq -er .release < "${REVISION_DATA_DIR}/${revision_file}" > /dev/null || ret=1
 
             if [ $ret -eq 1 ]
             then
@@ -606,7 +606,7 @@ jobs:
 
             python3 -m src.image.merge_release_info \
               --image-trigger "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}/image.yaml" \
-              --revision-data-file "${{ env.REVISION_DATA_DIR }}/${revision_file}"
+              --revision-data-file "${REVISION_DATA_DIR}/${revision_file}"
           done
 
       - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -127,7 +127,6 @@ jobs:
       pull-requests: write
     env:
       IS_PROD: ${{ ! startsWith(needs.get-submitted-files.outputs.image-name, 'mock-') }}
-      COMMENT_TAG: "repo-not-exist"
     steps:
       - name: Validate registry has repo
         id: validate-registry-has-repo
@@ -146,15 +145,34 @@ jobs:
 
       - name: Comment PR if repo does not exist
         if: ${{ steps.validate-registry-has-repo.outputs.docker-repo-exists == 'false' }}
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
-        with:
-          message: |
-            The Docker repository for this image does not exist yet. Merging of this repo is blocked.
-            _Run ID: **${{ github.run_id }}** ; Attempt: **${{ github.run_attempt }}**_
+        id: comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          comment_url=$(gh pr comment "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --body "The Docker repository for this image does not exist yet. Merging of this repo is blocked.
+          _Run ID: **${RUN_ID}** ; Attempt: **${RUN_ATTEMPT}**_
 
-            See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-          reactions: eyes
-          comment_tag: ${{ env.COMMENT_TAG }}
+          See [logs](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}).")
+          echo "comment-id=$(basename "${comment_url}")" >> "$GITHUB_OUTPUT"
+
+      - name: Add reaction to comment
+        if: ${{ steps.validate-registry-has-repo.outputs.docker-repo-exists == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ steps.comment.outputs.comment-id }}
+        run: |
+          gh api \
+            --method POST \
+            repos/${REPO}/issues/comments/${COMMENT_ID}/reactions \
+            --field content=eyes
 
   update-pr:
     runs-on: ubuntu-22.04
@@ -164,16 +182,31 @@ jobs:
     permissions: 
       pull-requests: write 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
-        with:
-          message: |
-            One or more files in this PR are not valid! :grimacing:
-            _Run ID: **${{ github.run_id }}** ; Attempt: **${{ github.run_attempt }}**_
+        id: comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          comment_url=$(gh pr comment "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --body "One or more files in this PR are not valid! :grimacing:
+          _Run ID: **${RUN_ID}** ; Attempt: **${RUN_ATTEMPT}**_
 
-            See [logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-          reactions: eyes
+          See [logs](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}).")
+          echo "comment-id=$(basename "${comment_url}")" >> "$GITHUB_OUTPUT"
+
+      - name: Add reaction to comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ steps.comment.outputs.comment-id }}
+        run: |
+          gh api \
+            --method POST \
+            repos/${REPO}/issues/comments/${COMMENT_ID}/reactions \
+            --field content=eyes

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source src/shared/logs.sh
           log_info "Changed files are: ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
-          echo "matrix={\"filename\":${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}}" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"filename\":$(echo ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES})}" >> "$GITHUB_OUTPUT"
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source src/shared/logs.sh
           log_info "Changed files are: ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
-          echo "matrix={\"filename\":$(echo ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES})}" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"filename\":${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}}" >> "$GITHUB_OUTPUT"
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -111,10 +111,10 @@ jobs:
         run: |
           pip install -r src/docs/requirements.txt
 
-          python3 -c '
+          python3 -c "
           import src.docs.generate_oci_doc_yaml as OCIDoc
-          OCIDoc.OCIDocumentationData.read_documentation_yaml("${MATRIX_FILENAME}")
-          '
+          OCIDoc.OCIDocumentationData.read_documentation_yaml('${MATRIX_FILENAME}')
+          "
         env:
           MATRIX_FILENAME: ${{ matrix.filename }}
 

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
           json: true
+          escape_json: false
           files: |
             oci/*/*.y*ml
 

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -160,7 +160,7 @@ jobs:
           _Run ID: **${RUN_ID}** ; Attempt: **${RUN_ATTEMPT}**_
 
           See [logs](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}).")
-          echo "comment-id=$(basename "${comment_url}")" >> "$GITHUB_OUTPUT"
+          echo "comment-id=${comment_url##*issuecomment-}" >> "$GITHUB_OUTPUT"
 
       - name: Add reaction to comment
         if: ${{ steps.validate-registry-has-repo.outputs.docker-repo-exists == 'false' }}
@@ -198,7 +198,7 @@ jobs:
           _Run ID: **${RUN_ID}** ; Attempt: **${RUN_ATTEMPT}**_
 
           See [logs](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}).")
-          echo "comment-id=$(basename "${comment_url}")" >> "$GITHUB_OUTPUT"
+          echo "comment-id=${comment_url##*issuecomment-}" >> "$GITHUB_OUTPUT"
 
       - name: Add reaction to comment
         env:

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -13,6 +13,8 @@ jobs:
       image-name: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files
@@ -38,16 +40,20 @@ jobs:
           fi
           source src/shared/logs.sh
           set -u
-          dir_names="${{ steps.changed-files-dir-names.outputs.all_changed_files }}"
+          dir_names="${STEPS_CHANGED_FILES_DIR_NAMES_OUTPUTS_ALL_CHANGED_FILES}"
           log_error "Can only modify 1 image per PR"
           (( $(echo "${dir_names}" | wc -w) == 1 ))
+        env:
+          STEPS_CHANGED_FILES_DIR_NAMES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
 
       - name: Save matrix layout for file validation
         id: changed-files-matrix
         run: |
           source src/shared/logs.sh
-          log_info 'Changed files are: ${{ steps.changed-files.outputs.all_changed_files }}'
-          echo "matrix={\"filename\":${{ steps.changed-files.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
+          log_info "Changed files are: ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
+          echo "matrix={\"filename\":${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
   check-missing-files:
     runs-on: ubuntu-22.04
@@ -57,6 +63,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Check if documentation.yaml exists
         uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
@@ -79,6 +87,8 @@ jobs:
       matrix: ${{ fromJSON(needs.get-submitted-files.outputs.changed-files-matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -92,7 +102,9 @@ jobs:
           fi
           set -u
           pip install yamllint
-          yamllint -c .yamllint.yaml ${{ matrix.filename }}
+          yamllint -c .yamllint.yaml ${MATRIX_FILENAME}
+        env:
+          MATRIX_FILENAME: ${{ matrix.filename }}
 
       - name: Validate documentation trigger file
         if: ${{ contains(matrix.filename, 'documentation.yaml') }}
@@ -101,8 +113,10 @@ jobs:
 
           python3 -c '
           import src.docs.generate_oci_doc_yaml as OCIDoc
-          OCIDoc.OCIDocumentationData.read_documentation_yaml("${{ matrix.filename }}")
+          OCIDoc.OCIDocumentationData.read_documentation_yaml("${MATRIX_FILENAME}")
           '
+        env:
+          MATRIX_FILENAME: ${{ matrix.filename }}
 
   validate-registry-has-repo:
     runs-on: ubuntu-latest
@@ -118,10 +132,12 @@ jobs:
         id: validate-registry-has-repo
         env:
           NAMESPACE: ${{ env.IS_PROD == 'true' && 'ubuntu' || 'rocksdev' }}
+          NEEDS_GET_SUBMITTED_FILES_OUTPUTS_IMAGE_NAME: ${{ needs.get-submitted-files.outputs.image-name }}
         run: |
           DOCKER_REPO_EXISTS='true'
+          img_name="$(basename "${NEEDS_GET_SUBMITTED_FILES_OUTPUTS_IMAGE_NAME}")"
           if curl -w "%{http_code}" -o /dev/null -s \
-              https://hub.docker.com/v2/repositories/$NAMESPACE/$(basename ${{ needs.get-submitted-files.outputs.image-name }}) \
+              "https://hub.docker.com/v2/repositories/${NAMESPACE}/${img_name}" \
             | grep -qv "200" ; then
             DOCKER_REPO_EXISTS='false'
           fi
@@ -148,6 +164,8 @@ jobs:
       pull-requests: write 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b

--- a/.github/workflows/Rebuild-Images.yaml
+++ b/.github/workflows/Rebuild-Images.yaml
@@ -16,6 +16,8 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+          with:
+            persist-credentials: false
     
         - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
           with:
@@ -38,7 +40,8 @@ jobs:
             OS_PROJECT_NAME: ${{ secrets.SWIFT_OS_TENANT_NAME }}
             OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL }}
             GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
+            INPUTS_IMAGE_NAME: ${{ inputs.image-name || '*' }}
           run: |
-            poetry run python3 find_images_to_update.py --image-name "${{ inputs.image-name || '*' }}" \
+            poetry run python3 find_images_to_update.py --image-name "$INPUTS_IMAGE_NAME" \
                                                         --ext-ref-prefix weekly-rebuild
   

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -256,7 +256,7 @@ jobs:
         with:
           tag: "${{ matrix.release-name }}"
           message: "release(${{ matrix.name }}): Release image revision ${{ matrix.revision }} to ${{ matrix.channel }}"
-          github_token: ${{ secrets.ROCKSBOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           commit_sha: ${{ matrix.canonical-tag }}
           force_push_tag: true
 
@@ -264,5 +264,5 @@ jobs:
         with:
           name: "${{ matrix.release-name }}"
           tag_name: "${{ matrix.release-name }}"
-          token: "${{ secrets.ROCKSBOT_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
           files: "sbom/*.sbom_preview.spdx.json"

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -35,9 +35,13 @@ jobs:
       oci-image-name: ${{ steps.get-image-name.outputs.img-name }}
     steps:
       - name: ${{ inputs.external_ref_id }}  # (2)
-        run: echo 'Started by ${{ inputs.external_ref_id }}' >> "$GITHUB_STEP_SUMMARY"
+        run: echo 'Started by ${INPUTS_EXTERNAL_REF_ID}' >> "$GITHUB_STEP_SUMMARY"
+        env:
+          INPUTS_EXTERNAL_REF_ID: ${{ inputs.external_ref_id }}
         
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -63,7 +67,7 @@ jobs:
             set -x
           fi
           source src/shared/logs.sh
-          img_dir="${{ steps.changed-files.outputs.all_changed_files }}"
+          img_dir="${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}"
           occurrences="${img_dir//[^,]}"
           if [ ${#occurrences} -ne 0 ]
           then
@@ -71,6 +75,8 @@ jobs:
             exit 1
           fi
           echo "img-name=$(basename ${img_dir})" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
   
   do-releases:
@@ -85,6 +91,8 @@ jobs:
       RELEASE_REPO_DIR: oci-factory-releases
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Fetch _releases.json
         uses: ./.github/actions/fetch-releases-json
@@ -149,6 +157,8 @@ jobs:
           # ECR_LTS_NAMESPACE: ${{ env.IS_PROD == 'true' && 'lts' || secrets.ECR_LTS_NAMESPACE_DEV }}
 
           PYTHONUNBUFFERED: 1
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+          STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE: ${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}
         run: |
           set -e
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
@@ -158,25 +168,30 @@ jobs:
           log_info "Running in production?  ${{ env.IS_PROD == 'true' && 'YES' || 'NO' }}"
           
           python3 -m src.image.release \
-            --image-trigger oci/${{ inputs.oci-image-name }}/image.yaml \
-            --image-name ${{ inputs.oci-image-name }} \
-            --all-releases oci/${{ inputs.oci-image-name }}/_releases.json \
-            --all-revision-tags "${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}" \
+            --image-trigger oci/${INPUTS_OCI_IMAGE_NAME}/image.yaml \
+            --image-name ${INPUTS_OCI_IMAGE_NAME} \
+            --all-releases oci/${INPUTS_OCI_IMAGE_NAME}/_releases.json \
+            --all-revision-tags "${STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE}" \
             --ghcr-repo "${{ github.repository_owner }}/oci-factory"
 
       - name: Update _releases.json
         run: |
           python3 -m src.image.release \
-            --image-trigger oci/${{ inputs.oci-image-name }}/image.yaml \
-            --image-name ${{ inputs.oci-image-name }} \
-            --all-releases oci/${{ inputs.oci-image-name }}/_releases.json \
-            --all-revision-tags "${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}" \
+            --image-trigger oci/${INPUTS_OCI_IMAGE_NAME}/image.yaml \
+            --image-name ${INPUTS_OCI_IMAGE_NAME} \
+            --all-releases oci/${INPUTS_OCI_IMAGE_NAME}/_releases.json \
+            --all-revision-tags "${STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE}" \
             --update-releases-json
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+          STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE: ${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}
 
       - name: Overwrite _releases.json
         run: |
-          mkdir -p ${{ env.RELEASE_REPO_DIR }}/oci/${{ inputs.oci-image-name }}
-          cp oci/${{ inputs.oci-image-name }}/_releases.json ${{ env.RELEASE_REPO_DIR }}/oci/${{ inputs.oci-image-name }}/_releases.json
+          mkdir -p ${{ env.RELEASE_REPO_DIR }}/oci/${INPUTS_OCI_IMAGE_NAME}
+          cp oci/${INPUTS_OCI_IMAGE_NAME}/_releases.json ${{ env.RELEASE_REPO_DIR }}/oci/${INPUTS_OCI_IMAGE_NAME}/_releases.json
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
 
       # Commit with actor's GitHub noreply email to pass CLA and keep the privacy of the actor
       # Use force push, to bypass the branch protection rules
@@ -212,6 +227,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ matrix.canonical-tag }}
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -224,15 +240,16 @@ jobs:
             set -x
           fi
           sbom_target_dir="$(pwd)/sbom"
-          find sbom -type f -name '*.spdx.zip' -exec unzip {} -d ${sbom_target_dir} \;
+          find sbom -type f -name '*.spdx.zip' -exec unzip {} -d "${sbom_target_dir}" \;
 
       # We force delete an existing tag because otherwise we won't get
       # an email notification and the GH release will have the date from when
       # it was created the first time (i.e. force-push won't update the date)
-      - run: gh release delete ${{ matrix.release-name }} --yes --cleanup-tag
+      - run: gh release delete ${MATRIX_RELEASE_NAME} --yes --cleanup-tag
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_RELEASE_NAME: ${{ matrix.release-name }}
           
       - name: Create Git tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -165,7 +165,7 @@ jobs:
             set -x
           fi
           source src/shared/logs.sh
-          log_info "Running in production?  ${{ env.IS_PROD == 'true' && 'YES' || 'NO' }}"
+          log_info "Running in production? $([[ "$IS_PROD" == "true" ]] && echo YES || echo NO)"
           
           python3 -m src.image.release \
             --image-trigger oci/${INPUTS_OCI_IMAGE_NAME}/image.yaml \

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -94,6 +94,7 @@ jobs:
           # or to the default branch of the oci-factory repo if the workflow is called from another repo.
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       # download and unpack the image under test, then store it under a common cache key. 
       # This unpacked image is used in test-oci-compliance, test-black-box and test-malware jobs
@@ -117,15 +118,19 @@ jobs:
       - name: Unpack Rock
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD:/workdir -w /workdir \
-            ${{ env.SKOPEO_IMAGE }} \
-            copy oci-archive:${{ inputs.oci-archive-name }} \
-            oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
+            -v "$PWD:/workdir" -w /workdir \
+            "${{ env.SKOPEO_IMAGE }}" \
+            copy "oci-archive:${INPUTS_OCI_ARCHIVE_NAME}" \
+            "oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
+        env:
+          INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
 
       - name: Set Cache Key
         id: set-cache
         run: |
-          echo "key=${{ github.run_id }}-${{ inputs.oci-archive-name }}"  >> $GITHUB_OUTPUT
+          echo "key=${{ github.run_id }}-${INPUTS_OCI_ARCHIVE_NAME}"  >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
 
       - name: Cache Rock
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
@@ -144,6 +149,7 @@ jobs:
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
@@ -159,10 +165,10 @@ jobs:
       - name: Run Umoci tests
         run: |
           sudo umoci unpack --keep-dirlinks \
-            --image ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+            --image "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
             bundle
 
-          umoci list --layout ${{ env.TEST_IMAGE_NAME }} | grep -w -c ${{ env.TEST_IMAGE_TAG }}
+          umoci list --layout "${{ env.TEST_IMAGE_NAME }}" | grep -w -c "${{ env.TEST_IMAGE_TAG }}"
 
   test-black-box:
     strategy:
@@ -181,14 +187,14 @@ jobs:
       - name: Copy image to Docker daemon
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD:/workdir -w /workdir \
-            ${{ env.SKOPEO_IMAGE }} \
-            copy oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
-            docker-daemon:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
+            -v "$PWD:/workdir" -w /workdir \
+            "${{ env.SKOPEO_IMAGE }}" \
+            copy "oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
+            "docker-daemon:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
 
       - name: Create container
         run: |
-          docker create ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
+          docker create "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
 
       - name: Test rock
         run: |
@@ -196,7 +202,7 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          docker run --rm --entrypoint pebble ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+          docker run --rm --entrypoint pebble "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
             help | grep Pebble
 
   test-efficiency:
@@ -213,6 +219,7 @@ jobs:
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
@@ -222,10 +229,10 @@ jobs:
       - name: Copy image to Docker daemon
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD:/workdir -w /workdir \
-            ${{ env.SKOPEO_IMAGE }} \
-            copy oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
-            docker-daemon:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}
+            -v "$PWD:/workdir" -w /workdir \
+            "${{ env.SKOPEO_IMAGE }}" \
+            copy "oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
+            "docker-daemon:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
 
       # The existing Dive GH actions are outdated:
       # https://github.com/MartinHeinz/dive-action/issues/1
@@ -234,9 +241,9 @@ jobs:
         run: |
           docker run -e CI=true --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml \
-            ${{ env.DIVE_IMAGE }} \
-            ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+            -v "$PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml" \
+            "${{ env.DIVE_IMAGE }}" \
+            "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
             --ci-config /.dive-ci.yaml \
             --highestUserWastedPercent disabled
 
@@ -245,9 +252,9 @@ jobs:
         run: |
           docker run -e CI=true --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml \
-            ${{ env.DIVE_IMAGE }} \
-            ${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }} \
+            -v "$PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml" \
+            "${{ env.DIVE_IMAGE }}" \
+            "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
             --ci-config /.dive-ci.yaml \
             --lowestEfficiency disabled
 
@@ -262,22 +269,27 @@ jobs:
     steps:
       - name: Check mutual exclusivity of ignored vulnerabilities and trivyignore path
         run: |
-          if [[ "${{ inputs.ignored-vulnerabilities }}" != "" && "${{ inputs.trivyignore-path }}" != "" ]]; then
+          if [[ "${INPUTS_IGNORED_VULNERABILITIES}" != "" && "${INPUTS_TRIVYIGNORE_PATH}" != "" ]]; then
             echo "Error: 'ignored-vulnerabilities' and 'trivyignore-path' inputs are mutually exclusive."
             exit 1
           fi
+        env:
+          INPUTS_IGNORED_VULNERABILITIES: ${{ inputs.ignored-vulnerabilities }}
+          INPUTS_TRIVYIGNORE_PATH: ${{ inputs.trivyignore-path }}
 
       - name: Cloning OCI Factory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
       
       - name: Checkout Rock Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: github.repository != 'canonical/oci-factory' && inputs.trivyignore-path != ''
         with:
           path: ${{ env.ROCK_REPO_DIR }}
+          persist-credentials: false
 
       - name: Download Rock
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -308,29 +320,32 @@ jobs:
 
           docker_image="${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
           echo "docker-image=$docker_image" >> "$GITHUB_OUTPUT"
-          source=oci-archive:${{ env.TEST_IMAGE_NAME }} 
 
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD:/workdir -w /workdir \
-            ${{ env.SKOPEO_IMAGE }} \
-            copy oci-archive:${{ inputs.oci-archive-name }} \
-            docker-daemon:$docker_image
+            -v "$PWD:/workdir" -w /workdir \
+            "${{ env.SKOPEO_IMAGE }}" \
+            copy "oci-archive:${INPUTS_OCI_ARCHIVE_NAME}" \
+            "docker-daemon:$docker_image"
 
           # Append the ROCK_REPO_DIR path prefix to the trivyignore path
           # if the repo is not canonical/oci-factory
-          trivyignore_path="${{ inputs.trivyignore-path }}"
+          trivyignore_path="${INPUTS_TRIVYIGNORE_PATH}"
           if [[ "${{ github.repository }}" != "canonical/oci-factory" ]]; then
             trivyignore_path="${{ env.ROCK_REPO_DIR }}/${trivyignore_path}"
           fi
 
           if [[ ! -s "${trivyignore_path}" ]]; then
             trivyignore_path=.trivyignore
-            echo "${{ inputs.ignored-vulnerabilities }}" | tr ' ' '\n' > "$trivyignore_path"
+            echo "${INPUTS_IGNORED_VULNERABILITIES}" | tr ' ' '\n' > "$trivyignore_path"
           fi
 
           echo "trivyignore-path=$trivyignore_path" >> "$GITHUB_OUTPUT"
 
-          echo "report-name=${{ inputs.oci-archive-name }}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
+          echo "report-name=${INPUTS_OCI_ARCHIVE_NAME}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
+          INPUTS_TRIVYIGNORE_PATH: ${{ inputs.trivyignore-path }}
+          INPUTS_IGNORED_VULNERABILITIES: ${{ inputs.ignored-vulnerabilities }}
 
       - name: Scan for vulnerabilities
         # TODO: bump trivy-action version once a newer version is released that uses v5 or later tags for actions/cache.
@@ -373,18 +388,22 @@ jobs:
             | .[]
             | {Target: $target, LastModifiedDate: .LastModifiedDate, VulnerabilityID: .VulnerabilityID,
               PkgName: .PkgName, Severity: .Severity}
-                  ]' < ${{ steps.configure-trivy.outputs.report-name }})"
+                  ]' < "${STEPS_CONFIGURE_TRIVY_OUTPUTS_REPORT_NAME}")"
 
           num_vulns=$(echo "$vulnerabilities" | jq -r 'length')
           
           if [[ $num_vulns -gt 0 ]]; then
-            echo "# Vulnerabilities found for ${{ inputs.oci-archive-name }}" >> $GITHUB_STEP_SUMMARY
-            title="Vulnerabilities found for ${{ inputs.oci-archive-name }}"
-            echo "## $title" >> $GITHUB_STEP_SUMMARY
-            echo "| ID | Target | Severity | Package |" >> $GITHUB_STEP_SUMMARY
-            echo "| -- | ----- | -------- | ------- |" >> $GITHUB_STEP_SUMMARY
-            echo "$vulnerabilities" | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> $GITHUB_STEP_SUMMARY
+            title="Vulnerabilities found for ${INPUTS_OCI_ARCHIVE_NAME}"
+            {
+              echo "## $title"
+              echo "| ID | Target | Severity | Package |"
+              echo "| -- | ----- | -------- | ------- |"
+              echo "$vulnerabilities" | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
+        env:
+          STEPS_CONFIGURE_TRIVY_OUTPUTS_REPORT_NAME: ${{ steps.configure-trivy.outputs.report-name }}
+          INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
           
       - name: Identify unncessary trivyignore entries
         if: ${{ !cancelled() }}
@@ -404,6 +423,7 @@ jobs:
         with:
           repository: canonical/oci-factory
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -119,7 +119,7 @@ jobs:
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:/workdir" -w /workdir \
-            "${SKOPEO_IMAGE }" \
+            "${SKOPEO_IMAGE}" \
             copy "oci-archive:${INPUTS_OCI_ARCHIVE_NAME}" \
             "oci:${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}"
         env:

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -165,7 +165,7 @@ jobs:
       - name: Run Umoci tests
         run: |
           sudo umoci unpack --keep-dirlinks \
-            --image "${TEST_IMAGE_NAME }:${TEST_IMAGE_TAG}" \
+            --image "${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}" \
            bundle
 
           umoci list --layout "${TEST_IMAGE_NAME}" | grep -w -c "${TEST_IMAGE_TAG}"

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -119,9 +119,9 @@ jobs:
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:/workdir" -w /workdir \
-            "${{ env.SKOPEO_IMAGE }}" \
+            "${SKOPEO_IMAGE }" \
             copy "oci-archive:${INPUTS_OCI_ARCHIVE_NAME}" \
-            "oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
+            "oci:${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}"
         env:
           INPUTS_OCI_ARCHIVE_NAME: ${{ inputs.oci-archive-name }}
 
@@ -165,10 +165,10 @@ jobs:
       - name: Run Umoci tests
         run: |
           sudo umoci unpack --keep-dirlinks \
-            --image "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
-            bundle
+            --image "${TEST_IMAGE_NAME }:${TEST_IMAGE_TAG}" \
+           bundle
 
-          umoci list --layout "${{ env.TEST_IMAGE_NAME }}" | grep -w -c "${{ env.TEST_IMAGE_TAG }}"
+          umoci list --layout "${TEST_IMAGE_NAME}" | grep -w -c "${TEST_IMAGE_TAG}"
 
   test-black-box:
     strategy:
@@ -188,13 +188,13 @@ jobs:
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:/workdir" -w /workdir \
-            "${{ env.SKOPEO_IMAGE }}" \
-            copy "oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
-            "docker-daemon:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
+            "${SKOPEO_IMAGE}" \
+            copy "oci:${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}" \
+            "docker-daemon:${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}"
 
       - name: Create container
         run: |
-          docker create "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
+          docker create "${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}"
 
       - name: Test rock
         run: |
@@ -202,7 +202,7 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          docker run --rm --entrypoint pebble "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
+          docker run --rm --entrypoint pebble "${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}" \
             help | grep Pebble
 
   test-efficiency:
@@ -230,9 +230,9 @@ jobs:
         run: |
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:/workdir" -w /workdir \
-            "${{ env.SKOPEO_IMAGE }}" \
-            copy "oci:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
-            "docker-daemon:${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}"
+            "${SKOPEO_IMAGE}" \
+            copy "oci:${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}" \
+            "docker-daemon:${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}"
 
       # The existing Dive GH actions are outdated:
       # https://github.com/MartinHeinz/dive-action/issues/1
@@ -242,8 +242,8 @@ jobs:
           docker run -e CI=true --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml" \
-            "${{ env.DIVE_IMAGE }}" \
-            "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
+            "${DIVE_IMAGE}" \
+            "${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}" \
             --ci-config /.dive-ci.yaml \
             --highestUserWastedPercent disabled
 
@@ -253,8 +253,8 @@ jobs:
           docker run -e CI=true --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD/src/tests/.dive-ci.yaml:/.dive-ci.yaml" \
-            "${{ env.DIVE_IMAGE }}" \
-            "${{ env.TEST_IMAGE_NAME }}:${{ env.TEST_IMAGE_TAG }}" \
+            "${DIVE_IMAGE}" \
+            "${TEST_IMAGE_NAME}:${TEST_IMAGE_TAG}" \
             --ci-config /.dive-ci.yaml \
             --lowestEfficiency disabled
 
@@ -323,7 +323,7 @@ jobs:
 
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:/workdir" -w /workdir \
-            "${{ env.SKOPEO_IMAGE }}" \
+            "${SKOPEO_IMAGE}" \
             copy "oci-archive:${INPUTS_OCI_ARCHIVE_NAME}" \
             "docker-daemon:$docker_image"
 

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -57,7 +57,7 @@ jobs:
 
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
             -v "$PWD:/workdir" -w /workdir \
-            "${{ env.SKOPEO_IMAGE }}" \
+            "${SKOPEO_IMAGE}" \
             copy "docker://${INPUTS_OCI_IMAGE_NAME}" \
             "oci-archive:$oci_filename" \
             --src-username "${GITHUB_ACTOR}" \
@@ -257,7 +257,7 @@ jobs:
               echo "| -- | ----- | -------- | ------- |"
               echo "${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}" | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"'
             } > issue.md
-            if [[ "${{ inputs.create-issue }}" == 'true' ]]; then
+            if [[ "${INPUTS_CREATE_ISSUE}" == 'true' ]]; then
               release_json="${INPUTS_OCI_IMAGE_PATH}/_releases.json"
               if [[ -f "$release_json" ]]; then
                 revision_to_released_tags=$(python3 -m src.shared.release_info get_revision_to_released_tags --all-releases "$release_json")
@@ -275,6 +275,7 @@ jobs:
           STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_NAME_WITH_TAG: ${{ steps.simplify-image-name.outputs.img_name_with_tag }}
           INPUTS_OCI_IMAGE_PATH: ${{ inputs.oci-image-path }}
           STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_REVISION: ${{ steps.simplify-image-name.outputs.img_revision }}
+          INPUTS_CREATE_ISSUE: ${{ inputs.create-issue }}
 
       - id: issue-exists
         if: ${{ inputs.create-issue}}

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -41,25 +41,29 @@ jobs:
     steps:
       - name: Check required input
         run: |
-          if [ "${{ github.repository }}" = "canonical/oci-factory" ] && [ -z "${{ inputs.oci-image-path }}" ]; then
+          if [ "${{ github.repository }}" = "canonical/oci-factory" ] && [ -z "${INPUTS_OCI_IMAGE_PATH}" ]; then
             echo "missing required input: oci-image-path"
             exit 1
           fi
+        env:
+          INPUTS_OCI_IMAGE_PATH: ${{ inputs.oci-image-path }}
 
       - id: configure
         run: |
-          oci_filename="$(basename "${{ inputs.oci-image-name }}" | tr ':' '_')"
+          oci_filename="$(basename "${INPUTS_OCI_IMAGE_NAME}" | tr ':' '_')"
 
           echo "oci-filename=$oci_filename" >> "$GITHUB_OUTPUT"
           echo "report-filename=${oci_filename}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
 
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $PWD:/workdir -w /workdir \
-            ${{ env.SKOPEO_IMAGE }} \
-            copy docker://${{ inputs.oci-image-name }} \
-            oci-archive:$oci_filename \
-            --src-username "${{ github.actor }}" \
+            -v "$PWD:/workdir" -w /workdir \
+            "${{ env.SKOPEO_IMAGE }}" \
+            copy "docker://${INPUTS_OCI_IMAGE_NAME}" \
+            "oci-archive:$oci_filename" \
+            --src-username "${GITHUB_ACTOR}" \
             --src-password "${{ secrets.GITHUB_TOKEN }}"
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         if: ${{ !cancelled() }}
@@ -91,6 +95,8 @@ jobs:
       vulnerabilities: ${{ steps.check-report.outputs.vulnerabilities }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Validate access to triggered image
         uses: ./.github/actions/validate-actor
@@ -111,7 +117,7 @@ jobs:
         if: ${{ !cancelled() }}
         id: check-report
         run: |
-          report="${{ needs.configure-scan.outputs.vulnerability-report }}" 
+          report="${NEEDS_CONFIGURE_SCAN_OUTPUTS_VULNERABILITY_REPORT}" 
           echo "notify=false" >> "$GITHUB_OUTPUT"
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
@@ -132,12 +138,15 @@ jobs:
           # time this scan ran
           for cve_updated in $last_modified_dates
           do
-            if [[ "$cve_updated" > "${{ inputs.date-last-scan }}" ]]
+            if [[ "$cve_updated" > "${INPUTS_DATE_LAST_SCAN}" ]]
             then
               echo "notify=true" >> "$GITHUB_OUTPUT"
               break
             fi
           done
+        env:
+          NEEDS_CONFIGURE_SCAN_OUTPUTS_VULNERABILITY_REPORT: ${{ needs.configure-scan.outputs.vulnerability-report }}
+          INPUTS_DATE_LAST_SCAN: ${{ inputs.date-last-scan }}
 
   # Many workflows are now using a similar notification job. It would be better
   # if this was a common workflows reachable via a workflow_call
@@ -148,6 +157,8 @@ jobs:
     if: ${{ !cancelled() && github.repository == 'canonical/oci-factory' && needs.parse-results.outputs.notify == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -171,8 +182,9 @@ jobs:
           SUMMARY: ''
           FOOTER: ''
           TITLE: 'Vulnerabilities found for ${{ inputs.oci-image-name }}'
+          STEPS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS: ${{ steps.get-contacts.outputs.mattermost-channels }}
         run: |
-          for channel in $(echo ${{ steps.get-contacts.outputs.mattermost-channels }} | tr ',' ' ')
+          for channel in $(echo ${STEPS_GET_CONTACTS_OUTPUTS_MATTERMOST_CHANNELS} | tr ',' ' ')
           do
             MM_CHANNEL_ID="${channel}" python3 -m src.notifications.mattermost_notifier send
           done
@@ -186,6 +198,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -195,27 +209,33 @@ jobs:
 
       - id: simplify-image-name
         run: |
-          img_name_with_tag=$(echo "${{ inputs.oci-image-name }}" | sed -r 's|.*/([a-zA-Z0-9-]+:[0-9.-]+_[0-9])+|\1|')
+          img_name_with_tag=$(echo "${INPUTS_OCI_IMAGE_NAME}" | sed -r 's|.*/([a-zA-Z0-9-]+:[0-9.-]+_[0-9])+|\1|')
           img_name=$(echo "${img_name_with_tag}" | cut -d ':' -f 1)
           img_revision=$(echo "${img_name_with_tag}" | cut -d '_' -f 2)
-          echo "img_revision=$img_revision" >> "$GITHUB_OUTPUT"
-          echo "img_name_with_tag=$img_name_with_tag" >> "$GITHUB_OUTPUT"
-          echo "img_name=$img_name" >> "$GITHUB_OUTPUT"
+          {
+            echo "img_revision=$img_revision"
+            echo "img_name_with_tag=$img_name_with_tag"
+            echo "img_name=$img_name"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
 
       # We assume that the sources within image.yaml are the same
       - name: Get image repo
         id: get-image-repo
         run: |
-          if [[ -n "${{ inputs.oci-image-path }}" ]]; then
-            img_repo=$(yq -r '.upload.[].source' "${{ github.workspace }}/${{ inputs.oci-image-path }}/image.yaml" | head -n 1)
+          if [[ -n "${INPUTS_OCI_IMAGE_PATH}" ]]; then
+            img_repo=$(yq -r '.upload.[].source' "${{ github.workspace }}/${INPUTS_OCI_IMAGE_PATH}/image.yaml" | head -n 1)
           else
             img_repo="${{ github.repository }}"
           fi
           echo "img-repo=$img_repo" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_IMAGE_PATH: ${{ inputs.oci-image-path }}
 
       - name: Fetch _releases.json
         if: github.repository == 'canonical/oci-factory' && steps.simplify-image-name.outputs.img_name != ''
-        uses: canonical/oci-factory/.github/actions/fetch-releases-json@main
+        uses: ./.github/actions/fetch-releases-json
         with:
           image-name: ${{ steps.simplify-image-name.outputs.img_name }}
 
@@ -226,20 +246,22 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          num_vulns=$(echo '${{ needs.parse-results.outputs.vulnerabilities }}' | jq -r 'length')
+          num_vulns=$(echo '${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}' | jq -r 'length')
           vulnerability_exists=$([[ $num_vulns -gt 0 ]] && echo 'true' || echo 'false')
           echo "vulnerability-exists=$vulnerability_exists" >> "$GITHUB_OUTPUT"
           if [[ $vulnerability_exists == 'true' ]]; then
-            title="Vulnerabilities found for ${{ steps.simplify-image-name.outputs.img_name_with_tag }}"
-            echo "## $title" > issue.md
-            echo "| ID | Target | Severity | Package |" >> issue.md
-            echo "| -- | ----- | -------- | ------- |" >> issue.md
-            echo '${{ needs.parse-results.outputs.vulnerabilities }}' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"' >> issue.md
+            title="Vulnerabilities found for ${STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_NAME_WITH_TAG}"
+            {
+              echo "## $title"
+              echo "| ID | Target | Severity | Package |"
+              echo "| -- | ----- | -------- | ------- |"
+              echo '${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"'
+            } > issue.md
             if [[ "${{ inputs.create-issue }}" == 'true' ]]; then
-              release_json="${{ inputs.oci-image-path }}/_releases.json"
+              release_json="${INPUTS_OCI_IMAGE_PATH}/_releases.json"
               if [[ -f "$release_json" ]]; then
                 revision_to_released_tags=$(python3 -m src.shared.release_info get_revision_to_released_tags --all-releases "$release_json")
-                affected_tracks=$(echo "${revision_to_released_tags}" | jq -r '."${{ steps.simplify-image-name.outputs.img_revision }}" | map("- `\(.)`") | join("\n")')
+                affected_tracks=$(echo "${revision_to_released_tags}" | jq -r '."${STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_REVISION}" | map("- `\(.)`") | join("\n")')
                 echo -e "\n### Affected tracks:" >> issue.md
                 echo -e "${affected_tracks}" >> issue.md
               fi
@@ -248,14 +270,22 @@ jobs:
             echo "issue-title=$title" >> "$GITHUB_OUTPUT"
             echo "issue-body-file=issue.md" >> "$GITHUB_OUTPUT"
           fi
+        env:
+          NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES: ${{ needs.parse-results.outputs.vulnerabilities }}
+          STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_NAME_WITH_TAG: ${{ steps.simplify-image-name.outputs.img_name_with_tag }}
+          INPUTS_OCI_IMAGE_PATH: ${{ inputs.oci-image-path }}
+          STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_REVISION: ${{ steps.simplify-image-name.outputs.img_revision }}
 
       - id: issue-exists
         if: ${{ inputs.create-issue}}
         run: |
-          issue_number=$(gh issue list --repo ${{ steps.get-image-repo.outputs.img-repo }} --json "number,title" \
-                  | jq -r '.[] | select(.title == "${{ steps.create-markdown.outputs.issue-title }}") | .number')
+          issue_number=$(gh issue list --repo ${STEPS_GET_IMAGE_REPO_OUTPUTS_IMG_REPO} --json "number,title" \
+                  | jq -r '.[] | select(.title == "${STEPS_CREATE_MARKDOWN_OUTPUTS_ISSUE_TITLE}") | .number')
           echo "issue-exists=$([[ -n "$issue_number" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "issue-number=$issue_number" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_GET_IMAGE_REPO_OUTPUTS_IMG_REPO: ${{ steps.get-image-repo.outputs.img-repo }}
+          STEPS_CREATE_MARKDOWN_OUTPUTS_ISSUE_TITLE: ${{ steps.create-markdown.outputs.issue-title }}
 
       # Truth table for issue creation
       # | issue-exists | notify | vulnerability-exists |   op   |
@@ -276,17 +306,25 @@ jobs:
             set -x
           fi
           op=nop
-          if [[ ${{ steps.issue-exists.outputs.issue-exists }}  == 'false' ]]; then
+          if [[ ${STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_EXISTS}  == 'false' ]]; then
             op="create"
-          elif [[ ${{ steps.issue-exists.outputs.issue-exists }} == 'true' \
-                  && ${{ needs.parse-results.outputs.notify }} == 'true' ]]; then
-            op="edit ${{ steps.issue-exists.outputs.issue-number }}"
+          elif [[ ${STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_EXISTS} == 'true' \
+                  && ${NEEDS_PARSE_RESULTS_OUTPUTS_NOTIFY} == 'true' ]]; then
+            op="edit ${STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_NUMBER}"
           fi
           if [[ $op != 'nop' ]]; then
-            gh issue $op --repo ${{ steps.get-image-repo.outputs.img-repo }} \
-              --title "${{ steps.create-markdown.outputs.issue-title }}" \
-              --body-file "${{ steps.create-markdown.outputs.issue-body-file }}"
+            # shellcheck disable=SC2086
+            gh issue $op --repo "${STEPS_GET_IMAGE_REPO_OUTPUTS_IMG_REPO}" \
+              --title "${STEPS_CREATE_MARKDOWN_OUTPUTS_ISSUE_TITLE}" \
+              --body-file "${STEPS_CREATE_MARKDOWN_OUTPUTS_ISSUE_BODY_FILE}"
           fi
+        env:
+          STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_EXISTS: ${{ steps.issue-exists.outputs.issue-exists }}
+          NEEDS_PARSE_RESULTS_OUTPUTS_NOTIFY: ${{ needs.parse-results.outputs.notify }}
+          STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_NUMBER: ${{ steps.issue-exists.outputs.issue-number }}
+          STEPS_GET_IMAGE_REPO_OUTPUTS_IMG_REPO: ${{ steps.get-image-repo.outputs.img-repo }}
+          STEPS_CREATE_MARKDOWN_OUTPUTS_ISSUE_TITLE: ${{ steps.create-markdown.outputs.issue-title }}
+          STEPS_CREATE_MARKDOWN_OUTPUTS_ISSUE_BODY_FILE: ${{ steps.create-markdown.outputs.issue-body-file }}
 
       - name: Close issue
         if: |
@@ -295,4 +333,7 @@ jobs:
           steps.create-markdown.outputs.vulnerability-exists == 'false' && 
           inputs.create-issue
         run: |
-          gh issue close ${{ steps.issue-exists.outputs.issue-number }} --repo ${{ steps.get-image-repo.outputs.img-repo }}
+          gh issue close ${STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_NUMBER} --repo ${STEPS_GET_IMAGE_REPO_OUTPUTS_IMG_REPO}
+        env:
+          STEPS_ISSUE_EXISTS_OUTPUTS_ISSUE_NUMBER: ${{ steps.issue-exists.outputs.issue-number }}
+          STEPS_GET_IMAGE_REPO_OUTPUTS_IMG_REPO: ${{ steps.get-image-repo.outputs.img-repo }}

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -246,7 +246,7 @@ jobs:
           if [[ "$RUNNER_DEBUG" == "1" ]]; then
             set -x
           fi
-          num_vulns=$(echo '${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}' | jq -r 'length')
+          num_vulns=$(echo "${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}" | jq -r 'length')
           vulnerability_exists=$([[ $num_vulns -gt 0 ]] && echo 'true' || echo 'false')
           echo "vulnerability-exists=$vulnerability_exists" >> "$GITHUB_OUTPUT"
           if [[ $vulnerability_exists == 'true' ]]; then
@@ -255,13 +255,13 @@ jobs:
               echo "## $title"
               echo "| ID | Target | Severity | Package |"
               echo "| -- | ----- | -------- | ------- |"
-              echo '${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}' | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"'
+              echo "${NEEDS_PARSE_RESULTS_OUTPUTS_VULNERABILITIES}" | jq -r '.[] | "| \(.VulnerabilityID) | /\(.Target) | \(.Severity) | \(.PkgName) |"'
             } > issue.md
             if [[ "${{ inputs.create-issue }}" == 'true' ]]; then
               release_json="${INPUTS_OCI_IMAGE_PATH}/_releases.json"
               if [[ -f "$release_json" ]]; then
                 revision_to_released_tags=$(python3 -m src.shared.release_info get_revision_to_released_tags --all-releases "$release_json")
-                affected_tracks=$(echo "${revision_to_released_tags}" | jq -r '."${STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_REVISION}" | map("- `\(.)`") | join("\n")')
+                affected_tracks=$(echo "${revision_to_released_tags}" | jq -r --arg rev "${STEPS_SIMPLIFY_IMAGE_NAME_OUTPUTS_IMG_REVISION}" '.[$rev] | map("- `\(.)`") | join("\n")')
                 echo -e "\n### Affected tracks:" >> issue.md
                 echo -e "${affected_tracks}" >> issue.md
               fi

--- a/.github/workflows/_Auto-updates.yaml
+++ b/.github/workflows/_Auto-updates.yaml
@@ -15,6 +15,8 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Get updated filenames
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
@@ -26,7 +28,9 @@ jobs:
             .github/base_digests/*
 
       - id: set-matrix
-        run: echo "matrix={\"base\":${{ steps.changed-files.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
+        run: echo "matrix={\"base\":${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
   check-auto-updates:
     name: Check for auto-updates based on ${{ matrix.base }}
@@ -38,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -60,4 +66,5 @@ jobs:
           OS_PROJECT_NAME: ${{ secrets.SWIFT_OS_TENANT_NAME }}
           OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL }}
           GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
-        run: poetry run python3 find_images_to_update.py `basename ${{ matrix.base }}`
+          MATRIX_BASE: ${{ matrix.base }}
+        run: poetry run python3 find_images_to_update.py "$(basename "${MATRIX_BASE}")"

--- a/.github/workflows/_Auto-updates.yaml
+++ b/.github/workflows/_Auto-updates.yaml
@@ -23,7 +23,7 @@ jobs:
         id: changed-files
         with:
           json: true
-          quotepath: false
+          escape_json: false
           files: |
             .github/base_digests/*
 

--- a/.github/workflows/_CLI-Client.yaml
+++ b/.github/workflows/_CLI-Client.yaml
@@ -13,6 +13,8 @@ jobs:
     name: Test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -27,6 +29,8 @@ jobs:
     name: Snap build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79
         id: snapcraft
         with:

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -17,8 +17,6 @@ on:
       - "tests/**"
       - "!tools/workflow-engine/**"
       - "!tools/cli-client/**"
-    branches:
-      - '*'
 
 env:
   # local path to clone the oci-factory to

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/validate-actor
         with:
           admin-only: true
@@ -45,6 +47,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -68,7 +71,7 @@ jobs:
       - name: Generate Summary
         if: ${{ !cancelled() }}
         run: |
-          python3 -m tools.junit_to_markdown --input-junit "${{ env.PYTEST_RESULT_PATH }}" >> $GITHUB_STEP_SUMMARY
+          python3 -m tools.junit_to_markdown --input-junit "${{ env.PYTEST_RESULT_PATH }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload pytest Result
         if: ${{ !cancelled() }}
@@ -87,6 +90,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Install bats
         run: |
@@ -97,7 +101,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ROCKSBOT_TOKEN }}
         run: |
-          find ${{ github.workspace }} -name 'test-*.bats' | xargs bats
+          find "${{ github.workspace }}" -name 'test-*.bats' -print0 | xargs -0 bats
   
   # # Test use case of reuseable workflow 
   # build-rock:

--- a/.github/workflows/_Test-OCI-Factory.yaml
+++ b/.github/workflows/_Test-OCI-Factory.yaml
@@ -17,6 +17,8 @@ on:
       - "tests/**"
       - "!tools/workflow-engine/**"
       - "!tools/cli-client/**"
+    branches:
+      - '*'
 
 env:
   # local path to clone the oci-factory to

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -55,11 +55,12 @@ upload:
     ignored-vulnerabilities:
       - "CVE-2023-1234"
       - "CVE-2023-5678"
-  - source: "canonical/rocks-toolbox"
-    commit: bb9138fbe81f893b4303a0e29df7cf9581069de0
-    directory: mock_rock/devel
-    release:
-      devel:
-        end-of-life: "2030-05-01T00:00:00Z"
-        risks:
-          - edge
+  # TODO: Restore the devel release once the https://github.com/canonical/rockcraft/issues/1262 is resolved.
+  # - source: "canonical/rocks-toolbox"
+  #   commit: bb9138fbe81f893b4303a0e29df7cf9581069de0
+  #   directory: mock_rock/devel
+  #   release:
+  #     devel:
+  #       end-of-life: "2030-05-01T00:00:00Z"
+  #       risks:
+  #         - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This pull request focuses on improving the robustness, maintainability, and security of the project's GitHub Actions workflows by addressing the **_CRITICAL_**-level antipatterns found by `zizmor`. The main changes include standardizing the use of environment variables for input and output handling, enhancing shell safety, pinning action versions for reproducibility, and ensuring credentials are not persisted unnecessarily.

**Workflow environment and input handling improvements:**

* Replaced direct GitHub Actions expressions (e.g., `${{ inputs.* }}`) in shell scripts with environment variables, making scripts more robust and easier to maintain across all workflows (`Build-Rock.yaml`, `Documentation.yaml`, `Announcements.yaml`).  Ref: https://docs.zizmor.sh/audits/#template-injection

**Security and reproducibility enhancements:**

* Added `persist-credentials: false` to all `actions/checkout` steps to prevent unnecessary credential persistence, improving workflow security.
* Pinned third-party GitHub Action versions to specific commit hashes for reproducibility and to prevent unexpected changes from upstream updates.

**Shell safety and code quality:**

* Improved shell command safety by quoting variable expansions and output file paths to prevent word splitting and globbing issues.
* Updated shell scripts to use `${VAR}` instead of `${{ ... }}` within shell blocks, aligning with best practices for environment variable usage.

**Other minor improvements:**

* Added missing `env` blocks and improved the clarity of variable usage in several jobs.
* Removed unnecessary `type: string` lines from the `action.yml` for cleaner action definitions.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

N/A

---

*Picture of a cool rock:*
