### PR TITLE
feat: onboard go 1.26-26.04

### DIFF
--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -16,9 +16,9 @@ upload:
       - CVE-2024-24788  # Not affected. CVSS: 5.9 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2024-24788
       - CVE-2024-24790  # Patched. CVSS: 9.8 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2024-24790
       - CVE-2024-34156  # Patched. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2024-34156
-      - CVE-2025-22871  # Needs evaluation. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-22871
+      - CVE-2025-22871  # Vulnerable, but no fix available. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-22871
       - CVE-2025-47906  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47906
-      - CVE-2025-47907  # Needs evaluation. CVSS: 7.0 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47907
+      - CVE-2025-47907  # Vulnerable, but no fix available. CVSS: 7.0 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47907
       - CVE-2025-47912  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-47912
       - CVE-2025-58183  # Needs evaluation. CVSS: 4.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-58183
       - CVE-2025-58185  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-58185
@@ -33,20 +33,21 @@ upload:
       - CVE-2025-61727  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61727
       - CVE-2025-61728  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61728
       - CVE-2025-61729  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61729
-      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
+      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 7.4 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
-      - CVE-2026-32280  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
       - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Needs evaluation. CVSS: 6.4 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32282
       - CVE-2026-32283  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32283
       - CVE-2026-33811  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33811
-      - CVE-2026-33814  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
+      - CVE-2026-33814  # Not tracked for golang-1.22 (golang-golang-x-net only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
       - CVE-2026-39820  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39820
       - CVE-2026-39823  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39823
       - CVE-2026-39825  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39825
       - CVE-2026-39826  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39826
-      - CVE-2026-39836  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
+      - CVE-2026-39836  # Not affected (Windows-only). CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
+      - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504
 
   - source: canonical/golang-rock
     directory: go-rock/1.26-26.04

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -49,27 +49,26 @@ upload:
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
 
   - source: canonical/golang-rock
-    directory: go-rock/1.25-26.04
-    commit: ca8bbe2663fb6c4e911751a90778f71bb3972368
+    directory: go-rock/1.26-26.04
+    commit: a09cbbfe909148cd965fae74f73b92cfb623f48f
     release:
       1.25-26.04:
-        end-of-life: "2026-05-30T00:00:00Z"
+        end-of-life: "2031-05-29T00:00:00Z"
         risks:
           - edge
     ignored-vulnerabilities:
-      - CVE-2025-61726  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61726
-      - CVE-2025-61728  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61728
-      - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 9.1 (Critical), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
-      - CVE-2026-32280  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-27137  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27137
+      - CVE-2026-27145  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27145
+      - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
       - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
-      - CVE-2026-32282  # Needs evaluation. CVSS: 6.4 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32282
       - CVE-2026-32283  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32283
+      - CVE-2026-33810  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33810
       - CVE-2026-33811  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33811
       - CVE-2026-33814  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
       - CVE-2026-39820  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39820
       - CVE-2026-39823  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39823
       - CVE-2026-39825  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39825
-      - CVE-2026-39826  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39826
-      - CVE-2026-39836  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
+      - CVE-2026-39836  # Not affected. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
       - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
+      - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR onboards the go rock with track 1.26-26.04. This is the LTS go rock on 26.04

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A
---

*Picture of a cool rock:*
