### PR TITLE
feat: bump litmuschaos-server to 3.29.0

### DIFF
--- a/oci/litmuschaos-server/image.yaml
+++ b/oci/litmuschaos-server/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
-  - source: canonical/litmuschaos-server-rock
-    commit: 131cdac1b59fae5d7d45b08f8fab90d43de4c56c
-    directory: 3.26.0
+  - source: canonical/litmus-rocks
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-server/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-05-22T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-05-22T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-02-19T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge

--- a/oci/litmuschaos-server/image.yaml
+++ b/oci/litmuschaos-server/image.yaml
@@ -30,3 +30,8 @@ upload:
       - CVE-2026-39836  # stdlib
       - CVE-2026-42499  # stdlib
       - CVE-2026-42504  # stdlib
+      - CVE-2025-62156  # github.com/argoproj/argo-workflows/v3
+      - CVE-2025-62157  # github.com/argoproj/argo-workflows/v3
+      - CVE-2025-66626  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-23960  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-31892  # github.com/argoproj/argo-workflows/v3

--- a/oci/litmuschaos-server/image.yaml
+++ b/oci/litmuschaos-server/image.yaml
@@ -12,3 +12,21 @@ upload:
         end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
+    ignored-vulnerabilities:
+      - CVE-2026-42294  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-42296  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-44973  # github.com/go-git/go-billy/v5
+      - CVE-2026-45022  # github.com/go-git/go-git/v5
+      - CVE-2026-25679  # stdlib
+      - CVE-2026-32280  # stdlib
+      - CVE-2026-32281  # stdlib
+      - CVE-2026-32283  # stdlib
+      - CVE-2026-33811  # stdlib
+      - CVE-2026-33814  # stdlib
+      - CVE-2026-39820  # stdlib
+      - CVE-2026-39823  # stdlib
+      - CVE-2026-39825  # stdlib
+      - CVE-2026-39826  # stdlib
+      - CVE-2026-39836  # stdlib
+      - CVE-2026-42499  # stdlib
+      - CVE-2026-42504  # stdlib


### PR DESCRIPTION
Bump litmuschaos-server rock from 3.23.0 to 3.29.0.

Changes:
- Update source to canonical/litmus-rocks monorepo
- Update base from 24.04 to 26.04
- Update .trivyignore with additional upstream CVEs