### PR TITLE
feat(ci): pro rock and ACR

### DIFF
--- a/.github/actions/crypt-artifact/crypt-artifact.sh
+++ b/.github/actions/crypt-artifact/crypt-artifact.sh
@@ -80,10 +80,6 @@ validate_args() {
         exit 1
     fi
 
-    if [ "$mode" = "decrypt" ] && ! file "$input_file" | grep -q "PGP symmetric key encrypted data"; then
-        log_error "Input file is not a valid GPG encrypted file: $input_file"
-        exit 1
-    fi
 }
 
 #
@@ -103,10 +99,8 @@ encrypt_file() {
 decrypt_file() {
     local output_file="${output_path:-${input_file%.gpg}}"
 
-    output=$(gpg --batch --yes --passphrase "$passphrase" -o "$output_file" -d "$input_file" 2>&1)
-    
-    if echo "$output" | grep -q "gpg: decryption failed:"; then
-        log_error "Decryption failed for file: $input_file. Bad passphrase."
+    if ! output=$(gpg --batch --yes --passphrase "$passphrase" -o "$output_file" -d "$input_file" 2>&1); then
+        log_error "Decryption failed for file: $input_file."
         exit 1
     else
         log_info "Decrypted file: $input_file into $output_file"

--- a/.github/actions/crypt-artifact/test-crypt-artifact.bats
+++ b/.github/actions/crypt-artifact/test-crypt-artifact.bats
@@ -208,7 +208,7 @@ teardown() {
  
   # Check that test_file_1.log was *not* removed (it was skipped)
   [ -f "$test_file" ]
-  grep -q "Input file is not a valid GPG encrypted file: $test_file" <<< "$output"
+  grep -q "Decryption failed for file: $test_file." <<< "$output"
 }
 
 @test "encryption fails with incorrect passphrase on decryption attempt" {
@@ -226,6 +226,7 @@ teardown() {
 
   # Check that the decryption failed
   [[ "$status" -eq 1 ]]
+  grep -q "Decryption failed for file: $encrypted_file." <<< "$output"
   
   # Check that the original file was not recreated, and the encrypted file remains
   ! [ -f "$test_file" ]

--- a/.github/workflows/Build-Rock.yaml
+++ b/.github/workflows/Build-Rock.yaml
@@ -63,6 +63,8 @@ on:
         description: "Passphrase for encrypting/decrypting rock artifacts when pro-services is used."
       pro-token:
         description: "The Ubuntu Pro token. Required for building Ubuntu Pro based rocks."
+      LP_CREDENTIALS_B64:
+        description: "Launchpad credentials for fallback builds."
 
 
 env:

--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -44,6 +44,9 @@ jobs:
   run-tests:
     name: Run tests for released images
     needs: [prepare-test-matrix]
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-test-matrix.outputs.released-revisions-matrix) }}
@@ -54,4 +57,5 @@ jobs:
       trivyignore-path: "oci/${{ matrix.name }}/.trivyignore"
       date-last-scan: ${{ needs.prepare-test-matrix.outputs.last-scan }}
       create-issue: true
+      encrypted-source-image: ${{ matrix.encrypted-source-image }}
     secrets: inherit

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -570,8 +570,8 @@ jobs:
             "docker://${GHCR_IMAGE}"
 
           encrypted_manifest=$(skopeo inspect --raw "docker://${GHCR_IMAGE}" \
-            --src-username "${GITHUB_ACTOR}" \
-            --src-password "${{ secrets.GITHUB_TOKEN }}")
+            --username "${GITHUB_ACTOR}" \
+            --password "${{ secrets.GITHUB_TOKEN }}")
           if jq -e 'has("layers")' <<< "${encrypted_manifest}" > /dev/null; then
             unencrypted_layers=$(jq '[.layers[].mediaType | select(endswith("+encrypted") | not)] | length' <<< "${encrypted_manifest}")
           else
@@ -579,8 +579,8 @@ jobs:
               jq -r '.manifests[].digest' <<< "${encrypted_manifest}" |
               while read -r digest; do
                 child_manifest=$(skopeo inspect --raw "docker://${GHCR_IMAGE%:*}@${digest}" \
-                  --src-username "${GITHUB_ACTOR}" \
-                  --src-password "${{ secrets.GITHUB_TOKEN }}")
+                  --username "${GITHUB_ACTOR}" \
+                  --password "${{ secrets.GITHUB_TOKEN }}")
                 jq '[.layers[].mediaType | select(endswith("+encrypted") | not)] | length' <<< "${child_manifest}"
               done | awk '{sum += $1} END {print sum}'
             )

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -488,7 +488,6 @@ jobs:
           STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME: ${{ steps.rename-oci-archive.outputs.name }}
 
       - name: Login to GHCR
-        if: ${{ matrix.pro-services == '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
@@ -521,6 +520,36 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
 
+      - name: Upload encrypted Pro image to GHCR
+        if: ${{ matrix.pro-services != '' }}
+        id: upload-encrypted-pro-image
+        env:
+          PRO_ROCK_ENCRYPTION_PUBLIC_KEY: ${{ secrets.PRO_ROCK_ENCRYPTION_PUBLIC_KEY }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/oci-factory/${{ matrix.name }}:${{ matrix.track }}_${{ matrix.revision }}
+          OCI_IMAGE_ARCHIVE: ${{ steps.rename-oci-archive.outputs.name }}
+        run: |
+          set -e
+          key_file="${RUNNER_TEMP}/pro-rock-encryption-public.pem"
+          printf '%s' "${PRO_ROCK_ENCRYPTION_PUBLIC_KEY}" > "${key_file}"
+          chmod 600 "${key_file}"
+
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
+
+          skopeo --insecure-policy copy \
+            --multi-arch all \
+            --remove-signatures \
+            --encryption-key "jwe:${key_file}" \
+            --encrypt-layer -1 \
+            --digestfile encrypted-pro-image-digest.txt \
+            --dest-username "${GITHUB_ACTOR}" \
+            --dest-password "${{ secrets.GITHUB_TOKEN }}" \
+            "oci-archive:${OCI_IMAGE_ARCHIVE}" \
+            "docker://${GHCR_IMAGE}"
+
+          echo "digest=$(cat encrypted-pro-image-digest.txt)" >> "$GITHUB_OUTPUT"
+
       - name: Upload build metadata to Swift
         env:
           OS_AUTH_URL: ${{ secrets.SWIFT_OS_AUTH_URL_PS7 }}
@@ -532,7 +561,7 @@ jobs:
           IMAGE_NAME: ${{ matrix.name }}
           SWIFT_CONTAINER_NAME: ${{ vars.SWIFT_CONTAINER_NAME }}
           MATRIX_BASE: ${{ matrix.base }}
-          IMAGE_DIGEST: ${{ matrix.pro-services == '' && steps.upload-image.outputs.digest || steps.image-digest.outputs.digest }}
+          IMAGE_DIGEST: ${{ matrix.pro-services == '' && steps.upload-image.outputs.digest || steps.upload-encrypted-pro-image.outputs.digest }}
           MATRIX_IGNORED_VULNERABILITIES: ${{ matrix.ignored-vulnerabilities }}
           MATRIX_NAME: ${{ matrix.name }}
           MATRIX_TRACK: ${{ matrix.track }}
@@ -646,6 +675,7 @@ jobs:
     needs: [prepare-build, prepare-releases]
     permissions:
       contents: write
+      packages: read
     uses: ./.github/workflows/Release.yaml
     with:
       oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -530,6 +530,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
 
+      - name: Get Pro image layers to encrypt
+        if: ${{ matrix.pro-services != '' }}
+        id: get-encrypt-layers
+        run: |
+          layers=$(src/image/get_encrypt_layers_from_oci_archive.sh \
+            --archive "${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}")
+          echo "layers=${layers}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME: ${{ steps.rename-oci-archive.outputs.name }}
+
       - name: Upload encrypted Pro image to GHCR
         if: ${{ matrix.pro-services != '' }}
         id: upload-encrypted-pro-image
@@ -537,7 +547,7 @@ jobs:
           PRO_ROCK_ENCRYPTION_PUBLIC_KEY: ${{ secrets.PRO_ROCK_ENCRYPTION_PUBLIC_KEY }}
           GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/oci-factory/${{ matrix.name }}:${{ matrix.track }}_${{ matrix.revision }}
           OCI_IMAGE_ARCHIVE: ${{ steps.rename-oci-archive.outputs.name }}
-          STEPS_GET_ARCHES_OUTPUTS_ARCHES: ${{ steps.get-arches.outputs.arches }}
+          STEPS_GET_ENCRYPT_LAYERS_OUTPUTS_LAYERS: ${{ steps.get-encrypt-layers.outputs.layers }}
         run: |
           set -e
           key_file="${RUNNER_TEMP}/pro-rock-encryption-public.pem"
@@ -548,25 +558,11 @@ jobs:
             set -x
           fi
 
-          first_arch="${STEPS_GET_ARCHES_OUTPUTS_ARCHES%%,*}"
-          raw_manifest=$(skopeo --override-arch "${first_arch}" inspect --raw "oci-archive:${OCI_IMAGE_ARCHIVE}")
-          layer_count=$(jq -r '.layers | length' <<< "${raw_manifest}")
-
-          if [[ -z "${layer_count}" || "${layer_count}" = "null" ]]; then
-            echo "Unable to determine OCI image layers to encrypt."
-            exit 1
-          fi
-          if [[ "${layer_count}" -le 0 ]]; then
-            echo "Cannot encrypt image with no layers."
-            exit 1
-          fi
-          encrypt_layers=$(seq -s, 0 "$((layer_count - 1))")
-
           skopeo --insecure-policy copy \
             --multi-arch all \
             --remove-signatures \
             --encryption-key "jwe:${key_file}" \
-            --encrypt-layer "${encrypt_layers}" \
+            --encrypt-layer "${STEPS_GET_ENCRYPT_LAYERS_OUTPUTS_LAYERS}" \
             --digestfile encrypted-pro-image-digest.txt \
             --dest-username "${GITHUB_ACTOR}" \
             --dest-password "${{ secrets.GITHUB_TOKEN }}" \

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -479,7 +479,16 @@ jobs:
           fi
           echo "hashes=$(sha256sum ${VULN_REPORT} ${OCI_IMAGE_ARCHIVE} ${SBOMS} | base64 -w0)"
 
+      - name: Calculate image digest
+        id: image-digest
+        run: |
+          digest=$(skopeo inspect --raw "oci-archive:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}" | sha256sum | cut -d' ' -f1)
+          echo "digest=sha256:${digest}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME: ${{ steps.rename-oci-archive.outputs.name }}
+
       - name: Login to GHCR
+        if: ${{ matrix.pro-services == '' }}
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
@@ -501,6 +510,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload to GHCR
+        if: ${{ matrix.pro-services == '' }}
         id: upload-image
         uses: ./.github/actions/upload-rock
         with:
@@ -522,7 +532,7 @@ jobs:
           IMAGE_NAME: ${{ matrix.name }}
           SWIFT_CONTAINER_NAME: ${{ vars.SWIFT_CONTAINER_NAME }}
           MATRIX_BASE: ${{ matrix.base }}
-          STEPS_UPLOAD_IMAGE_OUTPUTS_DIGEST: ${{ steps.upload-image.outputs.digest }}
+          IMAGE_DIGEST: ${{ matrix.pro-services == '' && steps.upload-image.outputs.digest || steps.image-digest.outputs.digest }}
           MATRIX_IGNORED_VULNERABILITIES: ${{ matrix.ignored-vulnerabilities }}
           MATRIX_NAME: ${{ matrix.name }}
           MATRIX_TRACK: ${{ matrix.track }}
@@ -530,7 +540,7 @@ jobs:
           STEPS_GENERATE_SBOMS_OUTPUTS_SBOMS: ${{ steps.generate-sboms.outputs.sboms }}
         run: |
           jq --arg base "${MATRIX_BASE}" \
-            --arg digest "${STEPS_UPLOAD_IMAGE_OUTPUTS_DIGEST}" \
+            --arg digest "${IMAGE_DIGEST}" \
             --arg ignored_vulnerabilities "${MATRIX_IGNORED_VULNERABILITIES}" \
             '. + {base: $base, digest: $digest, "ignored-vulnerabilities": $ignored_vulnerabilities}' \
             <<< '${{ toJSON(matrix) }}' \
@@ -560,6 +570,8 @@ jobs:
     needs: [prepare-build, prepare-upload, upload]
     runs-on: ubuntu-22.04
     if: ${{ needs.prepare-build.outputs.release-to != '' }}
+    outputs:
+      pro-artifact-passphrase-secret-name: ${{ steps.merge-release-requests.outputs.pro-artifact-passphrase-secret-name }}
     concurrency:
       group: ${{ needs.prepare-build.outputs.oci-img-path }}
       cancel-in-progress: true
@@ -619,6 +631,11 @@ jobs:
               --revision-data-file "${REVISION_DATA_DIR}/${revision_file}"
           done
 
+          pro_artifact_passphrase_secret_name=$(python3 -m src.image.pro \
+            pro_artifact_passphrase_secret \
+            --image-trigger "${NEEDS_PREPARE_BUILD_OUTPUTS_OCI_IMG_PATH}/image.yaml")
+          echo "pro-artifact-passphrase-secret-name=${pro_artifact_passphrase_secret_name}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ needs.prepare-build.outputs.oci-img-path }}/image.yaml
@@ -633,6 +650,7 @@ jobs:
     with:
       oci-image-name: "${{ needs.prepare-build.outputs.oci-img-name }}"
       image-trigger-cache-key: "${{ github.run_id }}-image-trigger"
+      pro-artifact-passphrase-secret-name: "${{ needs.prepare-releases.outputs.pro-artifact-passphrase-secret-name }}"
     secrets: inherit
 
   generate-provenance:

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -356,6 +356,16 @@ jobs:
         with:
           name: ${{ env.OCI_ARCHIVE_NAME }}
 
+      - name: Decrypt Pro image artifact
+        if: ${{ matrix.pro-services != '' }}
+        uses: ./.github/actions/crypt-artifact
+        with:
+          mode: decrypt
+          passphrase: ${{ secrets[matrix.pro-artifact-passphrase] }}
+          input-path: ${{ env.OCI_ARCHIVE_NAME }}.gpg
+          output-path: ${{ env.OCI_ARCHIVE_NAME }}
+          preserve-original: false
+
       - name: Name output artefact
         id: rename-oci-archive
         run: |

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -537,6 +537,7 @@ jobs:
           PRO_ROCK_ENCRYPTION_PUBLIC_KEY: ${{ secrets.PRO_ROCK_ENCRYPTION_PUBLIC_KEY }}
           GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/oci-factory/${{ matrix.name }}:${{ matrix.track }}_${{ matrix.revision }}
           OCI_IMAGE_ARCHIVE: ${{ steps.rename-oci-archive.outputs.name }}
+          STEPS_GET_ARCHES_OUTPUTS_ARCHES: ${{ steps.get-arches.outputs.arches }}
         run: |
           set -e
           key_file="${RUNNER_TEMP}/pro-rock-encryption-public.pem"
@@ -547,16 +548,51 @@ jobs:
             set -x
           fi
 
+          first_arch="${STEPS_GET_ARCHES_OUTPUTS_ARCHES%%,*}"
+          raw_manifest=$(skopeo --override-arch "${first_arch}" inspect --raw "oci-archive:${OCI_IMAGE_ARCHIVE}")
+          layer_count=$(jq -r '.layers | length' <<< "${raw_manifest}")
+
+          if [[ -z "${layer_count}" || "${layer_count}" = "null" ]]; then
+            echo "Unable to determine OCI image layers to encrypt."
+            exit 1
+          fi
+          if [[ "${layer_count}" -le 0 ]]; then
+            echo "Cannot encrypt image with no layers."
+            exit 1
+          fi
+          encrypt_layers=$(seq -s, 0 "$((layer_count - 1))")
+
           skopeo --insecure-policy copy \
             --multi-arch all \
             --remove-signatures \
             --encryption-key "jwe:${key_file}" \
-            --encrypt-layer -1 \
+            --encrypt-layer "${encrypt_layers}" \
             --digestfile encrypted-pro-image-digest.txt \
             --dest-username "${GITHUB_ACTOR}" \
             --dest-password "${{ secrets.GITHUB_TOKEN }}" \
             "oci-archive:${OCI_IMAGE_ARCHIVE}" \
             "docker://${GHCR_IMAGE}"
+
+          encrypted_manifest=$(skopeo inspect --raw "docker://${GHCR_IMAGE}" \
+            --src-username "${GITHUB_ACTOR}" \
+            --src-password "${{ secrets.GITHUB_TOKEN }}")
+          if jq -e 'has("layers")' <<< "${encrypted_manifest}" > /dev/null; then
+            unencrypted_layers=$(jq '[.layers[].mediaType | select(endswith("+encrypted") | not)] | length' <<< "${encrypted_manifest}")
+          else
+            unencrypted_layers=$(
+              jq -r '.manifests[].digest' <<< "${encrypted_manifest}" |
+              while read -r digest; do
+                child_manifest=$(skopeo inspect --raw "docker://${GHCR_IMAGE%:*}@${digest}" \
+                  --src-username "${GITHUB_ACTOR}" \
+                  --src-password "${{ secrets.GITHUB_TOKEN }}")
+                jq '[.layers[].mediaType | select(endswith("+encrypted") | not)] | length' <<< "${child_manifest}"
+              done | awk '{sum += $1} END {print sum}'
+            )
+          fi
+          if [[ "${unencrypted_layers}" -ne 0 ]]; then
+            echo "Encrypted Pro image upload left ${unencrypted_layers} unencrypted layers."
+            exit 1
+          fi
 
           echo "digest=$(cat encrypted-pro-image-digest.txt)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -197,7 +197,12 @@ jobs:
       rock-repo-commit: ${{ matrix.commit }}
       rockfile-directory: ${{ matrix.directory }}
       lpci-fallback: true
-    secrets: inherit
+      pro-services: ${{ matrix.pro-services }}
+    secrets:
+      source-github-token: ${{ secrets.ROCKSBOT_TOKEN }}
+      pro-token: ${{ secrets[matrix.pro-token] }}
+      pro-artifact-passphrase: ${{ secrets[matrix.pro-artifact-passphrase] }}
+      LP_CREDENTIALS_B64: ${{ secrets.LP_CREDENTIALS_B64 }}
 
   test-rock:
     needs: [prepare-build, build-rock]
@@ -210,7 +215,8 @@ jobs:
       oci-archive-name: "${{ matrix.name }}_${{ matrix.commit }}_${{ matrix.dir_identifier }}"
       trivyignore-path: ${{ matrix.ignored-vulnerabilities == '' && format('oci/{0}/.trivyignore', matrix.name) || '' }}
       ignored-vulnerabilities: ${{ matrix.ignored-vulnerabilities }}
-    secrets: inherit
+    secrets:
+      pro-artifact-passphrase: ${{ secrets[matrix.pro-artifact-passphrase] }}
 
   prepare-upload:
     runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
@@ -527,7 +533,9 @@ jobs:
             --arg digest "${STEPS_UPLOAD_IMAGE_OUTPUTS_DIGEST}" \
             --arg ignored_vulnerabilities "${MATRIX_IGNORED_VULNERABILITIES}" \
             '. + {base: $base, digest: $digest, "ignored-vulnerabilities": $ignored_vulnerabilities}' \
-            <<< '${{ toJSON(matrix) }}' > build_metadata.json
+            <<< '${{ toJSON(matrix) }}' \
+            | jq 'del(."pro-services", ."pro-token", ."pro-artifact-passphrase")' \
+            > build_metadata.json
           ./src/uploads/upload_to_swift.sh \
             "${MATRIX_NAME}" \
             "${MATRIX_TRACK}" \

--- a/.github/workflows/PR-Validator.yaml
+++ b/.github/workflows/PR-Validator.yaml
@@ -11,6 +11,7 @@ jobs:
     outputs:
       changed-files-matrix: ${{ steps.changed-files-matrix.outputs.matrix }}
       image-name: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
+      has-public-tracks: ${{ steps.check-public-tracks.outputs.has-public-tracks }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -56,6 +57,25 @@ jobs:
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.x"
+
+      - run: pip install -r src/image/requirements.txt
+
+      - name: Check public tracks
+        id: check-public-tracks
+        run: |
+          if [ -f "${STEPS_CHANGED_FILES_DIR_NAMES_OUTPUTS_ALL_CHANGED_FILES}/image.yaml" ]; then
+            has_public_tracks=$(python3 -m src.image.pro has_public_tracks \
+              --image-trigger "${STEPS_CHANGED_FILES_DIR_NAMES_OUTPUTS_ALL_CHANGED_FILES}/image.yaml")
+          else
+            has_public_tracks=true
+          fi
+          echo "has-public-tracks=${has_public_tracks}" >> "$GITHUB_OUTPUT"
+        env:
+          STEPS_CHANGED_FILES_DIR_NAMES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files-dir-names.outputs.all_changed_files }}
+
   check-missing-files:
     runs-on: ubuntu-22.04
     name: Check for missing files
@@ -68,6 +88,7 @@ jobs:
           persist-credentials: false
 
       - name: Check if documentation.yaml exists
+        if: ${{ needs.get-submitted-files.outputs.has-public-tracks == 'true' }}
         uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029
         with:
           files: "${{ needs.get-submitted-files.outputs.image-name }}/documentation.yaml"

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -85,6 +85,7 @@ jobs:
     needs: [validate-push-release-request]
     outputs:
       gh-releases-matrix: ${{ steps.release-image.outputs.gh-releases-matrix }}
+      has-public-tracks: ${{ steps.check-public-tracks.outputs.has-public-tracks }}
     env:
       IS_PROD: ${{ ! startsWith(inputs.oci-image-name, 'mock-') }}
       RELEASES_BRANCH: _releases
@@ -122,6 +123,16 @@ jobs:
         run: | 
           ./src/image/requirements.sh
           pip install -r src/image/requirements.txt
+
+      - name: Check public tracks
+        id: check-public-tracks
+        run: |
+          has_public_tracks=$(python3 -m src.image.pro has_public_tracks \
+            --image-trigger oci/${INPUTS_OCI_IMAGE_NAME}/image.yaml)
+          echo "has-public-tracks=${has_public_tracks}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+
       - name: Get all revisions per track
         id: get-all-canonical-tags
         env:
@@ -144,14 +155,14 @@ jobs:
           # https://github.com/actions/runner/issues/1483
           DOCKER_HUB_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.DOCKER_HUB_CREDS_PSW || secrets.DOCKER_HUB_CREDS_PSW_DEV }}
           DOCKER_HUB_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.DOCKER_HUB_CREDS_USR || secrets.DOCKER_HUB_CREDS_USR_DEV }}
