### PR TITLE
feat: bump litmuschaos-subscriber to 3.29.0

### DIFF
--- a/oci/litmuschaos-subscriber/image.yaml
+++ b/oci/litmuschaos-subscriber/image.yaml
@@ -12,3 +12,6 @@ upload:
         end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
+    ignored-vulnerabilities:
+      - CVE-2026-42294  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-42296  # github.com/argoproj/argo-workflows/v3

--- a/oci/litmuschaos-subscriber/image.yaml
+++ b/oci/litmuschaos-subscriber/image.yaml
@@ -15,3 +15,8 @@ upload:
     ignored-vulnerabilities:
       - CVE-2026-42294  # github.com/argoproj/argo-workflows/v3
       - CVE-2026-42296  # github.com/argoproj/argo-workflows/v3
+      - CVE-2025-62156  # github.com/argoproj/argo-workflows/v3
+      - CVE-2025-62157  # github.com/argoproj/argo-workflows/v3
+      - CVE-2025-66626  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-23960  # github.com/argoproj/argo-workflows/v3
+      - CVE-2026-31892  # github.com/argoproj/argo-workflows/v3

--- a/oci/litmuschaos-subscriber/image.yaml
+++ b/oci/litmuschaos-subscriber/image.yaml
@@ -1,18 +1,14 @@
-version: 1
+version: 2
 upload:
   - source: canonical/litmus-rocks
-    commit: 8492a9a6438ccb5402cc4400013ca52e650a5a13
-    directory: litmuschaos-subscriber/3.26.0
+    commit: 6b028e8991a7178aab912bf00b980a53feeca5fe
+    directory: litmuschaos-subscriber/3.29.0
     release:
-      3-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
+      3-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge
-      3.26-24.04:
-        end-of-life: '2026-07-10T00:00:00Z'
-        risks:
-          - edge
-      3.26.0-24.04:
-        end-of-life: '2026-04-11T00:00:00Z'
+      3.29-26.04:
+        end-of-life: '2026-09-01T00:00:00Z'
         risks:
           - edge


### PR DESCRIPTION
Bump litmuschaos-subscriber rock from 3.26.0 to 3.29.0.

Changes:
- Update commit to 6b028e8991a7178aab912bf00b980a53feeca5fe
- Update base from 24.04 to 26.04