### PR TITLE
chore: update Valkey image

### DIFF
--- a/oci/valkey/image.yaml
+++ b/oci/valkey/image.yaml
@@ -2,10 +2,10 @@ version: 1
 
 upload:
   - source: "canonical/charmed-valkey-rock"
-    commit: 916eff983d28129053093a560ff2e4a48e207ffc
+    commit: b347a0ecb3eb7e1c29d297e1cafcb6e46a66a0c9
     directory: .
     release:
-      7.2.11-24.04:
+      7.2.12-24.04:
         end-of-life: "2029-04-01T00:00:00Z"
         risks:
           - stable

--- a/oci/valkey/image.yaml
+++ b/oci/valkey/image.yaml
@@ -2,7 +2,7 @@ version: 1
 
 upload:
   - source: "canonical/charmed-valkey-rock"
-    commit: b347a0ecb3eb7e1c29d297e1cafcb6e46a66a0c9
+    commit: 899267413125b680cc59b3c8bfcece9253368d4a
     directory: .
     release:
       7.2.12-24.04:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
Update Valkey image to newer version 7.2.12, and address security issues raised on the previous image.

### Related issues
Security issues raised by the ROCKsBot, e.g. https://github.com/canonical/charmed-valkey-rock/issues/41