### PR TITLE
feat: bump litmuschaos-frontend to 3.29.0

### DIFF
--- a/oci/litmuschaos-frontend/image.yaml
+++ b/oci/litmuschaos-frontend/image.yaml
@@ -1,18 +1,14 @@
 version: 2
 upload:
-  - source: canonical/litmuschaos-frontend-rock
-    commit: cab6fe36faf08b0aff0ef553fb1cbf7ef0d26657
-    directory: 3.28.0
+  - source: canonical/litmus-rocks
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-frontend/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-17T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.28-24.04:
-        end-of-life: '2026-07-17T00:00:00Z'
-        risks:
-          - edge
-      3.28.0-24.04:
-        end-of-life: '2026-04-16T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
Bump litmuschaos-frontend rock from 3.26.0 to 3.29.0.

Changes:
- Update source to canonical/litmus-rocks monorepo
- Update base from 24.04 to 26.04
- Add .trivyignore for upstream CVEs