-          # ACR_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ACR_CREDS_USR || secrets.ACR_CREDS_USR_DEV }}
-          # ACR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ACR_CREDS_PSW || secrets.ACR_CREDS_PSW_DEV }}
+          ACR_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ACR_PRO_CREDS_USR || secrets.ACR_PRO_CREDS_USR_DEV }}
+          ACR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ACR_PRO_CREDS_PSW || secrets.ACR_PRO_CREDS_PSW_DEV }}
           ECR_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ECR_CREDS_USR || secrets.ECR_CREDS_USR_DEV }}
           ECR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ECR_CREDS_PSW || secrets.ECR_CREDS_PSW_DEV }}
           # ECR_LTS_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ECR_LTS_CREDS_USR || secrets.ECR_LTS_CREDS_USR_DEV }}
           # ECR_LTS_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ECR_LTS_CREDS_PSW || secrets.ECR_LTS_CREDS_PSW_DEV }}
           
-          # ACR_NAMESPACE: ${{ env.IS_PROD == 'true' && 'ubuntu.azurecr.io' || secrets.ACR_NAMESPACE_DEV }}
+          ACR_NAMESPACE: ${{ env.IS_PROD == 'true' && secrets.ACR_PRO_NAMESPACE || secrets.ACR_PRO_NAMESPACE_DEV }}
           DOCKER_HUB_NAMESPACE: ${{ env.IS_PROD == 'true' && 'docker.io/ubuntu' || secrets.DOCKER_HUB_NAMESPACE_DEV }}
           ECR_NAMESPACE: ${{ env.IS_PROD == 'true' && 'ubuntu' || secrets.ECR_NAMESPACE_DEV }}
           # ECR_LTS_NAMESPACE: ${{ env.IS_PROD == 'true' && 'lts' || secrets.ECR_LTS_NAMESPACE_DEV }}
@@ -207,6 +218,7 @@ jobs:
   update-documentation:
     name: Update documentation
     needs: [do-releases]
+    if: ${{ needs.do-releases.outputs.has-public-tracks == 'true' }}
     uses: ./.github/workflows/Documentation.yaml
     with:
       oci-image-name: "${{ inputs.oci-image-name }}"

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Cache key (to fetch image trigger from cache)'
         required: false
         type: string
+      pro-artifact-passphrase-secret-name:
+        description: 'Secret name used to decrypt Pro release source artifacts'
+        required: false
+        type: string
       external_ref_id:  # (1)
         description: 'Optional ID for unique run detection'
         required: false
@@ -24,6 +28,10 @@ on:
         type: string
       image-trigger-cache-key:
         description: 'Cache key (to fetch image trigger from cache)'
+        required: false
+        type: string
+      pro-artifact-passphrase-secret-name:
+        description: 'Secret name used to decrypt Pro release source artifacts'
         required: false
         type: string
 
@@ -133,6 +141,35 @@ jobs:
         env:
           INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
 
