### PR TITLE
chore: add stable, candidate and beta channels to JDK 25 image

### DIFF
--- a/oci/jdk/image.yaml
+++ b/oci/jdk/image.yaml
@@ -30,4 +30,7 @@ upload:
       25-26.04:
         end-of-life: "2031-05-29T00:00:00Z"
         risks:
+          - stable
+          - candidate
+          - beta
           - edge


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
We have released JDK 25 image earlier this year. Promote the image to the stable channel.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
