### PR TITLE
feat: bump litmuschaos-event-tracker to 3.29.0

### DIFF
--- a/oci/litmuschaos-event-tracker/image.yaml
+++ b/oci/litmuschaos-event-tracker/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 8492a9a6438ccb5402cc4400013ca52e650a5a13
-    directory: litmuschaos-event-tracker/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-event-tracker/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
Bump litmuschaos-event-tracker rock from 3.26.0 to 3.29.0.

Changes:
- Update commit to 6b028e8991a7178aab912bf00b980a53feeca5fe
- Update base from 24.04 to 26.04