### PR TITLE
chore: add new traefik release 2.11.46 multiarch

### DIFF
--- a/oci/traefik/image.yaml
+++ b/oci/traefik/image.yaml
@@ -1,11 +1,11 @@
 version: 1
 upload:
   - source: canonical/traefik-rock
-    commit: 664009f477a88b67a16a689e074f49f1d5d1eda1
+    commit: af6fcfa61bbdd6c7cb70e909a3e48c3ccdd98eae
     directory: 2.11.46
     release:
       2.11-26.04:
-        end-of-life: "2026-08-29T00:00:00Z"
+        end-of-life: "2026-09-15T00:00:00Z"
         risks:
           - edge
   - source: canonical/traefik-rock


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

Add new traefik release multi-arch with support for amd64, arm64 and s390x.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
