### PR TITLE
chore: stablize go 1.26 on 26.04 and eol 1.25

### DIFF
--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -50,13 +50,39 @@ upload:
       - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504
 
   - source: canonical/golang-rock
-    directory: go-rock/1.26-26.04
+    directory: go-rock/1.25-26.04
     commit: a09cbbfe909148cd965fae74f73b92cfb623f48f
     release:
       1.25-26.04:
+        end-of-life: "2026-07-01T00:00:00Z"
+        risks:
+          - edge
+    ignored-vulnerabilities:
+      - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
+      - CVE-2026-27145  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27145
+      - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
+      - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
+      - CVE-2026-32283  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32283
+      - CVE-2026-33811  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33811
+      - CVE-2026-33814  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-33814
+      - CVE-2026-39820  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39820
+      - CVE-2026-39823  # Needs evaluation. CVSS: 6.1 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39823
+      - CVE-2026-39825  # Needs evaluation. CVSS: 5.3 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39825
+      - CVE-2026-39836  # Not affected. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-39836
+      - CVE-2026-42499  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42499
+      - CVE-2026-42504  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-42504
+
+  - source: canonical/golang-rock
+    directory: go-rock/1.26-26.04
+    commit: a09cbbfe909148cd965fae74f73b92cfb623f48f
+    release:
+      1.26-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
         risks:
           - edge
+          - beta
+          - candidate
+          - stable
     ignored-vulnerabilities:
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
       - CVE-2026-27137  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27137

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -35,7 +35,7 @@ upload:
       - CVE-2025-61729  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61729
       - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 7.4 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
-      - CVE-2026-27145 # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27145
+      - CVE-2026-27145  # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27145
       - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
       - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Needs evaluation. CVSS: 6.4 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32282

--- a/oci/go/image.yaml
+++ b/oci/go/image.yaml
@@ -35,6 +35,7 @@ upload:
       - CVE-2025-61729  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-61729
       - CVE-2025-68121  # Vulnerable, but no fix available. CVSS: 7.4 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2025-68121
       - CVE-2026-25679  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-25679
+      - CVE-2026-27145 # Needs evaluation. CVSS: 6.5 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-27145
       - CVE-2026-32280  # Vulnerable, but no fix available. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32280
       - CVE-2026-32281  # Needs evaluation. CVSS: 7.5 (High), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32281
       - CVE-2026-32282  # Needs evaluation. CVSS: 6.4 (Medium), Ubuntu priority: Medium. https://ubuntu.com/security/CVE-2026-32282
@@ -54,7 +55,7 @@ upload:
     commit: a09cbbfe909148cd965fae74f73b92cfb623f48f
     release:
       1.25-26.04:
-        end-of-life: "2026-07-01T00:00:00Z"
+        end-of-life: "2026-07-31T00:00:00Z"
         risks:
           - edge
     ignored-vulnerabilities:


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

As the title goes

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
