### PR TITLE
chore: bump go:1.25-26.04 to stable

### DIFF
--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -16,9 +16,9 @@ upload:
       - CVE-2024-24788  # Not affected. CVSS: 5.9 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2024-24788
       - CVE-2024-24790  # Patched. CVSS: 9.8 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2024-24790
       - CVE-2024-34156  # Patched. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2024-34156
-      - CVE-2025-22871  # Needs evaluation. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-22871
+      - CVE-2025-22871  # Vulnerable, but no fix available. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-22871
       - CVE-2025-47906  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47906
-      - CVE-2025-47907  # Needs evaluation. CVSS: 7.0 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47907
+      - CVE-2025-47907  # Vulnerable, but no fix available. CVSS: 7.0 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47907
       - CVE-2025-47912  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47912
       - CVE-2025-58183  # Needs evaluation. CVSS: 4.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-58183
       - CVE-2025-58185  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-58185
@@ -33,19 +33,19 @@ upload:
       - CVE-2025-61727  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61727
       - CVE-2025-61728  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61728
       - CVE-2025-61729  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61729
-      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
+      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 7.4 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
-      - CVE-2026-32280  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
       - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Needs evaluation. CVSS: 6.4 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32282
       - CVE-2026-32283  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32283
       - CVE-2026-33811  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33811
-      - CVE-2026-33814  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
+      - CVE-2026-33814  # Not tracked for golang-1.22 (golang-golang-x-net only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
       - CVE-2026-39820  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39820
       - CVE-2026-39823  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39823
       - CVE-2026-39825  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39825
       - CVE-2026-39826  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39826
-      - CVE-2026-39836  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
+      - CVE-2026-39836  # Not affected (Windows-only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
       - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504
 
@@ -54,7 +54,7 @@ upload:
     commit: ca8bbe2663fb6c4e911751a90778f71bb3972368
     release:
       1.25-26.04:
-        end-of-life: "2026-05-30T00:00:00Z"
+        end-of-life: "2031-05-29T00:00:00Z"
         risks:
           - edge
           - beta
@@ -63,17 +63,17 @@ upload:
     ignored-vulnerabilities:
       - CVE-2025-61726  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61726
       - CVE-2025-61728  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61728
-      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
+      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 7.4 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
-      - CVE-2026-32280  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
       - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Needs evaluation. CVSS: 6.4 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32282
       - CVE-2026-32283  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32283
       - CVE-2026-33811  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33811
-      - CVE-2026-33814  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
+      - CVE-2026-33814  # Not tracked for golang-1.25 (golang-golang-x-net only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
       - CVE-2026-39820  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39820
       - CVE-2026-39823  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39823
       - CVE-2026-39825  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39825
       - CVE-2026-39826  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39826
-      - CVE-2026-39836  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
+      - CVE-2026-39836  # Not affected (Windows-only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -77,3 +77,4 @@ upload:
       - CVE-2026-39826  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39826
       - CVE-2026-39836  # Not affected (Windows-only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
+      - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -47,6 +47,7 @@ upload:
       - CVE-2026-39826  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39826
       - CVE-2026-39836  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
+      - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504
 
   - source: canonical/golang-rock
     directory: go-rock/1.25-26.04

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -56,6 +56,9 @@ upload:
         end-of-life: "2026-05-30T00:00:00Z"
         risks:
           - edge
+          - beta
+          - candidate
+          - stable
     ignored-vulnerabilities:
       - CVE-2025-61726  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61726
       - CVE-2025-61728  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61728


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

Bump `go:1.25-26.04` to stable.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

N/A

---

*Picture of a cool rock:*
