### PR TITLE
feat: bump litmuschaos rock versions

### DIFF
--- a/oci/litmuschaos-authserver/image.yaml
+++ b/oci/litmuschaos-authserver/image.yaml
@@ -1,14 +1,14 @@
 version: 2
 upload:
-  - source: canonical/litmuschaos-authserver-rock
+  - source: canonical/litmus-rocks
     commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
-    directory: 3.29.0
+    directory: litmuschaos-authserver/3.29.0
     release:
       3-24.04:
-        end-of-life: '2026-08-22T00:00:00Z'
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
       3.29-24.04:
-        end-of-life: '2026-08-22T00:00:00Z'
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-authserver/image.yaml
+++ b/oci/litmuschaos-authserver/image.yaml
@@ -4,11 +4,11 @@ upload:
     commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
     directory: litmuschaos-authserver/3.29.0
     release:
-      3-24.04:
+      3-26.04:
         end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.29-24.04:
+      3.29-26.04:
         end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-authserver/image.yaml
+++ b/oci/litmuschaos-authserver/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmuschaos-authserver-rock
-    commit: e5e17d14fb58bc8526972fd63b6536bc92e29cae
-    directory: 3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: 3.29.0
     release:
       3-24.04:
-        end-of-life: '2026-05-22T00:00:00Z'
+        end-of-life: '2026-08-22T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-05-22T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-02-19T00:00:00Z'
+      3.29-24.04:
+        end-of-life: '2026-08-22T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-event-tracker/image.yaml
+++ b/oci/litmuschaos-event-tracker/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 8492a9a6438ccb5402cc4400013ca52e650a5a13
-    directory: litmuschaos-event-tracker/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-event-tracker/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-exporter/image.yaml
+++ b/oci/litmuschaos-exporter/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 2d1b7a733557d093c04ffac6853f38f04d45fc0d
-    directory: litmuschaos-exporter/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-exporter/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-frontend/image.yaml
+++ b/oci/litmuschaos-frontend/image.yaml
@@ -1,18 +1,14 @@
 version: 2
 upload:
-  - source: canonical/litmuschaos-frontend-rock
-    commit: cab6fe36faf08b0aff0ef553fb1cbf7ef0d26657
-    directory: 3.28.0
+  - source: canonical/litmus-rocks
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-frontend/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-17T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.28-24.04:
-        end-of-life: '2026-07-17T00:00:00Z'
-        risks:
-          - edge
-      3.28.0-24.04:
-        end-of-life: '2026-04-16T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-operator/image.yaml
+++ b/oci/litmuschaos-operator/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 8492a9a6438ccb5402cc4400013ca52e650a5a13
-    directory: litmuschaos-operator/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-operator/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-runner/image.yaml
+++ b/oci/litmuschaos-runner/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 2d1b7a733557d093c04ffac6853f38f04d45fc0d
-    directory: litmuschaos-runner/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-runner/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-server/image.yaml
+++ b/oci/litmuschaos-server/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
-  - source: canonical/litmuschaos-server-rock
-    commit: 131cdac1b59fae5d7d45b08f8fab90d43de4c56c
-    directory: 3.26.0
+  - source: canonical/litmus-rocks
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-server/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-05-22T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-05-22T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-02-19T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-subscriber/image.yaml
+++ b/oci/litmuschaos-subscriber/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 8492a9a6438ccb5402cc4400013ca52e650a5a13
-    directory: litmuschaos-subscriber/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-subscriber/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
Updated version and commit details for the auth server.

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Update the rock versions for the litmuschaos project to 3.29

---

*Picture of a cool rock:* 🌋