+      - name: Check Pro tracks
+        id: check-pro-tracks
+        run: |
+          has_pro_tracks=$(python3 -m src.image.pro has_pro_tracks \
+            --image-trigger oci/${INPUTS_OCI_IMAGE_NAME}/image.yaml)
+          echo "has-pro-tracks=${has_pro_tracks}" >> "$GITHUB_OUTPUT"
+        env:
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+
+      - name: Download Pro release sources
+        if: ${{ steps.check-pro-tracks.outputs.has-pro-tracks == 'true' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: ${{ inputs.oci-image-name }}_*.gpg
+          path: pro-release-sources
+          merge-multiple: true
+
+      - name: Decrypt Pro release sources
+        if: ${{ steps.check-pro-tracks.outputs.has-pro-tracks == 'true' }}
+        env:
+          ARTIFACT_PASSPHRASE: ${{ secrets[inputs.pro-artifact-passphrase-secret-name] }}
+        run: |
+          for artifact in pro-release-sources/*.gpg; do
+            ./.github/actions/crypt-artifact/crypt-artifact.sh decrypt \
+              -i "${artifact}" \
+              -p "${ARTIFACT_PASSPHRASE}" \
+              -o "${artifact%.gpg}"
+          done
+
       - name: Get all revisions per track
         id: get-all-canonical-tags
         env:
@@ -183,6 +220,7 @@ jobs:
             --image-name ${INPUTS_OCI_IMAGE_NAME} \
             --all-releases oci/${INPUTS_OCI_IMAGE_NAME}/_releases.json \
             --all-revision-tags "${STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE}" \
+            --pro-release-sources pro-release-sources \
             --ghcr-repo "${{ github.repository_owner }}/oci-factory"
 
       - name: Update _releases.json

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -155,14 +155,14 @@ jobs:
           # https://github.com/actions/runner/issues/1483
           DOCKER_HUB_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.DOCKER_HUB_CREDS_PSW || secrets.DOCKER_HUB_CREDS_PSW_DEV }}
           DOCKER_HUB_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.DOCKER_HUB_CREDS_USR || secrets.DOCKER_HUB_CREDS_USR_DEV }}
-          ACR_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ACR_PRO_CREDS_USR || secrets.ACR_PRO_CREDS_USR_DEV }}
-          ACR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ACR_PRO_CREDS_PSW || secrets.ACR_PRO_CREDS_PSW_DEV }}
+          ACR_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ACR_CREDS_USR || secrets.ACR_CREDS_USR_DEV }}
+          ACR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ACR_CREDS_PSW || secrets.ACR_CREDS_PSW_DEV }}
           ECR_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ECR_CREDS_USR || secrets.ECR_CREDS_USR_DEV }}
           ECR_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ECR_CREDS_PSW || secrets.ECR_CREDS_PSW_DEV }}
           # ECR_LTS_CREDS_USR: ${{ env.IS_PROD == 'true' && secrets.ECR_LTS_CREDS_USR || secrets.ECR_LTS_CREDS_USR_DEV }}
           # ECR_LTS_CREDS_PSW: ${{ env.IS_PROD == 'true' && secrets.ECR_LTS_CREDS_PSW || secrets.ECR_LTS_CREDS_PSW_DEV }}
           
-          ACR_NAMESPACE: ${{ env.IS_PROD == 'true' && secrets.ACR_PRO_NAMESPACE || secrets.ACR_PRO_NAMESPACE_DEV }}
+          ACR_REGISTRY: ${{ env.IS_PROD == 'true' && secrets.ACR_REGISTRY || secrets.ACR_REGISTRY_DEV }}
           DOCKER_HUB_NAMESPACE: ${{ env.IS_PROD == 'true' && 'docker.io/ubuntu' || secrets.DOCKER_HUB_NAMESPACE_DEV }}
           ECR_NAMESPACE: ${{ env.IS_PROD == 'true' && 'ubuntu' || secrets.ECR_NAMESPACE_DEV }}
           # ECR_LTS_NAMESPACE: ${{ env.IS_PROD == 'true' && 'lts' || secrets.ECR_LTS_NAMESPACE_DEV }}

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -91,6 +91,9 @@ jobs:
     runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
     name: Release
     needs: [validate-push-release-request]
+    permissions:
+      contents: write
+      packages: read
     outputs:
       gh-releases-matrix: ${{ steps.release-image.outputs.gh-releases-matrix }}
       has-public-tracks: ${{ steps.check-public-tracks.outputs.has-public-tracks }}
@@ -150,26 +153,6 @@ jobs:
         env:
           INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
 
-      - name: Download Pro release sources
-        if: ${{ steps.check-pro-tracks.outputs.has-pro-tracks == 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          pattern: ${{ inputs.oci-image-name }}_*.gpg
-          path: pro-release-sources
-          merge-multiple: true
-
-      - name: Decrypt Pro release sources
-        if: ${{ steps.check-pro-tracks.outputs.has-pro-tracks == 'true' }}
-        env:
-          ARTIFACT_PASSPHRASE: ${{ secrets[inputs.pro-artifact-passphrase-secret-name] }}
-        run: |
-          for artifact in pro-release-sources/*.gpg; do
-            ./.github/actions/crypt-artifact/crypt-artifact.sh decrypt \
-              -i "${artifact}" \
-              -p "${ARTIFACT_PASSPHRASE}" \
-              -o "${artifact%.gpg}"
-          done
-
       - name: Get all revisions per track
         id: get-all-canonical-tags
         env:
@@ -181,7 +164,42 @@ jobs:
           IMAGE_NAME: ${{ inputs.oci-image-name }}
           SWIFT_CONTAINER_NAME: ${{ vars.SWIFT_CONTAINER_NAME }}
         run: ./src/image/get_canonical_tags_from_swift.sh
-      
+
+      - name: Decrypt Pro release sources from GHCR
+        if: ${{ steps.check-pro-tracks.outputs.has-pro-tracks == 'true' }}
+        env:
+          PRO_ROCK_DECRYPTION_PRIVATE_KEY: ${{ secrets.PRO_ROCK_DECRYPTION_PRIVATE_KEY }}
+          GHCR_REPO: ${{ github.repository_owner }}/oci-factory
+          INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+          STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE: ${{ steps.get-all-canonical-tags.outputs.canonical-tags-file }}
+        run: |
+          set -e
+          mkdir -p pro-release-sources
+          key_file="${RUNNER_TEMP}/pro-rock-decryption-private.pem"
+          printf '%s' "${PRO_ROCK_DECRYPTION_PRIVATE_KEY}" > "${key_file}"
+          chmod 600 "${key_file}"
+
+          if [[ "$RUNNER_DEBUG" == "1" ]]; then
+            set -x
+          fi
+
+          python3 -m src.image.pro pro_revision_refs \
+            --image-trigger "oci/${INPUTS_OCI_IMAGE_NAME}/image.yaml" \
+            --all-revision-tags "${STEPS_GET_ALL_CANONICAL_TAGS_OUTPUTS_CANONICAL_TAGS_FILE}" \
+            > pro-revision-refs.txt
+
+          while read -r revision_ref; do
+            if [[ -z "${revision_ref}" ]]; then
+              continue
+            fi
+            skopeo --insecure-policy copy \
+              --decryption-key "${key_file}" \
+              --src-username "${GITHUB_ACTOR}" \
+              --src-password "${{ secrets.GITHUB_TOKEN }}" \
+              "docker://ghcr.io/${GHCR_REPO}/${INPUTS_OCI_IMAGE_NAME}:${revision_ref}" \
+              "oci-archive:pro-release-sources/${INPUTS_OCI_IMAGE_NAME}_${revision_ref}"
+          done < pro-revision-refs.txt
+
       # Pull the latest changes to prevent conflicts merging _releases.json
       - run: pushd ${{ env.RELEASE_REPO_DIR }} && git pull --quiet && popd
 

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      encrypted-source-image:
+        description: 'Whether the source image is encrypted and must be decrypted before scanning'
+        required: false
+        type: boolean
+        default: false
 
 env:
   VULNERABILITY_REPORT_SUFFIX: '.vulnerability-report.json' # TODO: inherit string from caller
@@ -48,6 +53,15 @@ jobs:
         env:
           INPUTS_OCI_IMAGE_PATH: ${{ inputs.oci-image-path }}
 
+      - name: Write Pro decryption key
+        if: ${{ inputs.encrypted-source-image }}
+        env:
+          PRO_ROCK_DECRYPTION_PRIVATE_KEY: ${{ secrets.PRO_ROCK_DECRYPTION_PRIVATE_KEY }}
+        run: |
+          key_file="${RUNNER_TEMP}/pro-rock-decryption-private.pem"
+          printf '%s' "${PRO_ROCK_DECRYPTION_PRIVATE_KEY}" > "${key_file}"
+          chmod 600 "${key_file}"
+
       - id: configure
         run: |
           oci_filename="$(basename "${INPUTS_OCI_IMAGE_NAME}" | tr ':' '_')"
@@ -55,15 +69,22 @@ jobs:
           echo "oci-filename=$oci_filename" >> "$GITHUB_OUTPUT"
           echo "report-filename=${oci_filename}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
 
+          decryption_args=()
+          if [[ -n "${DECRYPTION_KEY}" ]]; then
+            decryption_args=(--decryption-key "${DECRYPTION_KEY}")
+          fi
+
           docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            -v "$PWD:/workdir" -w /workdir \
+            -v "$PWD:/workdir" -v "${RUNNER_TEMP}:${RUNNER_TEMP}" -w /workdir \
             "${SKOPEO_IMAGE}" \
-            copy "docker://${INPUTS_OCI_IMAGE_NAME}" \
+            copy "${decryption_args[@]}" \
+            "docker://${INPUTS_OCI_IMAGE_NAME}" \
             "oci-archive:$oci_filename" \
             --src-username "${GITHUB_ACTOR}" \
             --src-password "${{ secrets.GITHUB_TOKEN }}"
         env:
           INPUTS_OCI_IMAGE_NAME: ${{ inputs.oci-image-name }}
+          DECRYPTION_KEY: ${{ inputs.encrypted-source-image && format('{0}/pro-rock-decryption-private.pem', runner.temp) || '' }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         if: ${{ !cancelled() }}

--- a/oci/mock-rock/image.yaml
+++ b/oci/mock-rock/image.yaml
@@ -55,6 +55,21 @@ upload:
     ignored-vulnerabilities:
       - "CVE-2023-1234"
       - "CVE-2023-5678"
+  - source: "canonical/rocks-toolbox"
+    commit: eee5f5ebeff62848903156fb3fe93c5d37174085
+    directory: mock_rock/1.2
+    pro:
+      services:
+        - esm-apps
+        - esm-infra
+      config:
+        token: secrets.ROCKS_PRO_TOKEN
+        artifact-passphrase: secrets.ROCKS_PRO_ARTIFACT_PASSPHRASE
+    release:
+      1.2-22.04:
+        end-of-life: "2030-05-01T00:00:00Z"
+        risks:
+          - edge
   # TODO: Restore the devel release once the https://github.com/canonical/rockcraft/issues/1262 is resolved.
   # - source: "canonical/rocks-toolbox"
   #   commit: bb9138fbe81f893b4303a0e29df7cf9581069de0

--- a/src/image/get_encrypt_layers_from_oci_archive.sh
+++ b/src/image/get_encrypt_layers_from_oci_archive.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --archive <oci-archive-path>"
+}
+
+archive=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --archive)
+            archive="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${archive}" ]]; then
+    usage
+    exit 1
+fi
+
+if [[ ! -f "${archive}" ]]; then
+    echo "OCI archive does not exist: ${archive}" >&2
+    exit 1
+fi
+
+layer_indexes() {
+    local layer_count="$1"
+
+    if [[ -z "${layer_count}" || "${layer_count}" == "null" ]]; then
+        echo "Unable to determine OCI image layers to encrypt." >&2
+        exit 1
+    fi
+
+    if [[ "${layer_count}" -le 0 ]]; then
+        echo "Cannot encrypt image with no layers." >&2
+        exit 1
+    fi
+
+    seq -s, 0 "$((layer_count - 1))"
+}
+
+archive_layout=""
+raw_manifest=""
+if ! raw_manifest=$(skopeo inspect --raw "oci-archive:${archive}" 2>/dev/null); then
+    archive_layout="$(mktemp -d)"
+    trap 'rm -rf "${archive_layout}"' EXIT
+    tar -xf "${archive}" -C "${archive_layout}"
+    raw_manifest=$(jq . "${archive_layout}/index.json")
+fi
+
+if jq -e 'has("layers")' <<< "${raw_manifest}" > /dev/null; then
+    layer_indexes "$(jq -r '.layers | length' <<< "${raw_manifest}")"
+    exit 0
+fi
+
+if ! jq -e 'has("manifests")' <<< "${raw_manifest}" > /dev/null; then
+    echo "Unsupported OCI archive manifest: expected layers or manifests." >&2
+    exit 1
+fi
+
+if [[ -z "${archive_layout}" ]]; then
+    archive_layout="$(mktemp -d)"
+    trap 'rm -rf "${archive_layout}"' EXIT
+    tar -xf "${archive}" -C "${archive_layout}"
+fi
+
+layer_counts=$(
+    jq -r '.manifests[].digest' <<< "${raw_manifest}" |
+    while read -r digest; do
+        blob="${digest#sha256:}"
+        jq '.layers | length' "${archive_layout}/blobs/sha256/${blob}"
+    done | sort -n | uniq
+)
+
+if [[ -z "${layer_counts}" ]]; then
+    echo "Unable to determine OCI image layers to encrypt." >&2
+    exit 1
+fi
+
+if [[ "$(wc -l <<< "${layer_counts}")" -ne 1 ]]; then
+    echo "Cannot encrypt all layers: manifests have different layer counts: ${layer_counts}" >&2
+    exit 1
+fi
+
+layer_indexes "${layer_counts}"

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -21,6 +21,7 @@ import json
 import yaml
 
 from ..shared.logs import get_logger
+from .pro import get_published_track, normalize_services
 from .utils.schema.revision_data import RevisionDataSchema
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
@@ -42,6 +43,28 @@ def backfill_higher_risks(channels: dict) -> None:
                 # if there a lower risk to follow?
                 if KNOWN_RISKS_ORDERED[i - 1] in val:
                     val[risk] = f"{track}_{KNOWN_RISKS_ORDERED[i-1]}"
+
+
+def backfill_higher_risks_for_variant(track: str, variant: dict) -> None:
+    """Backfill risks inside a Pro variant."""
+    for i, risk in enumerate(KNOWN_RISKS_ORDERED):
+        if risk not in variant:
+            if risk == "stable":
+                continue
+            if KNOWN_RISKS_ORDERED[i - 1] in variant:
+                variant[risk] = variant[KNOWN_RISKS_ORDERED[i - 1]]
+
+
+def find_or_create_pro_variant(track_release: dict, pro_config: dict) -> dict:
+    """Return the Pro variant matching the given config, creating it if needed."""
+    services = normalize_services(pro_config["services"])
+    for variant in track_release.setdefault("pro-variants", []):
+        if normalize_services(variant["services"]) == services:
+            return variant
+
+    variant = {"services": services, "pro": {**pro_config, "services": services}}
+    track_release["pro-variants"].append(variant)
+    return variant
 
 
 if __name__ == "__main__":
@@ -79,17 +102,23 @@ if __name__ == "__main__":
 
     # Update "release" from image trigger with new revision releases
     for track, val in new_revision_releases.items():
-        if track not in user_releases:
-            user_releases[track] = {}
+        pro_config = val.get("pro") or new_revision_pro
+        published_track = get_published_track(track, pro_config)
+        if published_track not in user_releases:
+            user_releases[published_track] = {}
 
         if "end-of-life" in val:
-            user_releases[track]["end-of-life"] = val["end-of-life"]
+            user_releases[published_track]["end-of-life"] = val["end-of-life"]
 
-        if pro_config := val.get("pro") or new_revision_pro:
-            user_releases[track]["pro"] = pro_config
+        if pro_config:
+            variant = find_or_create_pro_variant(user_releases[published_track], pro_config)
+            for risk in val["risks"]:
+                variant[risk] = str(new_revision)
+            backfill_higher_risks_for_variant(published_track, variant)
+            continue
 
         for risk in val["risks"]:
-            user_releases[track][risk] = str(new_revision)
+            user_releases[published_track][risk] = str(new_revision)
 
     # For every track, we need to backfill the risks
     backfill_higher_risks(user_releases)

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         if "end-of-life" in val:
             user_releases[track]["end-of-life"] = val["end-of-life"]
 
-        if "pro" in val:
+        if val.get("pro"):
             user_releases[track]["pro"] = val["pro"]
 
         for risk in val["risks"]:

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -84,6 +84,9 @@ if __name__ == "__main__":
         if "end-of-life" in val:
             user_releases[track]["end-of-life"] = val["end-of-life"]
 
+        if "pro" in val:
+            user_releases[track]["pro"] = val["pro"]
+
         for risk in val["risks"]:
             user_releases[track][risk] = str(new_revision)
 

--- a/src/image/merge_release_info.py
+++ b/src/image/merge_release_info.py
@@ -75,6 +75,7 @@ if __name__ == "__main__":
 
     new_revision_releases = revision_data["release"]
     new_revision = revision_data["revision"]
+    new_revision_pro = revision_data.get("pro")
 
     # Update "release" from image trigger with new revision releases
     for track, val in new_revision_releases.items():
@@ -84,8 +85,8 @@ if __name__ == "__main__":
         if "end-of-life" in val:
             user_releases[track]["end-of-life"] = val["end-of-life"]
 
-        if val.get("pro"):
-            user_releases[track]["pro"] = val["pro"]
+        if pro_config := val.get("pro") or new_revision_pro:
+            user_releases[track]["pro"] = pro_config
 
         for risk in val["risks"]:
             user_releases[track][risk] = str(new_revision)

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -127,6 +127,9 @@ def filter_eol_builds(builds: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def get_build_pro(build: dict[str, Any]) -> dict[str, Any] | None:
     """Return the Pro config for a build, ensuring all released tracks agree."""
+    if build.get("pro"):
+        return build["pro"]
+
     releases = build.get("release", {})
     if not releases:
         return None
@@ -170,6 +173,16 @@ def flatten_pro_builds(builds: list[dict[str, Any]]) -> None:
         build["pro-artifact-passphrase"] = pro_config["config"][
             "artifact-passphrase"
         ].removeprefix("secrets.")
+
+
+def get_dir_identifier(build: dict[str, Any]) -> str:
+    """Return a unique artifact/cache directory identifier for a build."""
+    dir_identifier = build["directory"].rstrip("/").replace("/", "_")
+    if pro_config := build.get("pro"):
+        services = "_".join(sorted(pro_config["services"]))
+        dir_identifier = f"{dir_identifier}_{services}"
+
+    return dir_identifier
 
 
 def write_revision_data(data_dir: Path, build: dict[str, Any]):
@@ -238,7 +251,7 @@ def inject_metadata(builds: list[dict[str, Any]], next_revision: int, oci_path: 
 
         # Add dir_identifier to assemble the cache key and artefact path
         # No need to write it to rev data file since it's only used in matrix
-        build["dir_identifier"] = build["directory"].rstrip("/").replace("/", "_")
+        build["dir_identifier"] = get_dir_identifier(build)
 
         with tempdir() as d:
             url = get_source_url(build["source"])

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -168,7 +168,7 @@ def flatten_pro_builds(builds: list[dict[str, Any]]) -> None:
             continue
 
         build["pro"] = pro_config
-        build["pro-services"] = " ".join(pro_config["services"])
+        build["pro-services"] = ",".join(pro_config["services"])
         build["pro-token"] = pro_config["config"]["token"].removeprefix("secrets.")
         build["pro-artifact-passphrase"] = pro_config["config"][
             "artifact-passphrase"

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -125,6 +125,53 @@ def filter_eol_builds(builds: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return non_release_builds + release_builds
 
 
+def get_build_pro(build: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the Pro config for a build, ensuring all released tracks agree."""
+    releases = build.get("release", {})
+    if not releases:
+        return None
+
+    pro_configs = []
+    for release in releases.values():
+        if pro_config := release.get("pro"):
+            pro_configs.append(pro_config)
+
+    if not pro_configs:
+        return None
+
+    if len(pro_configs) != len(releases):
+        raise InvalidSchemaError(
+            f'Build "{build["name"]}" mixes Pro and public release tracks.'
+        )
+
+    first_config = pro_configs[0]
+    if any(pro_config != first_config for pro_config in pro_configs):
+        raise InvalidSchemaError(
+            f'Build "{build["name"]}" has multiple different Pro configurations.'
+        )
+
+    return first_config
+
+
+def flatten_pro_builds(builds: list[dict[str, Any]]) -> None:
+    """Flatten Pro fields for the GitHub Actions matrix."""
+    for build in builds:
+        pro_config = get_build_pro(build)
+        build["pro-services"] = ""
+        build["pro-token"] = ""
+        build["pro-artifact-passphrase"] = ""
+
+        if not pro_config:
+            continue
+
+        build["pro"] = pro_config
+        build["pro-services"] = " ".join(pro_config["services"])
+        build["pro-token"] = pro_config["config"]["token"].removeprefix("secrets.")
+        build["pro-artifact-passphrase"] = pro_config["config"][
+            "artifact-passphrase"
+        ].removeprefix("secrets.")
+
+
 def write_revision_data(data_dir: Path, build: dict[str, Any]):
     """Prepare and dump revision data from build dict. Ignore any fields not included in RevisionDataSchema"""
     revision_data = RevisionDataSchemaFilter(**build)
@@ -260,6 +307,7 @@ def main():
 
     # remove any builds without valid tracks
     builds = filter_eol_builds(builds)
+    flatten_pro_builds(builds)
 
     # pretty print builds
     logger.info(

--- a/src/image/prepare_single_image_build_matrix.py
+++ b/src/image/prepare_single_image_build_matrix.py
@@ -176,7 +176,7 @@ def write_revision_data(data_dir: Path, build: dict[str, Any]):
     """Prepare and dump revision data from build dict. Ignore any fields not included in RevisionDataSchema"""
     revision_data = RevisionDataSchemaFilter(**build)
     with open(data_dir / str(build["revision"]), "w", encoding="UTF-8") as fh:
-        fh.write(revision_data.model_dump_json(by_alias=True))
+        fh.write(revision_data.model_dump_json(by_alias=True, exclude_none=True))
 
 
 def locate_trigger_yaml(oci_path: Path) -> Path:

--- a/src/image/pro.py
+++ b/src/image/pro.py
@@ -28,16 +28,45 @@ def is_pro_track(image_trigger: dict, track: str) -> bool:
     return bool(image_trigger.get("release", {}).get(track, {}).get("pro"))
 
 
-def has_public_tracks(image_trigger: dict) -> bool:
-    """Return whether the image trigger has any non-Pro release tracks."""
+def get_release_tracks(image_trigger: dict) -> list[dict]:
+    """Return all release track definitions from an image trigger."""
     release_tracks = list(image_trigger.get("release", {}).values())
     for upload in image_trigger.get("upload", []) or []:
         release_tracks.extend(upload.get("release", {}).values())
+
+    return release_tracks
+
+
+def has_public_tracks(image_trigger: dict) -> bool:
+    """Return whether the image trigger has any non-Pro release tracks."""
+    release_tracks = get_release_tracks(image_trigger)
 
     if not release_tracks:
         return True
 
     return any(not release.get("pro") for release in release_tracks)
+
+
+def has_pro_tracks(image_trigger: dict) -> bool:
+    """Return whether the image trigger has any Pro release tracks."""
+    return any(release.get("pro") for release in get_release_tracks(image_trigger))
+
+
+def get_pro_artifact_passphrase_secret(image_trigger: dict) -> str:
+    """Return the unique artifact passphrase secret name for Pro release tracks."""
+    secrets = {
+        release["pro"]["config"]["artifact-passphrase"].removeprefix("secrets.")
+        for release in get_release_tracks(image_trigger)
+        if release.get("pro")
+    }
+
+    if not secrets:
+        return ""
+
+    if len(secrets) != 1:
+        raise ValueError("All Pro release tracks must use the same artifact passphrase.")
+
+    return secrets.pop()
 
 
 def load_image_trigger(image_trigger_path: str) -> dict:
@@ -51,13 +80,24 @@ def load_image_trigger(image_trigger_path: str) -> dict:
 
 def main():
     parser = argparse.ArgumentParser(description="Inspect Pro settings in image.yaml")
-    parser.add_argument("function", choices=["has_public_tracks"])
+    parser.add_argument(
+        "function",
+        choices=[
+            "has_public_tracks",
+            "has_pro_tracks",
+            "pro_artifact_passphrase_secret",
+        ],
+    )
     parser.add_argument("--image-trigger", required=True)
     args = parser.parse_args()
 
     image_trigger = load_image_trigger(args.image_trigger)
     if args.function == "has_public_tracks":
         print("true" if has_public_tracks(image_trigger) else "false")
+    elif args.function == "has_pro_tracks":
+        print("true" if has_pro_tracks(image_trigger) else "false")
+    elif args.function == "pro_artifact_passphrase_secret":
+        print(get_pro_artifact_passphrase_secret(image_trigger))
 
 
 if __name__ == "__main__":

--- a/src/image/pro.py
+++ b/src/image/pro.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import argparse
+
+import yaml
+
+from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
+
+
+def get_track_from_tag(tag: str) -> str:
+    """Return the release track represented by a channel tag or stable alias."""
+    if tag in KNOWN_RISKS_ORDERED:
+        return "latest"
+
+    try:
+        track, risk = tag.rsplit("_", 1)
+    except ValueError:
+        return tag
+
+    if risk in KNOWN_RISKS_ORDERED:
+        return track
+
+    return tag
+
+
+def is_pro_track(image_trigger: dict, track: str) -> bool:
+    """Return whether a release track is configured for Ubuntu Pro."""
+    return bool(image_trigger.get("release", {}).get(track, {}).get("pro"))
+
+
+def has_public_tracks(image_trigger: dict) -> bool:
+    """Return whether the image trigger has any non-Pro release tracks."""
+    release_tracks = list(image_trigger.get("release", {}).values())
+    for upload in image_trigger.get("upload", []) or []:
+        release_tracks.extend(upload.get("release", {}).values())
+
+    if not release_tracks:
+        return True
+
+    return any(not release.get("pro") for release in release_tracks)
+
+
+def load_image_trigger(image_trigger_path: str) -> dict:
+    """Load and validate an image trigger file."""
+    with open(image_trigger_path, encoding="UTF-8") as trigger:
+        image_trigger = yaml.load(trigger, Loader=yaml.BaseLoader)
+
+    _ = ImageSchema(**image_trigger)
+    return image_trigger
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Inspect Pro settings in image.yaml")
+    parser.add_argument("function", choices=["has_public_tracks"])
+    parser.add_argument("--image-trigger", required=True)
+    args = parser.parse_args()
+
+    image_trigger = load_image_trigger(args.image_trigger)
+    if args.function == "has_public_tracks":
+        print("true" if has_public_tracks(image_trigger) else "false")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/image/pro.py
+++ b/src/image/pro.py
@@ -4,6 +4,8 @@ import argparse
 
 import yaml
 
+import src.shared.release_info as shared
+
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
 
@@ -32,7 +34,10 @@ def get_release_tracks(image_trigger: dict) -> list[dict]:
     """Return all release track definitions from an image trigger."""
     release_tracks = list(image_trigger.get("release", {}).values())
     for upload in image_trigger.get("upload", []) or []:
-        release_tracks.extend(upload.get("release", {}).values())
+        for release in upload.get("release", {}).values():
+            if upload.get("pro") and not release.get("pro"):
+                release = {**release, "pro": upload["pro"]}
+            release_tracks.append(release)
 
     return release_tracks
 
@@ -69,6 +74,18 @@ def get_pro_artifact_passphrase_secret(image_trigger: dict) -> str:
     return secrets.pop()
 
 
+def get_pro_revision_refs(image_trigger: dict, all_revision_tags: list[str]) -> list[str]:
+    """Return canonical <track>_<revision> refs whose track is configured for Pro."""
+    refs = []
+    for revision_ref in all_revision_tags:
+        if not revision_ref:
+            continue
+        track, _ = revision_ref.rsplit("_", 1)
+        if is_pro_track(image_trigger, track):
+            refs.append(revision_ref)
+    return refs
+
+
 def load_image_trigger(image_trigger_path: str) -> dict:
     """Load and validate an image trigger file."""
     with open(image_trigger_path, encoding="UTF-8") as trigger:
@@ -85,10 +102,12 @@ def main():
         choices=[
             "has_public_tracks",
             "has_pro_tracks",
+            "pro_revision_refs",
             "pro_artifact_passphrase_secret",
         ],
     )
     parser.add_argument("--image-trigger", required=True)
+    parser.add_argument("--all-revision-tags", required=False, default="")
     args = parser.parse_args()
 
     image_trigger = load_image_trigger(args.image_trigger)
@@ -96,6 +115,11 @@ def main():
         print("true" if has_public_tracks(image_trigger) else "false")
     elif args.function == "has_pro_tracks":
         print("true" if has_pro_tracks(image_trigger) else "false")
+    elif args.function == "pro_revision_refs":
+        for revision_ref in get_pro_revision_refs(
+            image_trigger, shared.get_all_revision_tags(args.all_revision_tags)
+        ):
+            print(revision_ref)
     elif args.function == "pro_artifact_passphrase_secret":
         print(get_pro_artifact_passphrase_secret(image_trigger))
 

--- a/src/image/pro.py
+++ b/src/image/pro.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+from typing import Any
 
 import yaml
 
@@ -25,9 +26,27 @@ def get_track_from_tag(tag: str) -> str:
     return tag
 
 
-def is_pro_track(image_trigger: dict, track: str) -> bool:
-    """Return whether a release track is configured for Ubuntu Pro."""
-    return bool(image_trigger.get("release", {}).get(track, {}).get("pro"))
+def normalize_services(services: list[str]) -> list[str]:
+    """Return a deterministic Pro services list."""
+    return sorted(services)
+
+
+def non_esm_services(services: list[str]) -> list[str]:
+    """Return Pro services that must be represented in published tags."""
+    return [service for service in normalize_services(services) if not service.startswith("esm-")]
+
+
+def get_published_track(track: str, pro: dict[str, Any] | None = None) -> str:
+    """Return the public tag track for a release track and optional Pro config."""
+    if not pro:
+        return track
+
+    tag_services = non_esm_services(pro.get("services", []))
+    if not tag_services:
+        return track
+
+    version, base = track.rsplit("-", 1)
+    return f"{version}-{'-'.join(tag_services)}-{base}"
 
 
 def get_release_tracks(image_trigger: dict) -> list[dict]:
@@ -42,19 +61,42 @@ def get_release_tracks(image_trigger: dict) -> list[dict]:
     return release_tracks
 
 
+def get_pro_variants(image_trigger: dict) -> list[dict]:
+    """Return all merged Pro variants from the release section."""
+    variants = []
+    for track, release in image_trigger.get("release", {}).items():
+        for variant in release.get("pro-variants", []) or []:
+            variants.append({**variant, "track": track})
+    return variants
+
+
 def has_public_tracks(image_trigger: dict) -> bool:
     """Return whether the image trigger has any non-Pro release tracks."""
-    release_tracks = get_release_tracks(image_trigger)
+    root_releases = image_trigger.get("release", {}).values()
+    if any(
+        any(risk in release for risk in KNOWN_RISKS_ORDERED)
+        for release in root_releases
+    ):
+        return True
+
+    release_tracks = []
+    for upload in image_trigger.get("upload", []) or []:
+        for release in upload.get("release", {}).values():
+            if upload.get("pro") and not release.get("pro"):
+                release = {**release, "pro": upload["pro"]}
+            release_tracks.append(release)
 
     if not release_tracks:
-        return True
+        return not has_pro_tracks(image_trigger)
 
     return any(not release.get("pro") for release in release_tracks)
 
 
 def has_pro_tracks(image_trigger: dict) -> bool:
     """Return whether the image trigger has any Pro release tracks."""
-    return any(release.get("pro") for release in get_release_tracks(image_trigger))
+    return bool(get_pro_variants(image_trigger)) or any(
+        release.get("pro") for release in get_release_tracks(image_trigger)
+    )
 
 
 def get_pro_artifact_passphrase_secret(image_trigger: dict) -> str:
@@ -64,24 +106,42 @@ def get_pro_artifact_passphrase_secret(image_trigger: dict) -> str:
         for release in get_release_tracks(image_trigger)
         if release.get("pro")
     }
+    secrets.update(
+        variant["pro"]["config"]["artifact-passphrase"].removeprefix("secrets.")
+        for variant in get_pro_variants(image_trigger)
+        if variant.get("pro")
+    )
 
     if not secrets:
         return ""
 
     if len(secrets) != 1:
-        raise ValueError("All Pro release tracks must use the same artifact passphrase.")
+        raise ValueError(
+            "All Pro release tracks must use the same artifact passphrase."
+        )
 
     return secrets.pop()
 
 
-def get_pro_revision_refs(image_trigger: dict, all_revision_tags: list[str]) -> list[str]:
-    """Return canonical <track>_<revision> refs whose track is configured for Pro."""
+def get_pro_revision_refs(
+    image_trigger: dict, all_revision_tags: list[str]
+) -> list[str]:
+    """Return canonical <source-track>_<revision> refs for Pro revisions."""
+    pro_revisions = set()
+    for variant in get_pro_variants(image_trigger):
+        for risk in KNOWN_RISKS_ORDERED:
+            target = variant.get(risk)
+            if isinstance(target, dict):
+                target = target.get("target")
+            if target and str(target).isdigit():
+                pro_revisions.add(str(target))
+
     refs = []
     for revision_ref in all_revision_tags:
         if not revision_ref:
             continue
-        track, _ = revision_ref.rsplit("_", 1)
-        if is_pro_track(image_trigger, track):
+        _, revision = revision_ref.rsplit("_", 1)
+        if revision in pro_revisions:
             refs.append(revision_ref)
     return refs
 

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -64,6 +64,12 @@ parser.add_argument(
     action="store_true",
     default=False,
 )
+parser.add_argument(
+    "--pro-release-sources",
+    help="Directory containing decrypted Pro OCI archive release sources.",
+    required=False,
+    default="",
+)
 
 
 def remove_eol_tags(tag_to_revision, all_releases):
@@ -143,6 +149,17 @@ def group_release_tags_by_revision_and_destination(release_tags, image_trigger):
         group_by_revision[revision][destination].append(tag)
 
     return group_by_revision
+
+
+def get_release_source(destination, revision_track, revision, img_name, ghcr_repo, pro_sources):
+    """Return the skopeo source image reference for a release destination."""
+    if destination == "pro-acr":
+        source_path = os.path.join(pro_sources, f"{img_name}_{revision_track}_{revision}")
+        if not os.path.isfile(source_path):
+            raise FileNotFoundError(f"Pro release source not found: {source_path}")
+        return f"oci-archive:{source_path}"
+
+    return f"docker://ghcr.io/{ghcr_repo}/{img_name}:{revision_track}_{revision}"
 
 
 def main():
@@ -314,12 +331,16 @@ def main():
         github_tags = []
         for revision, tags_by_destination in group_by_revision.items():
             revision_track = revision_to_track[revision]
-            source_img = (
-                "docker://ghcr.io/"
-                f"{args.ghcr_repo}/{img_name}:{revision_track}_{revision}"
-            )
             this_dir = os.path.dirname(__file__)
             for destination, tags in tags_by_destination.items():
+                source_img = get_release_source(
+                    destination,
+                    revision_track,
+                    revision,
+                    img_name,
+                    args.ghcr_repo,
+                    args.pro_release_sources,
+                )
                 logger.info(
                     f"Releasing {source_img} to {destination} with tags:\n{tags}"
                 )

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -24,6 +24,7 @@ from .utils.eol_utils import (
     generate_base_eol_exceed_warning,
     track_eol_exceeds_base_eol,
 )
+from .pro import get_track_from_tag, is_pro_track
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
 logger = get_logger()
@@ -132,6 +133,16 @@ def find_tracks_has_eol_exceeding_base_eol(all_releases):
             tracks.append(eols)
 
     return tracks
+
+
+def group_release_tags_by_revision_and_destination(release_tags, image_trigger):
+    """Group tags by revision and publish destination."""
+    group_by_revision = defaultdict(lambda: defaultdict(list))
+    for tag, revision in sorted(release_tags.items()):
+        destination = "pro-acr" if is_pro_track(image_trigger, get_track_from_tag(tag)) else "public"
+        group_by_revision[revision][destination].append(tag)
+
+    return group_by_revision
 
 
 def main():
@@ -290,9 +301,9 @@ def main():
 
     # we finally have all the OCI tags to be released,
     # and which revisions to release for each tag. Let's release!
-    group_by_revision = defaultdict(list)
-    for tag, revision in sorted(release_tags.items()):
-        group_by_revision[revision].append(tag)
+    group_by_revision = group_release_tags_by_revision_and_destination(
+        release_tags, image_trigger
+    )
 
     if not args.update_releases_json:
         logger.info(
@@ -301,28 +312,35 @@ def main():
         )
 
         github_tags = []
-        for revision, tags in group_by_revision.items():
+        for revision, tags_by_destination in group_by_revision.items():
             revision_track = revision_to_track[revision]
             source_img = (
                 "docker://ghcr.io/"
                 f"{args.ghcr_repo}/{img_name}:{revision_track}_{revision}"
             )
             this_dir = os.path.dirname(__file__)
-            logger.info(f"Releasing {source_img} with tags:\n{tags}")
-            subprocess.check_call(
-                [f"{this_dir}/tag_and_publish.sh", source_img, img_name] + tags
-            )
-
-            for tag in tags:
-                gh_release_info = {}
-                gh_release_info["canonical-tag"] = (
-                    f"{img_name}_{revision_track}_{revision}"
+            for destination, tags in tags_by_destination.items():
+                logger.info(
+                    f"Releasing {source_img} to {destination} with tags:\n{tags}"
                 )
-                gh_release_info["release-name"] = f"{img_name}_{tag}"
-                gh_release_info["name"] = f"{img_name}"
-                gh_release_info["revision"] = f"{revision}"
-                gh_release_info["channel"] = f"{tag}"
-                github_tags.append(gh_release_info)
+                env = os.environ.copy()
+                env["PUBLISH_DESTINATION"] = destination
+                subprocess.check_call(
+                    [f"{this_dir}/tag_and_publish.sh", source_img, img_name] + tags,
+                    env=env,
+                )
+
+            for tags in tags_by_destination.values():
+                for tag in tags:
+                    gh_release_info = {}
+                    gh_release_info["canonical-tag"] = (
+                        f"{img_name}_{revision_track}_{revision}"
+                    )
+                    gh_release_info["release-name"] = f"{img_name}_{tag}"
+                    gh_release_info["name"] = f"{img_name}"
+                    gh_release_info["revision"] = f"{revision}"
+                    gh_release_info["channel"] = f"{tag}"
+                    github_tags.append(gh_release_info)
 
         matrix = {"include": github_tags}
 

--- a/src/image/release.py
+++ b/src/image/release.py
@@ -24,7 +24,7 @@ from .utils.eol_utils import (
     generate_base_eol_exceed_warning,
     track_eol_exceeds_base_eol,
 )
-from .pro import get_track_from_tag, is_pro_track
+from .pro import get_track_from_tag
 from .utils.schema.triggers import KNOWN_RISKS_ORDERED, ImageSchema
 
 logger = get_logger()
@@ -76,7 +76,23 @@ def remove_eol_tags(tag_to_revision, all_releases):
     """Remove all EOL tags from tag to revision mapping."""
 
     filtered_tag_to_revision = tag_to_revision.copy()
-    for base_tag, _ in tag_to_revision.items():
+    for base_tag, target_value_data in tag_to_revision.items():
+        if isinstance(target_value_data, dict) and isinstance(
+            target_value_data["revision"], int
+        ):
+            track, _ = output_tag(base_tag).rsplit("_", 1)
+            if (
+                "end-of-life" in all_releases[track]
+                and (eol_date := all_releases[track]["end-of-life"])
+                < execution_timestamp
+                and base_tag in filtered_tag_to_revision
+            ):
+                logger.warning(
+                    f"Warning: Removing EOL tag {repr(base_tag)}, date: {eol_date}"
+                )
+                filtered_tag_to_revision.pop(base_tag)
+            continue
+
         path = []  # track revisions to prevent inf loop
         tag = base_tag  # init state
         while True:
@@ -88,6 +104,9 @@ def remove_eol_tags(tag_to_revision, all_releases):
             path.append(tag)
 
             # if we find a numeric revision, break since we reached the end of the path
+            if isinstance(tag, dict):
+                tag = str(tag["revision"])
+
             if tag.isdigit():
                 break
 
@@ -144,11 +163,63 @@ def find_tracks_has_eol_exceeding_base_eol(all_releases):
 def group_release_tags_by_revision_and_destination(release_tags, image_trigger):
     """Group tags by revision and publish destination."""
     group_by_revision = defaultdict(lambda: defaultdict(list))
-    for tag, revision in sorted(release_tags.items()):
-        destination = "pro-acr" if is_pro_track(image_trigger, get_track_from_tag(tag)) else "public"
-        group_by_revision[revision][destination].append(tag)
+    for _, release_data in sorted(release_tags.items()):
+        revision = release_data["revision"]
+        destination = release_data["destination"]
+        group_by_revision[revision][destination].append(release_data["tag"])
 
     return group_by_revision
+
+
+def validate_unique_destination_tags(release_tags):
+    """Ensure one destination/tag points to only one revision."""
+    seen = {}
+    for _, release_data in release_tags.items():
+        key = (release_data["destination"], release_data["tag"])
+        revision = release_data["revision"]
+        if key in seen and seen[key] != revision:
+            raise shared.BadChannel(
+                "Multiple release variants target the same destination/tag: "
+                f"{key[0]}:{key[1]} points to both revisions {seen[key]} and {revision}."
+            )
+        seen[key] = revision
+
+
+def get_or_create_pro_variant(track_release: dict, services: list[str], pro_config: dict) -> dict:
+    """Return the _releases.json Pro variant matching services, creating it if needed."""
+    services = sorted(services)
+    for variant in track_release.setdefault("pro-variants", []):
+        if sorted(variant["services"]) == services:
+            return variant
+    variant = {"services": services}
+    track_release["pro-variants"].append(variant)
+    return variant
+
+
+def target_value(value):
+    """Return the release target string from a scalar or target object."""
+    if isinstance(value, dict):
+        return value["target"]
+    return value
+
+
+def output_tag(map_key: str) -> str:
+    """Return the registry tag represented by an internal release map key."""
+    if map_key.startswith("pro:"):
+        return map_key.split(":", 2)[2]
+    return map_key
+
+
+def release_entry(revision, destination, tag=None, track=None):
+    """Return release routing metadata for a concrete revision."""
+    if tag is not None and track is None:
+        track = get_track_from_tag(tag)
+    return {
+        "revision": revision,
+        "destination": destination,
+        "tag": tag,
+        "track": track,
+    }
 
 
 def get_release_source(destination, revision_track, revision, img_name, ghcr_repo, pro_sources):
@@ -197,6 +268,7 @@ def main():
     _ = ImageSchema(**image_trigger)
 
     tag_mapping_from_trigger = {}
+    tag_destination = {}
     for track, risks in image_trigger["release"].items():
         if track not in all_releases:
             logger.info(f"Track {track} will be created for the 1st time")
@@ -210,14 +282,36 @@ def main():
                 all_releases[track]["end-of-life"] = value
                 continue
 
+            if risk == "pro-variants":
+                for variant in value or []:
+                    stored_variant = get_or_create_pro_variant(
+                        all_releases[track], variant["services"], variant["pro"]
+                    )
+                    for variant_risk in KNOWN_RISKS_ORDERED:
+                        variant_value = variant.get(variant_risk)
+                        if variant_value is None:
+                            continue
+                        stored_variant[variant_risk] = {
+                            "target": target_value(variant_value)
+                        }
+                        tag = f"{track}_{variant_risk}"
+                        map_key = f"pro:{','.join(variant['services'])}:{tag}"
+                        logger.info(
+                            f"Pro channel {tag} points to {target_value(variant_value)}"
+                        )
+                        tag_mapping_from_trigger[map_key] = target_value(variant_value)
+                        tag_destination[map_key] = "pro-acr"
+                continue
+
             if risk not in KNOWN_RISKS_ORDERED:
                 logger.warning(f"Skipping unknown risk {risk} in track {track}")
                 continue
 
-            all_releases[track][risk] = {"target": value}
+            all_releases[track][risk] = {"target": target_value(value)}
             tag = f"{track}_{risk}"
-            logger.info(f"Channel {tag} points to {value}")
-            tag_mapping_from_trigger[tag] = value
+            logger.info(f"Channel {tag} points to {target_value(value)}")
+            tag_mapping_from_trigger[tag] = target_value(value)
+            tag_destination[tag] = "public"
 
     # update EOL dates from upload dictionary
     for upload in image_trigger["upload"] or []:
@@ -247,7 +341,15 @@ def main():
     # - the target revisions exist
     # - the target tags (when following) do not incur in a circular dependency
     # - the target tags (when following) exist
-    tag_to_revision = tag_mapping_from_trigger.copy()
+    tag_to_revision = {
+        tag: release_entry(
+            target,
+            tag_destination[tag],
+            tag=output_tag(tag),
+            track=get_track_from_tag(output_tag(tag)),
+        )
+        for tag, target in tag_mapping_from_trigger.items()
+    }
     for channel_tag, target in tag_mapping_from_trigger.items():
         # a target cannot follow its own tag
         if target == channel_tag:
@@ -290,7 +392,12 @@ def main():
             )
             raise shared.BadChannel(msg)
 
-        tag_to_revision[channel_tag] = int(follow_tag)
+        tag_to_revision[channel_tag] = release_entry(
+            int(follow_tag),
+            tag_destination[channel_tag],
+            tag=output_tag(channel_tag),
+            track=get_track_from_tag(output_tag(channel_tag)),
+        )
 
     # if we get here, it is a valid (tag, revision)
 
@@ -299,25 +406,36 @@ def main():
 
     # we now need to add tag aliases
     release_tags = filtered_tag_to_revision.copy()
-    for base_tag, revision in tag_to_revision.items():
+    for base_tag, release_data in tag_to_revision.items():
+        revision = release_data["revision"]
+        destination = release_data["destination"]
         # "latest" is a special tag for OCI
         if re.match(
             rf"latest_({'|'.join(KNOWN_RISKS_ORDERED)})$",
             base_tag,
         ):
-            latest_alias = base_tag.split("_")[-1]
+            base_output_tag = output_tag(base_tag)
+            latest_alias = base_output_tag.split("_")[-1]
             logger.info(f"Exceptionally converting tag {base_tag} to {latest_alias}.")
-            release_tags[latest_alias] = revision
+            alias_key = f"{base_tag}:alias:{latest_alias}"
+            release_tags[alias_key] = release_entry(
+                revision, destination, tag=latest_alias, track="latest"
+            )
             release_tags.pop(base_tag)
 
         # stable risks have an alias with any risk string
-        if base_tag.endswith("_stable"):
-            stable_alias = "_".join(base_tag.split("_")[:-1])
+        if output_tag(base_tag).endswith("_stable"):
+            base_output_tag = output_tag(base_tag)
+            stable_alias = "_".join(base_output_tag.split("_")[:-1])
             logger.info(f"Adding stable tag alias {stable_alias} for {base_tag}")
-            release_tags[stable_alias] = revision
+            alias_key = f"{base_tag}:alias:{stable_alias}"
+            release_tags[alias_key] = release_entry(
+                revision, destination, tag=stable_alias, track=stable_alias
+            )
 
     # we finally have all the OCI tags to be released,
     # and which revisions to release for each tag. Let's release!
+    validate_unique_destination_tags(release_tags)
     group_by_revision = group_release_tags_by_revision_and_destination(
         release_tags, image_trigger
     )

--- a/src/image/tag_and_publish.sh
+++ b/src/image/tag_and_publish.sh
@@ -93,9 +93,10 @@ ghcr_repo_name="${GHCR_REPO}/${image_name}"
 docker_hub_repo_name="${DOCKER_HUB_NAMESPACE}/${image_name}"
 acr_repo_name="${ACR_NAMESPACE}/${image_name}"
 ecr_repo_name="${ECR_NAMESPACE}/${image_name}"
+publish_destination="${PUBLISH_DESTINATION:-public}"
 # ecr_lts_repo_name="${ECR_LTS_NAMESPACE}/${image_name}"
 
-log_info "Publishing ${image_name} to registries with tags: ${tag_names[*]}"
+log_info "Publishing ${image_name} to ${publish_destination} registries with tags: ${tag_names[*]}"
 
 trace_suspend
 if [ ! -z $GHCR_REPO ]; then
@@ -108,6 +109,22 @@ if [ ! -z $GHCR_REPO ]; then
         "${tag_names[@]}"
     
     exit 0
+fi
+
+if [ "${publish_destination}" = "pro-acr" ]; then
+    ### ACR
+    publish_with_username_password \
+        "$ACR_CREDS_USR" \
+        "$ACR_CREDS_PSW" \
+        ${acr_repo_name} \
+        "${tag_names[@]}"
+
+    exit 0
+fi
+
+if [ "${publish_destination}" != "public" ]; then
+    log_error "Unknown publish destination: ${publish_destination}"
+    exit 1
 fi
 
 docker login -u $DOCKER_HUB_CREDS_USR -p $DOCKER_HUB_CREDS_PSW

--- a/src/image/tag_and_publish.sh
+++ b/src/image/tag_and_publish.sh
@@ -91,7 +91,7 @@ publish_to_aws_ecr_public()
 # From env
 ghcr_repo_name="${GHCR_REPO}/${image_name}"
 docker_hub_repo_name="${DOCKER_HUB_NAMESPACE}/${image_name}"
-acr_repo_name="${ACR_NAMESPACE}/${image_name}"
+acr_repo_name="${ACR_REGISTRY}/${image_name}"
 ecr_repo_name="${ECR_NAMESPACE}/${image_name}"
 publish_destination="${PUBLISH_DESTINATION:-public}"
 # ecr_lts_repo_name="${ECR_LTS_NAMESPACE}/${image_name}"

--- a/src/image/test-get_encrypt_layers_from_oci_archive.bats
+++ b/src/image/test-get_encrypt_layers_from_oci_archive.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/get_encrypt_layers_from_oci_archive.sh"
+
+setup() {
+  workdir="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "${workdir}"
+}
+
+sha() {
+  sha256sum "$1" | cut -d' ' -f1
+}
+
+write_blob() {
+  local layout="$1"
+  local file="$2"
+  local digest
+  digest="$(sha "${file}")"
+  mkdir -p "${layout}/blobs/sha256"
+  cp "${file}" "${layout}/blobs/sha256/${digest}"
+  echo "sha256:${digest}"
+}
+
+make_config() {
+  local layout="$1"
+  local config_file="${layout}/config.json"
+  printf '{}' > "${config_file}"
+  write_blob "${layout}" "${config_file}"
+}
+
+make_layer() {
+  local layout="$1"
+  local number="$2"
+  local layer_file="${layout}/layer-${number}.tar"
+  printf 'layer-%s' "${number}" > "${layer_file}"
+  write_blob "${layout}" "${layer_file}"
+}
+
+make_manifest() {
+  local layout="$1"
+  local layer_count="$2"
+  local manifest_file="$3"
+  local config_digest layer_digest layers_json
+
+  config_digest="$(make_config "${layout}")"
+  layers_json="[]"
+  for ((i=0; i<layer_count; i++)); do
+    layer_digest="$(make_layer "${layout}" "${i}")"
+    layers_json="$(jq --arg digest "${layer_digest}" '. + [{mediaType: "application/vnd.oci.image.layer.v1.tar+gzip", digest: $digest, size: 7}]' <<< "${layers_json}")"
+  done
+
+  jq -n \
+    --arg config_digest "${config_digest}" \
+    --argjson layers "${layers_json}" \
+    '{schemaVersion: 2, mediaType: "application/vnd.oci.image.manifest.v1+json", config: {mediaType: "application/vnd.oci.image.config.v1+json", digest: $config_digest, size: 2}, layers: $layers}' \
+    > "${manifest_file}"
+  write_blob "${layout}" "${manifest_file}"
+}
+
+make_archive() {
+  local layout="$1"
+  local archive="$2"
+  tar -C "${layout}" -cf "${archive}" .
+}
+
+make_single_manifest_archive() {
+  local archive="$1"
+  local layer_count="$2"
+  local layout="${workdir}/layout"
+  mkdir -p "${layout}"
+  printf '{"imageLayoutVersion":"1.0.0"}' > "${layout}/oci-layout"
+  manifest_digest="$(make_manifest "${layout}" "${layer_count}" "${layout}/manifest.json")"
+  jq -n --arg digest "${manifest_digest}" '{schemaVersion: 2, manifests: [{mediaType: "application/vnd.oci.image.manifest.v1+json", digest: $digest, size: 1, annotations: {"org.opencontainers.image.ref.name": "test"}}]}' > "${layout}/index.json"
+  make_archive "${layout}" "${archive}"
+}
+
+make_index_archive() {
+  local archive="$1"
+  local first_count="$2"
+  local second_count="$3"
+  local layout="${workdir}/layout"
+  mkdir -p "${layout}"
+  printf '{"imageLayoutVersion":"1.0.0"}' > "${layout}/oci-layout"
+  first_digest="$(make_manifest "${layout}" "${first_count}" "${layout}/manifest-amd64.json")"
+  second_digest="$(make_manifest "${layout}" "${second_count}" "${layout}/manifest-arm64.json")"
+  jq -n \
+    --arg first_digest "${first_digest}" \
+    --arg second_digest "${second_digest}" \
+    '{schemaVersion: 2, mediaType: "application/vnd.oci.image.index.v1+json", manifests: [{mediaType: "application/vnd.oci.image.manifest.v1+json", digest: $first_digest, size: 1, platform: {os: "linux", architecture: "amd64"}}, {mediaType: "application/vnd.oci.image.manifest.v1+json", digest: $second_digest, size: 1, platform: {os: "linux", architecture: "arm64"}}]}' \
+    > "${layout}/index.json"
+  make_archive "${layout}" "${archive}"
+}
+
+@test "single manifest with one layer returns 0" {
+  archive="${workdir}/single-one.oci"
+  make_single_manifest_archive "${archive}" 1
+
+  run "${SCRIPT}" --archive "${archive}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "0" ]
+}
+
+@test "single manifest with three layers returns comma-separated indexes" {
+  archive="${workdir}/single-three.oci"
+  make_single_manifest_archive "${archive}" 3
+
+  run "${SCRIPT}" --archive "${archive}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "0,1,2" ]
+}
+
+@test "index with consistent child layer counts returns indexes" {
+  archive="${workdir}/index.oci"
+  make_index_archive "${archive}" 2 2
+
+  run "${SCRIPT}" --archive "${archive}"
+
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "0,1" ]
+}
+
+@test "index with mismatched child layer counts fails" {
+  archive="${workdir}/index-mismatch.oci"
+  make_index_archive "${archive}" 2 3
+
+  run "${SCRIPT}" --archive "${archive}"
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"manifests have different layer counts"* ]]
+}
+
+@test "manifest with no layers fails" {
+  archive="${workdir}/empty.oci"
+  make_single_manifest_archive "${archive}" 0
+
+  run "${SCRIPT}" --archive "${archive}"
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"Cannot encrypt image with no layers"* ]]
+}

--- a/src/image/utils/schema/revision_data.py
+++ b/src/image/utils/schema/revision_data.py
@@ -1,4 +1,4 @@
-from .triggers import ImageUploadSchema
+from .triggers import ImageUploadSchema, ProSchema
 
 
 class RevisionDataSchema(ImageUploadSchema):
@@ -8,3 +8,4 @@ class RevisionDataSchema(ImageUploadSchema):
     path: str
     revision: int
     track: str
+    pro: ProSchema | None = None

--- a/src/image/utils/schema/triggers.py
+++ b/src/image/utils/schema/triggers.py
@@ -72,6 +72,7 @@ class ImageUploadSchema(pydantic.BaseModel):
     ignored_vulnerabilities: Optional[list[str]] = pydantic.Field(
         default_factory=list, alias="ignored-vulnerabilities"
     )
+    pro: Optional[ProSchema] = None
     release: Optional[Dict[str, ImageUploadReleaseSchema]] = None
 
     model_config = pydantic.ConfigDict(extra="forbid")
@@ -122,7 +123,11 @@ class ImageSchema(pydantic.BaseModel):
             return v
         unique_triggers = set()
         for upload in v:
-            trigger = f"{upload.source}_{upload.commit}_{upload.directory}"
+            pro_services = sorted(upload.pro.services) if upload.pro else []
+            trigger = (
+                f"{upload.source}_{upload.commit}_{upload.directory}_"
+                f"{','.join(pro_services)}"
+            )
             if trigger in unique_triggers:
                 raise ImageTriggerValidationError(
                     f"Image trigger {trigger} is not unique."

--- a/src/image/utils/schema/triggers.py
+++ b/src/image/utils/schema/triggers.py
@@ -42,6 +42,27 @@ class ProSchema(pydantic.BaseModel):
         return value
 
 
+class ProVariantSchema(pydantic.BaseModel):
+    """Schema of a Pro release variant in the merged release section."""
+
+    services: List[str]
+    pro: ProSchema
+    stable: str = None
+    candidate: str = None
+    beta: str = None
+    edge: str = None
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.model_validator(mode="after")
+    def _check_risks(self) -> "ProVariantSchema":
+        if not any([self.stable, self.candidate, self.beta, self.edge]):
+            raise ImageTriggerValidationError(
+                "At least one risk must be specified per Pro variant."
+            )
+        return self
+
+
 class ImageUploadReleaseSchema(pydantic.BaseModel):
     """Schema of the release option for uploads in the image.yaml trigger"""
 
@@ -87,6 +108,9 @@ class ChannelsSchema(pydantic.BaseModel):
     beta: str = None
     edge: str = None
     pro: Optional[ProSchema] = None
+    pro_variants: Optional[List[ProVariantSchema]] = pydantic.Field(
+        default_factory=list, alias="pro-variants"
+    )
 
     model_config = pydantic.ConfigDict(extra="forbid")
 
@@ -94,7 +118,7 @@ class ChannelsSchema(pydantic.BaseModel):
     def _check_risks(self, values: List) -> List:
         """There must be at least one risk specified."""
         error = "At least one risk must be specified per track."
-        if not any([self.stable, self.candidate, self.beta, self.edge]):
+        if not any([self.stable, self.candidate, self.beta, self.edge, self.pro_variants]):
             raise ImageTriggerValidationError(error)
 
         return values

--- a/src/image/utils/schema/triggers.py
+++ b/src/image/utils/schema/triggers.py
@@ -16,6 +16,32 @@ class ImageReachedEol(Exception):
     """Exception to be thrown when end-of-life is reached."""
 
 
+class ProConfigSchema(pydantic.BaseModel):
+    """Schema of the Ubuntu Pro credentials configuration."""
+
+    token: str
+    artifact_passphrase: str = pydantic.Field(alias="artifact-passphrase")
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+
+class ProSchema(pydantic.BaseModel):
+    """Schema of the Ubuntu Pro build configuration."""
+
+    services: List[str]
+    config: ProConfigSchema
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    @pydantic.field_validator("services", mode="after")
+    def _ensure_non_empty_services(cls, value):
+        if not value:
+            raise ImageTriggerValidationError(
+                "At least one Ubuntu Pro service must be present."
+            )
+        return value
+
+
 class ImageUploadReleaseSchema(pydantic.BaseModel):
     """Schema of the release option for uploads in the image.yaml trigger"""
 
@@ -24,6 +50,7 @@ class ImageUploadReleaseSchema(pydantic.BaseModel):
     # TODO: when upgrading to 24.04, switch to the following line
     # risks: List[Literal[*KNOWN_RISKS_ORDERED]]
     risks: List[Literal["stable", "candidate", "beta", "edge"]]
+    pro: Optional[ProSchema] = None
 
     model_config = pydantic.ConfigDict(extra="forbid")
 
@@ -58,6 +85,7 @@ class ChannelsSchema(pydantic.BaseModel):
     candidate: str = None
     beta: str = None
     edge: str = None
+    pro: Optional[ProSchema] = None
 
     model_config = pydantic.ConfigDict(extra="forbid")
 

--- a/src/tests/get_released_revisions.py
+++ b/src/tests/get_released_revisions.py
@@ -17,10 +17,8 @@ import sys
 from datetime import datetime, timezone
 
 import docker
-import yaml
 
 from ..shared.logs import get_logger
-from ..image.pro import is_pro_track
 
 SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", "quay.io/skopeo/stable:v1.20.0")
 REGISTRY = "ghcr.io/canonical/oci-factory"
@@ -72,10 +70,6 @@ def build_released_revisions_matrix(oci_images_path: str) -> tuple[dict, list[di
         with open(_releases_file) as rf:
             releases = json.load(rf)
 
-        image_trigger_file = f"{oci_images_path}/{img}/image.yaml"
-        with open(image_trigger_file, encoding="UTF-8") as trigger:
-            image_trigger = yaml.load(trigger, Loader=yaml.BaseLoader)
-
         released_revisions[img] = []
         for track, risks in releases.items():
             if risks.get("end-of-life") and risks["end-of-life"] < datetime.now(
@@ -90,7 +84,7 @@ def build_released_revisions_matrix(oci_images_path: str) -> tuple[dict, list[di
                 logger.warning(f"Track {track} is missing its end-of-life field")
 
             for key, targets in risks.items():
-                if key in ["end-of-life", "pro"]:
+                if key in ["end-of-life", "pro", "pro-variants"]:
                     continue
                 try:
                     if int(targets["target"]) in released_revisions[img]:
@@ -107,9 +101,31 @@ def build_released_revisions_matrix(oci_images_path: str) -> tuple[dict, list[di
                         "source-image": get_image_name_in_registry(
                             img, targets["target"]
                         ),
-                        "encrypted-source-image": is_pro_track(image_trigger, track),
+                        "encrypted-source-image": False,
                     }
                 )
+
+            for variant in risks.get("pro-variants", []) or []:
+                for key, targets in variant.items():
+                    if key in ["services", "pro"]:
+                        continue
+                    try:
+                        revision = int(targets["target"])
+                        if revision in released_revisions[img]:
+                            continue
+                    except ValueError:
+                        continue
+
+                    released_revisions[img].append(revision)
+                    ghcr_images.append(
+                        {
+                            "name": img,
+                            "source-image": get_image_name_in_registry(
+                                img, targets["target"]
+                            ),
+                            "encrypted-source-image": True,
+                        }
+                    )
 
     return released_revisions, ghcr_images
 

--- a/src/tests/get_released_revisions.py
+++ b/src/tests/get_released_revisions.py
@@ -17,8 +17,10 @@ import sys
 from datetime import datetime, timezone
 
 import docker
+import yaml
 
 from ..shared.logs import get_logger
+from ..image.pro import is_pro_track
 
 SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", "quay.io/skopeo/stable:v1.20.0")
 REGISTRY = "ghcr.io/canonical/oci-factory"
@@ -58,6 +60,60 @@ def get_image_name_in_registry(img_name: str, revision: str) -> str:
             return f"{tagless_image_name}:{tag}"
 
 
+def build_released_revisions_matrix(oci_images_path: str) -> tuple[dict, list[dict]]:
+    """Return released revisions and the continuous-testing matrix entries."""
+    released_revisions = {}
+    ghcr_images = []
+    for img in os.listdir(oci_images_path):
+        _releases_file = f"{oci_images_path}/{img}/_releases.json"
+        if not os.path.isfile(_releases_file):
+            continue
+
+        with open(_releases_file) as rf:
+            releases = json.load(rf)
+
+        image_trigger_file = f"{oci_images_path}/{img}/image.yaml"
+        with open(image_trigger_file, encoding="UTF-8") as trigger:
+            image_trigger = yaml.load(trigger, Loader=yaml.BaseLoader)
+
+        released_revisions[img] = []
+        for track, risks in releases.items():
+            if risks.get("end-of-life") and risks["end-of-life"] < datetime.now(
+                timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%SZ"):
+                logger.info(
+                    f"Skipping track {track} because it reached its end of life"
+                    f": {risks['end-of-life']}"
+                )
+                continue
+            elif not risks.get("end-of-life"):
+                logger.warning(f"Track {track} is missing its end-of-life field")
+
+            for key, targets in risks.items():
+                if key in ["end-of-life", "pro"]:
+                    continue
+                try:
+                    if int(targets["target"]) in released_revisions[img]:
+                        continue
+                except ValueError:
+                    # this target is following another tag and thus is not
+                    # a revision number
+                    continue
+
+                released_revisions[img].append(int(targets["target"]))
+                ghcr_images.append(
+                    {
+                        "name": img,
+                        "source-image": get_image_name_in_registry(
+                            img, targets["target"]
+                        ),
+                        "encrypted-source-image": is_pro_track(image_trigger, track),
+                    }
+                )
+
+    return released_revisions, ghcr_images
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=str(
@@ -75,49 +131,9 @@ if __name__ == "__main__":
 
     logger.info(f"Looping through OCI images in {args.oci_images_path}")
 
-    released_revisions = {}
-    ghcr_images = []
-    for img in os.listdir(args.oci_images_path):
-        _releases_file = f"{args.oci_images_path}/{img}/_releases.json"
-        if not os.path.isfile(_releases_file):
-            continue
-
-        with open(_releases_file) as rf:
-            releases = json.load(rf)
-
-        released_revisions[img] = []
-        for track, risks in releases.items():
-            if risks.get("end-of-life") and risks["end-of-life"] < datetime.now(
-                timezone.utc
-            ).strftime("%Y-%m-%dT%H:%M:%SZ"):
-                logger.info(
-                    f"Skipping track {track} because it reached its end of life"
-                    f": {risks['end-of-life']}"
-                )
-                continue
-            elif not risks.get("end-of-life"):
-                logger.warning(f"Track {track} is missing its end-of-life field")
-
-            for key, targets in risks.items():
-                if key == "end-of-life":
-                    continue
-                try:
-                    if int(targets["target"]) in released_revisions[img]:
-                        continue
-                except ValueError:
-                    # this target is following another tag and thus is not
-                    # a revision number
-                    continue
-
-                released_revisions[img].append(int(targets["target"]))
-                ghcr_images.append(
-                    {
-                        "name": img,
-                        "source-image": get_image_name_in_registry(
-                            img, targets["target"]
-                        ),
-                    }
-                )
+    released_revisions, ghcr_images = build_released_revisions_matrix(
+        args.oci_images_path
+    )
 
     logger.info(f"Released revisions: {json.dumps(released_revisions, indent=2)}")
     logger.info(f"Released revisions in GHCR: {ghcr_images}")

--- a/tests/unit/test_find_images_to_update.py
+++ b/tests/unit/test_find_images_to_update.py
@@ -1,0 +1,39 @@
+import importlib.util
+
+
+spec = importlib.util.spec_from_file_location(
+    "find_images_to_update",
+    "tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py",
+)
+find_images_to_update = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(find_images_to_update)
+
+
+def test_find_release_channels_preserves_pro_from_releases_json():
+    pro_config = {
+        "services": ["esm-apps"],
+        "config": {
+            "token": "secrets.UBUNTU_PRO_TOKEN",
+            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+        },
+    }
+    releases = {
+        "1.0-24.04": {
+            "end-of-life": "2030-05-01T00:00:00Z",
+            "stable": {"target": "7"},
+            "candidate": {"target": "1.0-24.04_stable"},
+            "pro": pro_config,
+        },
+        "latest": {
+            "end-of-life": "2030-05-01T00:00:00Z",
+            "stable": {"target": "8"},
+        },
+    }
+
+    assert find_images_to_update.find_release_channels(releases, 7) == {
+        "1.0-24.04": {
+            "risks": ["stable", "candidate"],
+            "end-of-life": "2030-05-01T00:00:00Z",
+            "pro": pro_config,
+        }
+    }

--- a/tests/unit/test_get_released_revisions.py
+++ b/tests/unit/test_get_released_revisions.py
@@ -1,0 +1,69 @@
+import json
+
+import yaml
+
+import src.tests.get_released_revisions as released
+
+
+def test_build_released_revisions_matrix_marks_pro_tracks(tmp_path, monkeypatch):
+    image_dir = tmp_path / "mock-rock"
+    image_dir.mkdir()
+    pro_config = {
+        "services": ["esm-apps"],
+        "config": {
+            "token": "secrets.UBUNTU_PRO_TOKEN",
+            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+        },
+    }
+    (image_dir / "image.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 2,
+                "release": {
+                    "1.0-24.04": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "stable": "1",
+                        "pro": pro_config,
+                    },
+                    "latest": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "stable": "2",
+                    },
+                },
+            }
+        )
+    )
+    (image_dir / "_releases.json").write_text(
+        json.dumps(
+            {
+                "1.0-24.04": {
+                    "end-of-life": "2030-05-01T00:00:00Z",
+                    "stable": {"target": "1"},
+                },
+                "latest": {
+                    "end-of-life": "2030-05-01T00:00:00Z",
+                    "stable": {"target": "2"},
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(
+        released,
+        "get_image_name_in_registry",
+        lambda image, revision: f"ghcr.io/canonical/oci-factory/{image}:tag-{revision}",
+    )
+
+    _, matrix = released.build_released_revisions_matrix(str(tmp_path))
+
+    assert matrix == [
+        {
+            "name": "mock-rock",
+            "source-image": "ghcr.io/canonical/oci-factory/mock-rock:tag-1",
+            "encrypted-source-image": True,
+        },
+        {
+            "name": "mock-rock",
+            "source-image": "ghcr.io/canonical/oci-factory/mock-rock:tag-2",
+            "encrypted-source-image": False,
+        },
+    ]

--- a/tests/unit/test_get_released_revisions.py
+++ b/tests/unit/test_get_released_revisions.py
@@ -1,44 +1,23 @@
 import json
 
-import yaml
-
 import src.tests.get_released_revisions as released
 
 
 def test_build_released_revisions_matrix_marks_pro_tracks(tmp_path, monkeypatch):
     image_dir = tmp_path / "mock-rock"
     image_dir.mkdir()
-    pro_config = {
-        "services": ["esm-apps"],
-        "config": {
-            "token": "secrets.UBUNTU_PRO_TOKEN",
-            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
-        },
-    }
-    (image_dir / "image.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "version": 2,
-                "release": {
-                    "1.0-24.04": {
-                        "end-of-life": "2030-05-01T00:00:00Z",
-                        "stable": "1",
-                        "pro": pro_config,
-                    },
-                    "latest": {
-                        "end-of-life": "2030-05-01T00:00:00Z",
-                        "stable": "2",
-                    },
-                },
-            }
-        )
-    )
+    (image_dir / "image.yaml").write_text("version: 2\nupload: []\n")
     (image_dir / "_releases.json").write_text(
         json.dumps(
             {
                 "1.0-24.04": {
                     "end-of-life": "2030-05-01T00:00:00Z",
-                    "stable": {"target": "1"},
+                    "pro-variants": [
+                        {
+                            "services": ["esm-apps"],
+                            "stable": {"target": "1"},
+                        }
+                    ],
                 },
                 "latest": {
                     "end-of-life": "2030-05-01T00:00:00Z",

--- a/tests/unit/test_image_trigger_file_validator.py
+++ b/tests/unit/test_image_trigger_file_validator.py
@@ -114,3 +114,66 @@ def test_ignored_vulnerabilities_with_v2_schema():
     }
 
     prep_matrix.validate_image_trigger(image_trigger)
+
+
+def test_image_trigger_validator_pro_release():
+    image_trigger = {
+        "version": 2,
+        "release": {
+            "1.0-24.04": {
+                "end-of-life": "2030-05-01T00:00:00Z",
+                "stable": "1",
+                "pro": {
+                    "services": ["esm-apps", "esm-infra"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                },
+            },
+        },
+        "upload": [
+            {
+                "source": "canonical/rocks-toolbox",
+                "commit": "abcdef1234567890",
+                "directory": "mock_rock/1.2",
+                "release": {
+                    "1.0-24.04": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "risks": ["stable"],
+                        "pro": {
+                            "services": ["esm-apps", "esm-infra"],
+                            "config": {
+                                "token": "secrets.UBUNTU_PRO_TOKEN",
+                                "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                            },
+                        },
+                    }
+                },
+            }
+        ],
+    }
+
+    prep_matrix.validate_image_trigger(image_trigger)
+
+
+def test_image_trigger_validator_pro_requires_services():
+    image_trigger = {
+        "version": 2,
+        "release": {
+            "1.0-24.04": {
+                "end-of-life": "2030-05-01T00:00:00Z",
+                "stable": "1",
+                "pro": {
+                    "services": [],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                },
+            }
+        },
+    }
+
+    with pytest.raises(ImageTriggerValidationError):
+        prep_matrix.validate_image_trigger(image_trigger)

--- a/tests/unit/test_image_trigger_file_validator.py
+++ b/tests/unit/test_image_trigger_file_validator.py
@@ -157,6 +157,61 @@ def test_image_trigger_validator_pro_release():
     prep_matrix.validate_image_trigger(image_trigger)
 
 
+def test_image_trigger_validator_upload_pro():
+    image_trigger = {
+        "version": 2,
+        "upload": [
+            {
+                "source": "canonical/rocks-toolbox",
+                "commit": "abcdef1234567890",
+                "directory": "mock_rock/1.2",
+                "pro": {
+                    "services": ["esm-apps", "esm-infra"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                },
+                "release": {
+                    "1.0-24.04": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "risks": ["stable"],
+                    }
+                },
+            }
+        ],
+    }
+
+    prep_matrix.validate_image_trigger(image_trigger)
+
+
+def test_image_trigger_validator_allows_duplicate_triplet_with_different_pro_services():
+    image_trigger = {
+        "version": 2,
+        "upload": [
+            {
+                "source": "canonical/rocks-toolbox",
+                "commit": "abcdef1234567890",
+                "directory": "mock_rock/1.2",
+            },
+            {
+                "source": "canonical/rocks-toolbox",
+                "commit": "abcdef1234567890",
+                "directory": "mock_rock/1.2",
+                "pro": {
+                    "services": ["esm-apps"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                },
+            },
+        ],
+    }
+
+    prep_matrix.validate_image_trigger(image_trigger)
+
+
 def test_image_trigger_validator_pro_requires_services():
     image_trigger = {
         "version": 2,

--- a/tests/unit/test_merge_release_info.py
+++ b/tests/unit/test_merge_release_info.py
@@ -1,0 +1,89 @@
+import json
+import runpy
+import sys
+
+import yaml
+
+import src.image.prepare_single_image_build_matrix as prep_matrix
+
+
+def test_write_revision_data_excludes_none_pro(tmp_path):
+    build = {
+        "source": "canonical/rocks-toolbox",
+        "commit": "abcdef1234567890",
+        "directory": "mock_rock/1.1",
+        "name": "mock-rock",
+        "path": "oci/mock-rock",
+        "revision": 1,
+        "track": "1.1-22.04",
+        "pro": None,
+        "release": {
+            "1.1-22.04": {
+                "end-of-life": "2030-05-01T00:00:00Z",
+                "risks": ["beta"],
+            }
+        },
+    }
+
+    prep_matrix.write_revision_data(tmp_path, build)
+
+    revision_data = json.loads((tmp_path / "1").read_text())
+    assert "pro" not in revision_data
+
+
+def test_merge_release_info_ignores_null_pro(tmp_path, monkeypatch):
+    image_trigger_path = tmp_path / "image.yaml"
+    image_trigger_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 2,
+                "upload": [],
+                "release": {
+                    "latest": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "candidate": "1.2-22.04_beta",
+                    }
+                },
+            }
+        )
+    )
+
+    revision_data_path = tmp_path / "revision-data.json"
+    revision_data_path.write_text(
+        json.dumps(
+            {
+                "source": "canonical/rocks-toolbox",
+                "commit": "abcdef1234567890",
+                "directory": "mock_rock/1.1",
+                "name": "mock-rock",
+                "path": "oci/mock-rock",
+                "revision": 1,
+                "track": "1.1-22.04",
+                "pro": None,
+                "release": {
+                    "1.1-22.04": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "risks": ["beta"],
+                    }
+                },
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "merge_release_info.py",
+            "--image-trigger",
+            str(image_trigger_path),
+            "--revision-data-file",
+            str(revision_data_path),
+        ],
+    )
+
+    runpy.run_module("src.image.merge_release_info", run_name="__main__")
+
+    merged_trigger = yaml.safe_load(image_trigger_path.read_text())
+    assert "pro" not in merged_trigger["release"]["1.1-22.04"]
+    prep_matrix.validate_image_trigger(merged_trigger)

--- a/tests/unit/test_merge_release_info.py
+++ b/tests/unit/test_merge_release_info.py
@@ -87,3 +87,55 @@ def test_merge_release_info_ignores_null_pro(tmp_path, monkeypatch):
     merged_trigger = yaml.safe_load(image_trigger_path.read_text())
     assert "pro" not in merged_trigger["release"]["1.1-22.04"]
     prep_matrix.validate_image_trigger(merged_trigger)
+
+
+def test_merge_release_info_copies_upload_pro_to_release_tracks(tmp_path, monkeypatch):
+    image_trigger_path = tmp_path / "image.yaml"
+    image_trigger_path.write_text(yaml.safe_dump({"version": 2, "upload": []}))
+
+    pro_config = {
+        "services": ["esm-apps"],
+        "config": {
+            "token": "secrets.UBUNTU_PRO_TOKEN",
+            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+        },
+    }
+    revision_data_path = tmp_path / "revision-data.json"
+    revision_data_path.write_text(
+        json.dumps(
+            {
+                "source": "canonical/rocks-toolbox",
+                "commit": "abcdef1234567890",
+                "directory": "mock_rock/1.1",
+                "name": "mock-rock",
+                "path": "oci/mock-rock",
+                "revision": 1,
+                "track": "1.1-22.04",
+                "pro": pro_config,
+                "release": {
+                    "1.1-22.04": {
+                        "end-of-life": "2030-05-01T00:00:00Z",
+                        "risks": ["beta", "edge"],
+                    }
+                },
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "merge_release_info.py",
+            "--image-trigger",
+            str(image_trigger_path),
+            "--revision-data-file",
+            str(revision_data_path),
+        ],
+    )
+
+    runpy.run_module("src.image.merge_release_info", run_name="__main__")
+
+    merged_trigger = yaml.safe_load(image_trigger_path.read_text())
+    assert merged_trigger["release"]["1.1-22.04"]["pro"] == pro_config
+    prep_matrix.validate_image_trigger(merged_trigger)

--- a/tests/unit/test_merge_release_info.py
+++ b/tests/unit/test_merge_release_info.py
@@ -137,5 +137,12 @@ def test_merge_release_info_copies_upload_pro_to_release_tracks(tmp_path, monkey
     runpy.run_module("src.image.merge_release_info", run_name="__main__")
 
     merged_trigger = yaml.safe_load(image_trigger_path.read_text())
-    assert merged_trigger["release"]["1.1-22.04"]["pro"] == pro_config
+    assert merged_trigger["release"]["1.1-22.04"]["pro-variants"] == [
+        {
+            "services": ["esm-apps"],
+            "pro": pro_config,
+            "beta": "1",
+            "edge": "1",
+        }
+    ]
     prep_matrix.validate_image_trigger(merged_trigger)

--- a/tests/unit/test_prepare_single_image_build_matrix.py
+++ b/tests/unit/test_prepare_single_image_build_matrix.py
@@ -147,7 +147,7 @@ def test_flatten_pro_builds():
 
     prep_matrix.flatten_pro_builds(builds)
 
-    assert builds[0]["pro-services"] == "esm-apps esm-infra"
+    assert builds[0]["pro-services"] == "esm-apps,esm-infra"
     assert builds[0]["pro-token"] == "UBUNTU_PRO_TOKEN"
     assert builds[0]["pro-artifact-passphrase"] == "PRO_ARTIFACT_PASSPHRASE"
     assert builds[0]["pro"] == builds[0]["release"]["1.0-24.04"]["pro"]
@@ -166,7 +166,7 @@ def test_flatten_pro_builds_uses_upload_pro():
 
     prep_matrix.flatten_pro_builds(builds)
 
-    assert builds[0]["pro-services"] == "esm-apps esm-infra"
+    assert builds[0]["pro-services"] == "esm-apps,esm-infra"
     assert builds[0]["pro-token"] == "UBUNTU_PRO_TOKEN"
     assert builds[0]["pro-artifact-passphrase"] == "PRO_ARTIFACT_PASSPHRASE"
 

--- a/tests/unit/test_prepare_single_image_build_matrix.py
+++ b/tests/unit/test_prepare_single_image_build_matrix.py
@@ -122,3 +122,87 @@ def test_locate_trigger_yaml(tmpdir):
     image_yaml_path.unlink()
     found_path = prep_matrix.locate_trigger_yaml(tmpdir_path)
     assert found_path == image_yml_path
+
+
+def test_flatten_pro_builds():
+    builds = [
+        {
+            "name": "mock",
+            "release": {
+                "1.0-24.04": {
+                    "end-of-life": "2030-05-01T00:00:00Z",
+                    "risks": ["stable"],
+                    "pro": {
+                        "services": ["esm-apps", "esm-infra"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                        },
+                    },
+                }
+            },
+        },
+        {"name": "public"},
+    ]
+
+    prep_matrix.flatten_pro_builds(builds)
+
+    assert builds[0]["pro-services"] == "esm-apps esm-infra"
+    assert builds[0]["pro-token"] == "UBUNTU_PRO_TOKEN"
+    assert builds[0]["pro-artifact-passphrase"] == "PRO_ARTIFACT_PASSPHRASE"
+    assert builds[0]["pro"] == builds[0]["release"]["1.0-24.04"]["pro"]
+    assert builds[1]["pro-services"] == ""
+
+
+def test_flatten_pro_builds_rejects_multiple_configs():
+    builds = [
+        {
+            "name": "mock",
+            "release": {
+                "1.0-24.04": {
+                    "pro": {
+                        "services": ["esm-apps"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                        },
+                    },
+                },
+                "1.1-24.04": {
+                    "pro": {
+                        "services": ["esm-infra"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                        },
+                    },
+                },
+            },
+        }
+    ]
+
+    with pytest.raises(prep_matrix.InvalidSchemaError):
+        prep_matrix.flatten_pro_builds(builds)
+
+
+def test_flatten_pro_builds_rejects_mixed_public_and_pro_tracks():
+    builds = [
+        {
+            "name": "mock",
+            "release": {
+                "1.0-24.04": {
+                    "pro": {
+                        "services": ["esm-apps"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                        },
+                    },
+                },
+                "latest": {"risks": ["stable"]},
+            },
+        }
+    ]
+
+    with pytest.raises(prep_matrix.InvalidSchemaError):
+        prep_matrix.flatten_pro_builds(builds)

--- a/tests/unit/test_prepare_single_image_build_matrix.py
+++ b/tests/unit/test_prepare_single_image_build_matrix.py
@@ -154,6 +154,38 @@ def test_flatten_pro_builds():
     assert builds[1]["pro-services"] == ""
 
 
+def test_flatten_pro_builds_uses_upload_pro():
+    pro_config = {
+        "services": ["esm-apps", "esm-infra"],
+        "config": {
+            "token": "secrets.UBUNTU_PRO_TOKEN",
+            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+        },
+    }
+    builds = [{"name": "mock", "pro": pro_config}]
+
+    prep_matrix.flatten_pro_builds(builds)
+
+    assert builds[0]["pro-services"] == "esm-apps esm-infra"
+    assert builds[0]["pro-token"] == "UBUNTU_PRO_TOKEN"
+    assert builds[0]["pro-artifact-passphrase"] == "PRO_ARTIFACT_PASSPHRASE"
+
+
+def test_dir_identifier_includes_sorted_pro_services():
+    build = {
+        "directory": "mock_rock/1.2",
+        "pro": {
+            "services": ["esm-infra", "esm-apps"],
+            "config": {
+                "token": "secrets.UBUNTU_PRO_TOKEN",
+                "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+            },
+        },
+    }
+
+    assert prep_matrix.get_dir_identifier(build) == "mock_rock_1.2_esm-apps_esm-infra"
+
+
 def test_flatten_pro_builds_rejects_multiple_configs():
     builds = [
         {

--- a/tests/unit/test_pro.py
+++ b/tests/unit/test_pro.py
@@ -1,4 +1,12 @@
-from src.image.pro import get_track_from_tag, has_public_tracks, is_pro_track
+import pytest
+
+from src.image.pro import (
+    get_pro_artifact_passphrase_secret,
+    get_track_from_tag,
+    has_pro_tracks,
+    has_public_tracks,
+    is_pro_track,
+)
 
 
 def test_get_track_from_tag_without_naming_assumptions():
@@ -24,3 +32,45 @@ def test_has_public_tracks():
         {"release": {"1.0-24.04": {"pro": pro_config}, "latest": {}}}
     )
     assert is_pro_track({"release": {"1.0-24.04": {"pro": pro_config}}}, "1.0-24.04")
+
+
+def test_pro_helpers():
+    pro_config = {
+        "services": ["esm-apps"],
+        "config": {
+            "token": "secrets.UBUNTU_PRO_TOKEN",
+            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+        },
+    }
+    image_trigger = {"release": {"1.0-24.04": {"pro": pro_config}}}
+
+    assert has_pro_tracks(image_trigger)
+    assert get_pro_artifact_passphrase_secret(image_trigger) == "PRO_ARTIFACT_PASSPHRASE"
+
+
+def test_pro_artifact_passphrase_secret_must_be_unique():
+    image_trigger = {
+        "release": {
+            "1.0-24.04": {
+                "pro": {
+                    "services": ["esm-apps"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                }
+            },
+            "2.0-24.04": {
+                "pro": {
+                    "services": ["esm-apps"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.OTHER_PASSPHRASE",
+                    },
+                }
+            },
+        }
+    }
+
+    with pytest.raises(ValueError):
+        get_pro_artifact_passphrase_secret(image_trigger)

--- a/tests/unit/test_pro.py
+++ b/tests/unit/test_pro.py
@@ -1,0 +1,26 @@
+from src.image.pro import get_track_from_tag, has_public_tracks, is_pro_track
+
+
+def test_get_track_from_tag_without_naming_assumptions():
+    assert get_track_from_tag("stable") == "latest"
+    assert get_track_from_tag("1.0-24.04_stable") == "1.0-24.04"
+    assert get_track_from_tag("1.0-24.04") == "1.0-24.04"
+
+
+def test_has_public_tracks():
+    pro_config = {
+        "services": ["esm-apps"],
+        "config": {
+            "token": "secrets.UBUNTU_PRO_TOKEN",
+            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+        },
+    }
+
+    assert not has_public_tracks({"release": {"1.0-24.04": {"pro": pro_config}}})
+    assert not has_public_tracks(
+        {"upload": [{"release": {"1.0-24.04": {"pro": pro_config}}}]}
+    )
+    assert has_public_tracks(
+        {"release": {"1.0-24.04": {"pro": pro_config}, "latest": {}}}
+    )
+    assert is_pro_track({"release": {"1.0-24.04": {"pro": pro_config}}}, "1.0-24.04")

--- a/tests/unit/test_pro.py
+++ b/tests/unit/test_pro.py
@@ -3,10 +3,10 @@ import pytest
 from src.image.pro import (
     get_pro_artifact_passphrase_secret,
     get_pro_revision_refs,
+    get_published_track,
     get_track_from_tag,
     has_pro_tracks,
     has_public_tracks,
-    is_pro_track,
 )
 
 
@@ -25,7 +25,7 @@ def test_has_public_tracks():
         },
     }
 
-    assert not has_public_tracks({"release": {"1.0-24.04": {"pro": pro_config}}})
+    assert not has_public_tracks({"release": {"1.0-24.04": {"pro-variants": [{"pro": pro_config, "services": ["esm-apps"], "stable": "1"}]}}})
     assert not has_public_tracks(
         {"upload": [{"release": {"1.0-24.04": {"pro": pro_config}}}]}
     )
@@ -33,9 +33,8 @@ def test_has_public_tracks():
         {"upload": [{"pro": pro_config, "release": {"1.0-24.04": {}}}]}
     )
     assert has_public_tracks(
-        {"release": {"1.0-24.04": {"pro": pro_config}, "latest": {}}}
+        {"release": {"1.0-24.04": {"pro-variants": []}, "latest": {"stable": "1"}}}
     )
-    assert is_pro_track({"release": {"1.0-24.04": {"pro": pro_config}}}, "1.0-24.04")
 
 
 def test_pro_helpers():
@@ -46,7 +45,7 @@ def test_pro_helpers():
             "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
         },
     }
-    image_trigger = {"release": {"1.0-24.04": {"pro": pro_config}}}
+    image_trigger = {"release": {"1.0-24.04": {"pro-variants": [{"pro": pro_config, "services": ["esm-apps"], "stable": "1"}]}}}
 
     assert has_pro_tracks(image_trigger)
     assert get_pro_artifact_passphrase_secret(image_trigger) == "PRO_ARTIFACT_PASSPHRASE"
@@ -60,22 +59,30 @@ def test_pro_artifact_passphrase_secret_must_be_unique():
     image_trigger = {
         "release": {
             "1.0-24.04": {
-                "pro": {
+                "pro-variants": [{
                     "services": ["esm-apps"],
-                    "config": {
-                        "token": "secrets.UBUNTU_PRO_TOKEN",
-                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    "stable": "1",
+                    "pro": {
+                        "services": ["esm-apps"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                        },
                     },
-                }
+                }]
             },
             "2.0-24.04": {
-                "pro": {
+                "pro-variants": [{
                     "services": ["esm-apps"],
-                    "config": {
-                        "token": "secrets.UBUNTU_PRO_TOKEN",
-                        "artifact-passphrase": "secrets.OTHER_PASSPHRASE",
+                    "stable": "2",
+                    "pro": {
+                        "services": ["esm-apps"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.OTHER_PASSPHRASE",
+                        },
                     },
-                }
+                }]
             },
         }
     }
@@ -88,13 +95,17 @@ def test_get_pro_revision_refs():
     image_trigger = {
         "release": {
             "1.0-24.04": {
-                "pro": {
+                "pro-variants": [{
                     "services": ["esm-apps"],
-                    "config": {
-                        "token": "secrets.UBUNTU_PRO_TOKEN",
-                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    "stable": "1",
+                    "pro": {
+                        "services": ["esm-apps"],
+                        "config": {
+                            "token": "secrets.UBUNTU_PRO_TOKEN",
+                            "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                        },
                     },
-                }
+                }]
             },
             "latest": {},
         }
@@ -103,3 +114,16 @@ def test_get_pro_revision_refs():
     assert get_pro_revision_refs(
         image_trigger, ["1.0-24.04_1", "latest_2"]
     ) == ["1.0-24.04_1"]
+
+
+def test_get_published_track():
+    assert get_published_track("1.2-24.04") == "1.2-24.04"
+    assert get_published_track(
+        "1.2-24.04", {"services": ["esm-apps", "esm-infra"]}
+    ) == "1.2-24.04"
+    assert get_published_track(
+        "1.2-24.04", {"services": ["fips", "esm-infra"]}
+    ) == "1.2-fips-24.04"
+    assert get_published_track(
+        "1.2-24.04", {"services": ["fips-updates", "fips"]}
+    ) == "1.2-fips-fips-updates-24.04"

--- a/tests/unit/test_pro.py
+++ b/tests/unit/test_pro.py
@@ -2,6 +2,7 @@ import pytest
 
 from src.image.pro import (
     get_pro_artifact_passphrase_secret,
+    get_pro_revision_refs,
     get_track_from_tag,
     has_pro_tracks,
     has_public_tracks,
@@ -28,6 +29,9 @@ def test_has_public_tracks():
     assert not has_public_tracks(
         {"upload": [{"release": {"1.0-24.04": {"pro": pro_config}}}]}
     )
+    assert not has_public_tracks(
+        {"upload": [{"pro": pro_config, "release": {"1.0-24.04": {}}}]}
+    )
     assert has_public_tracks(
         {"release": {"1.0-24.04": {"pro": pro_config}, "latest": {}}}
     )
@@ -46,6 +50,10 @@ def test_pro_helpers():
 
     assert has_pro_tracks(image_trigger)
     assert get_pro_artifact_passphrase_secret(image_trigger) == "PRO_ARTIFACT_PASSPHRASE"
+
+    upload_trigger = {"upload": [{"pro": pro_config, "release": {"1.0-24.04": {}}}]}
+    assert has_pro_tracks(upload_trigger)
+    assert get_pro_artifact_passphrase_secret(upload_trigger) == "PRO_ARTIFACT_PASSPHRASE"
 
 
 def test_pro_artifact_passphrase_secret_must_be_unique():
@@ -74,3 +82,24 @@ def test_pro_artifact_passphrase_secret_must_be_unique():
 
     with pytest.raises(ValueError):
         get_pro_artifact_passphrase_secret(image_trigger)
+
+
+def test_get_pro_revision_refs():
+    image_trigger = {
+        "release": {
+            "1.0-24.04": {
+                "pro": {
+                    "services": ["esm-apps"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                }
+            },
+            "latest": {},
+        }
+    }
+
+    assert get_pro_revision_refs(
+        image_trigger, ["1.0-24.04_1", "latest_2"]
+    ) == ["1.0-24.04_1"]

--- a/tests/unit/test_release.py
+++ b/tests/unit/test_release.py
@@ -1,7 +1,7 @@
 import pytest
 
 import src.shared.release_info as shared
-from src.image.release import remove_eol_tags
+from src.image.release import group_release_tags_by_revision_and_destination, remove_eol_tags
 
 from ..fixtures.sample_data import circular_release_json, release_json
 
@@ -78,3 +78,34 @@ def test_remove_eol_tags_circular_release(circular_release_json):
 
     with pytest.raises(shared.BadChannel):
         remove_eol_tags(revision_to_tag, circular_release_json)
+
+
+def test_group_release_tags_by_revision_and_destination():
+    image_trigger = {
+        "version": "2",
+        "release": {
+            "latest": {"end-of-life": "2030-05-01T00:00:00Z", "stable": "1"},
+            "1.0-24.04": {
+                "end-of-life": "2030-05-01T00:00:00Z",
+                "stable": "2",
+                "pro": {
+                    "services": ["esm-apps"],
+                    "config": {
+                        "token": "secrets.UBUNTU_PRO_TOKEN",
+                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
+                    },
+                },
+            },
+        },
+    }
+    release_tags = {
+        "stable": 1,
+        "latest": 1,
+        "1.0-24.04_stable": 2,
+        "1.0-24.04": 2,
+    }
+
+    result = group_release_tags_by_revision_and_destination(release_tags, image_trigger)
+
+    assert result[1]["public"] == ["latest", "stable"]
+    assert result[2]["pro-acr"] == ["1.0-24.04", "1.0-24.04_stable"]

--- a/tests/unit/test_release.py
+++ b/tests/unit/test_release.py
@@ -5,6 +5,8 @@ from src.image.release import (
     get_release_source,
     group_release_tags_by_revision_and_destination,
     remove_eol_tags,
+    release_entry,
+    validate_unique_destination_tags,
 )
 
 from ..fixtures.sample_data import circular_release_json, release_json
@@ -85,34 +87,35 @@ def test_remove_eol_tags_circular_release(circular_release_json):
 
 
 def test_group_release_tags_by_revision_and_destination():
-    image_trigger = {
-        "version": "2",
-        "release": {
-            "latest": {"end-of-life": "2030-05-01T00:00:00Z", "stable": "1"},
-            "1.0-24.04": {
-                "end-of-life": "2030-05-01T00:00:00Z",
-                "stable": "2",
-                "pro": {
-                    "services": ["esm-apps"],
-                    "config": {
-                        "token": "secrets.UBUNTU_PRO_TOKEN",
-                        "artifact-passphrase": "secrets.PRO_ARTIFACT_PASSPHRASE",
-                    },
-                },
-            },
-        },
-    }
     release_tags = {
-        "stable": 1,
-        "latest": 1,
-        "1.0-24.04_stable": 2,
-        "1.0-24.04": 2,
+        "stable": release_entry(1, "public", tag="stable"),
+        "latest": release_entry(1, "public", tag="latest"),
+        "pro:esm-apps:1.0-24.04_stable": release_entry(
+            2, "pro-acr", tag="1.0-24.04_stable"
+        ),
+        "pro:esm-apps:1.0-24.04_stable:alias:1.0-24.04": release_entry(
+            2, "pro-acr", tag="1.0-24.04"
+        ),
     }
 
-    result = group_release_tags_by_revision_and_destination(release_tags, image_trigger)
+    result = group_release_tags_by_revision_and_destination(release_tags, {})
 
     assert result[1]["public"] == ["latest", "stable"]
-    assert result[2]["pro-acr"] == ["1.0-24.04", "1.0-24.04_stable"]
+    assert sorted(result[2]["pro-acr"]) == ["1.0-24.04", "1.0-24.04_stable"]
+
+
+def test_validate_unique_destination_tags_rejects_collision():
+    release_tags = {
+        "pro:esm-apps:1.0-24.04_stable": release_entry(
+            1, "pro-acr", tag="1.0-24.04_stable"
+        ),
+        "pro:esm-infra:1.0-24.04_stable": release_entry(
+            2, "pro-acr", tag="1.0-24.04_stable"
+        ),
+    }
+
+    with pytest.raises(shared.BadChannel):
+        validate_unique_destination_tags(release_tags)
 
 
 def test_get_release_source_for_public_uses_ghcr():

--- a/tests/unit/test_release.py
+++ b/tests/unit/test_release.py
@@ -1,7 +1,11 @@
 import pytest
 
 import src.shared.release_info as shared
-from src.image.release import group_release_tags_by_revision_and_destination, remove_eol_tags
+from src.image.release import (
+    get_release_source,
+    group_release_tags_by_revision_and_destination,
+    remove_eol_tags,
+)
 
 from ..fixtures.sample_data import circular_release_json, release_json
 
@@ -109,3 +113,25 @@ def test_group_release_tags_by_revision_and_destination():
 
     assert result[1]["public"] == ["latest", "stable"]
     assert result[2]["pro-acr"] == ["1.0-24.04", "1.0-24.04_stable"]
+
+
+def test_get_release_source_for_public_uses_ghcr():
+    assert get_release_source(
+        "public", "1.0-24.04", 1, "mock-rock", "canonical/oci-factory", ""
+    ) == "docker://ghcr.io/canonical/oci-factory/mock-rock:1.0-24.04_1"
+
+
+def test_get_release_source_for_pro_uses_local_archive(tmp_path):
+    source = tmp_path / "mock-rock_1.0-24.04_1"
+    source.touch()
+
+    assert get_release_source(
+        "pro-acr", "1.0-24.04", 1, "mock-rock", "canonical/oci-factory", tmp_path
+    ) == f"oci-archive:{source}"
+
+
+def test_get_release_source_for_pro_requires_local_archive(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        get_release_source(
+            "pro-acr", "1.0-24.04", 1, "mock-rock", "canonical/oci-factory", tmp_path
+        )

--- a/tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
+++ b/tools/workflow-engine/charms/temporal-worker/oci_factory/activities/find_images_to_update.py
@@ -23,9 +23,9 @@ import zipfile
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
 
-import requests
 import swiftclient
 import yaml
+import requests
 
 
 # TODO:
@@ -47,6 +47,64 @@ def find_released_revisions(releases_json: dict) -> list:
                 released_revisions.append(revision)
 
     return released_revisions
+
+
+def resolve_release_target(releases_json: dict, target: str, visited: set[str]) -> int | None:
+    """Resolve a release target to a concrete revision number."""
+    if target in visited:
+        logging.warning(f"Skipping circular release target {target}")
+        return None
+    visited.add(target)
+
+    try:
+        return int(target)
+    except ValueError:
+        pass
+
+    try:
+        track, risk = target.rsplit("_", 1)
+        return resolve_release_target(
+            releases_json, releases_json[track][risk]["target"], visited
+        )
+    except (KeyError, ValueError, TypeError):
+        logging.warning(f"Skipping unresolved release target {target}")
+        return None
+
+
+def find_release_channels(releases_json: dict, target_revision: int) -> dict:
+    """Find release tracks and risks that point to a revision in _releases.json."""
+    release_to = {}
+    for track, risks in releases_json.items():
+        if risks.get("end-of-life"):
+            if risks["end-of-life"] < datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ):
+                logging.info(
+                    f"Skipping track {track} because it reached its end of life: "
+                    f"{risks['end-of-life']}"
+                )
+                continue
+        else:
+            logging.warning(f"Track {track} is missing its end-of-life field")
+            continue
+
+        for risk, targets in risks.items():
+            if risk in ["end-of-life", "pro"]:
+                continue
+
+            revision = resolve_release_target(releases_json, targets["target"], set())
+
+            if revision != target_revision:
+                continue
+
+            if track not in release_to:
+                release_to[track] = {"risks": []}
+            release_to[track]["risks"].append(risk)
+            release_to[track]["end-of-life"] = risks["end-of-life"]
+            if pro_config := risks.get("pro"):
+                release_to[track]["pro"] = pro_config
+
+    return release_to
 
 
 def trigger_triplet(trigger: dict) -> str:
@@ -82,19 +140,6 @@ def trigger_image_rebuild():
     # Let's use an uber image trigger file to trigger the CI rebuilds
     uber_img_trigger = {"version": 2, "upload": []}
     uploads = {}  # key: trigger triplet, value: uber_image_trigger["upload"] entry
-    # We'll also need to find which tags (channels) to release the new
-    # rebuilds to
-    # TODO: Get rid of this once we have a proper DB where to store all the
-    # image information.
-    # This is a bit nasty as these APIs return paginated results
-    # and don't offer enough querying parameters to filter the results.
-    ecr_tags_url = "https://api.us-east-1.gallery.ecr.aws/describeImageTags"
-    body = {"repositoryName": image, "maxResults": 1000}
-    if image.startswith("mock-"):
-        body["registryAliasName"] = "rocksdev"
-    else:
-        body["registryAliasName"] = "ubuntu"
-    tags = json.loads(requests.post(ecr_tags_url, json=body).content.decode())
     # Each Swift object corresponds to an image revision (<=> build)
     for image_revision in img_objs:
         _, _, revision, _ = image_revision["name"].split("/")
@@ -134,61 +179,10 @@ def trigger_image_rebuild():
                 "ignored-vulnerabilities", ""
             ).split(),
         }
-        release_to = {}
-        imageTagDetails = tags.get("imageTagDetails", {})
-        if not imageTagDetails:
-            logging.warning(
-                f"{tags.get('message', 'Image tags not found in registry')}. Skip!"
-            )
-            continue
-
-        tags_matched = False
-        for tag in imageTagDetails:
-            if tag["imageDetail"].get("imageDigest") != revision_digest:
-                continue
-            tags_matched = True
-
-            if tag["imageTag"] in ["edge", "beta", "candidate", "stable"]:
-                to_track = "latest"
-                to_risk = tag["imageTag"]
-            else:
-                try:
-                    to_track, to_risk = tag["imageTag"].rsplit("_", 1)
-                except ValueError as err:
-                    if "not enough values to unpack" in str(err):
-                        # These cases are driven by the <track> alias which
-                        # is created for tags like <track>_stable
-                        to_track = tag["imageTag"]
-                        to_risk = "stable"
-                    else:
-                        logging.exception(f"Unrecognized tag {tag['imageTag']}")
-                        continue
-
-            if releases[to_track].get("end-of-life"):
-                if releases[to_track]["end-of-life"] < datetime.now(
-                    timezone.utc
-                ).strftime("%Y-%m-%dT%H:%M:%SZ"):
-                    logging.info(
-                        f"Skipping track {to_track} because it reached its "
-                        f"end of life: {releases[to_track]['end-of-life']}"
-                    )
-                    continue
-                else:
-                    if to_track not in release_to:
-                        release_to[str(to_track)] = {"risks": [to_risk]}
-                    else:
-                        release_to[to_track]["risks"].append(to_risk)
-                    release_to[to_track]["end-of-life"] = releases[to_track][
-                        "end-of-life"
-                    ]
-            else:
-                logging.warning(f"Track {to_track} is missing its end-of-" "life field")
-
-        if not tags_matched:
-            logging.warning(
-                f"Unable to find a tag for {image} revision {revision} in ECR"
-            )
-            continue
+        release_to = find_release_channels(releases, int(revision))
+        if pro_config := build_metadata.get("pro"):
+            for release in release_to.values():
+                release["pro"] = pro_config
 
         triplet = trigger_triplet(build_and_upload_data)
 


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR adds support for Pro rocks. The `image.yaml` schema now accepts a pro block on release tracks, matching rocks-template:
```
pro:
  services: [...]
  config:
    token: secrets.UBUNTU_PRO_TOKEN
    artifact-passphrase: secrets.PRO_ARTIFACT_PASSPHRASE
```

Pro tracks are built with Pro enabled, published only to ACR, build metadata is preserved in Swift for rebuilds, and documentation generation is skipped when an image is Pro-only.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
