### PR TITLE
fix: Update Mattermost channel ID in contacts.yaml

### DIFF
--- a/oci/traefik/contacts.yaml
+++ b/oci/traefik/contacts.yaml
@@ -2,6 +2,6 @@ notify:
   emails:
     - platform-engineering@groups.canonical.com
   mattermost-channels:
-    - ud8qc65sdjnzf8ahrir6ers9dy
+    - pphoirkuo3na9bbjjnswrni7nh
 maintainers:
   - swetha1654


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description

The ID currently points to our public channel, which is flooded with rockbot messages about CI failures / successes.
<!--- Describe your changes in detail -->

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
