### PR TITLE
feat(ci): always use containerized skopeo

### DIFF
--- a/.github/actions/upload-rock/action.yml
+++ b/.github/actions/upload-rock/action.yml
@@ -25,6 +25,11 @@ inputs:
     description: "The github token needed for downloading the artifact from a different repository or workflow run."
   decrypt-passphrase:
     description: "The passphrase for the artifact if it is encrypted."
+  skopeo-image:
+    description: "Skopeo image used to inspect and upload the artifact."
+    required: false
+    # Skopeo v1.22.2.
+    default: "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
 outputs:
   digest:
     description: "The digest of the uploaded image"
@@ -53,10 +58,12 @@ runs:
     - name: Get Metadata
       id: meta
       shell: bash
+      env:
+        SKOPEO_IMAGE: ${{ inputs.skopeo-image }}
       run: |
         docker run --rm \
           -v $PWD:/workdir -w /workdir \
-          "quay.io/skopeo/stable:v1.20.0" \
+          "${SKOPEO_IMAGE}" \
           inspect oci-archive:${{ inputs.artifact_name }} > metadata.json
 
         digest="$(cat metadata.json | jq -r .Digest)"
@@ -64,11 +71,13 @@ runs:
 
     - name: Upload Rock to Registry
       shell: bash
+      env:
+        SKOPEO_IMAGE: ${{ inputs.skopeo-image }}
       run: |
         for tag in ${{ inputs.tags }}; do
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+          docker run --rm \
           -v $PWD:/workdir -w /workdir \
-          "quay.io/skopeo/stable:v1.20.0" \
+          "${SKOPEO_IMAGE}" \
           copy \
           --dest-username "${{ inputs.username }}" \
           --dest-password "${{ inputs.password }}" \

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -47,6 +47,8 @@ on:
 env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"
   ROCK_REPO_DIR: rock-repo
+  # Skopeo v1.22.2.
+  SKOPEO_IMAGE: "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
 
 jobs:
   prepare-build:
@@ -339,8 +341,6 @@ jobs:
           ROCKS_DEV_LP_USERNAME: ${{ secrets.ROCKS_DEV_LP_USERNAME }}
           CPC_BUILD_TOOLS_REPO: git.launchpad.net/~cloudware/cloudware/+git/cpc_build_tools
           # CPC_BUILD_TOOLS_REPO_REF: 9b716ed8a8ba728d036b54b1bb17a8f49dbda434
-          SKOPEO_BRANCH: "v1.20.0"
-          SKOPEO_URL: "https://github.com/containers/skopeo"
         run: |
           ./src/image/requirements.sh
           ./src/uploads/requirements.sh
@@ -383,8 +383,11 @@ jobs:
             set -x
           fi
           source src/shared/logs.sh
-          arches=$(skopeo inspect --raw \
-            oci-archive:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME} \
+          arches=$(docker run --rm \
+            -v "$PWD:/workdir" -w /workdir \
+            "${SKOPEO_IMAGE}" \
+            inspect --raw \
+            "oci-archive:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}" \
             | jq -r 'if has("manifests") then .manifests[].platform.architecture else "${{ runner.arch }}" end' \
             | jq -nRcr '[inputs] | join(",")')
 
@@ -426,7 +429,10 @@ jobs:
             log_info "Generate SBOM for ${arch}"
 
             # --insecure-policy is required on private-endpoint runners.
-            skopeo --insecure-policy --override-arch "${arch}" copy \
+            docker run --rm \
+              -v "$PWD:/workdir" -w /workdir \
+              "${SKOPEO_IMAGE}" \
+              --insecure-policy --override-arch "${arch}" copy \
               "oci-archive:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}" \
               "oci:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_NAME}.${arch}:${STEPS_RENAME_OCI_ARCHIVE_OUTPUTS_CANONICAL_TAG}" \
 
@@ -502,6 +508,7 @@ jobs:
           name: ${{ github.repository_owner }}/oci-factory/${{ matrix.name }}
           tags: ${{ matrix.track }}_${{ matrix.revision }}
           registry: ghcr.io
+          skopeo-image: ${{ env.SKOPEO_IMAGE }}
           password: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
 

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -117,8 +117,6 @@ jobs:
           ROCKS_DEV_LP_USERNAME: ${{ secrets.ROCKS_DEV_LP_USERNAME }}
           CPC_BUILD_TOOLS_REPO: git.launchpad.net/~cloudware/cloudware/+git/cpc_build_tools
           # CPC_BUILD_TOOLS_REPO_REF: 9b716ed8a8ba728d036b54b1bb17a8f49dbda434
-          SKOPEO_BRANCH: 'v1.20.0'
-          SKOPEO_URL: 'https://github.com/containers/skopeo'
         run: | 
           ./src/image/requirements.sh
           pip install -r src/image/requirements.txt

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -64,7 +64,8 @@ env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"  # TODO: inherit string from caller
   TEST_IMAGE_NAME: "test-img"
   TEST_IMAGE_TAG: "test"
-  SKOPEO_IMAGE: "quay.io/skopeo/stable:v1.20.0"
+  # Skopeo v1.22.2.
+  SKOPEO_IMAGE: "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
   UMOCI_VERSION: "v0.4.7"
   UMOCI_BINARY: "umoci.amd64"
   DIVE_IMAGE: "wagoodman/dive:v0.13.1"
@@ -117,7 +118,7 @@ jobs:
 
       - name: Unpack Rock
         run: |
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+          docker run --rm \
             -v "$PWD:/workdir" -w /workdir \
             "${SKOPEO_IMAGE}" \
             copy "oci-archive:${INPUTS_OCI_ARCHIVE_NAME}" \

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -29,7 +29,8 @@ on:
 
 env:
   VULNERABILITY_REPORT_SUFFIX: '.vulnerability-report.json' # TODO: inherit string from caller
-  SKOPEO_IMAGE: 'quay.io/skopeo/stable:v1.20.0'
+  # Skopeo v1.22.2.
+  SKOPEO_IMAGE: 'quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615'
 
 jobs:
   configure-scan:
@@ -55,7 +56,7 @@ jobs:
           echo "oci-filename=$oci_filename" >> "$GITHUB_OUTPUT"
           echo "report-filename=${oci_filename}${{ env.VULNERABILITY_REPORT_SUFFIX }}" >> "$GITHUB_OUTPUT"
 
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+          docker run --rm \
             -v "$PWD:/workdir" -w /workdir \
             "${SKOPEO_IMAGE}" \
             copy "docker://${INPUTS_OCI_IMAGE_NAME}" \

--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -23,6 +23,7 @@ from src.docs.schema.v1.DocSchema import DocSchema as DocSchemaV1
 from src.docs.schema.v2.DocSchema import DocSchema as DocSchemaV2
 
 from ..shared.logs import get_logger
+from ..shared.skopeo import DEFAULT_SKOPEO_IMAGE
 
 MOCK_RELEASE: List[Dict[str, Any]] = [
     {
@@ -58,11 +59,9 @@ logger = get_logger()
 
 def cli_args() -> argparse.ArgumentParser:
     """Arguments parser"""
-    parser = argparse.ArgumentParser(
-        description="""
+    parser = argparse.ArgumentParser(description="""
         Generate documentation of OCI images in OCI Factory.
-        """
-    )
+        """)
 
     parser.add_argument(
         "--ecr-api-key",
@@ -201,7 +200,17 @@ class OCIDocumentationData:
                 os.fchmod(file.fileno(), 0o600)
                 json.dump(auth_config, file)
 
-            command = ["skopeo", cmd] + ["--authfile", auth_file] + args
+            command = [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                f"{tmp_dir}:/skopeo-auth:ro",
+                os.environ.get("SKOPEO_IMAGE", DEFAULT_SKOPEO_IMAGE),
+                cmd,
+                "--authfile",
+                "/skopeo-auth/auth.json",
+            ] + args
 
             return json.loads(self.process_run(command))
 

--- a/src/docs/generate_oci_doc_yaml.py
+++ b/src/docs/generate_oci_doc_yaml.py
@@ -205,7 +205,7 @@ class OCIDocumentationData:
                 "run",
                 "--rm",
                 "-v",
-                f"{tmp_dir}:/skopeo-auth:ro",
+                f"{auth_file}:/skopeo-auth/auth.json:ro",
                 os.environ.get("SKOPEO_IMAGE", DEFAULT_SKOPEO_IMAGE),
                 cmd,
                 "--authfile",

--- a/src/image/requirements.sh
+++ b/src/image/requirements.sh
@@ -1,18 +1,5 @@
 #!/bin/bash -e
 
-## Install Skopeo
-git clone -b ${SKOPEO_BRANCH} --depth 1 ${SKOPEO_URL} /tmp/skopeo
-pushd /tmp/skopeo
-
-docker run -v $PWD:/src -w /src -e DISABLE_DOCS=1 \
-    golang:1.25 sh -c \
-    'apt update; apt install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config; \
-    git config --global --add safe.directory /src; make'
-
-sudo mv bin/skopeo /usr/local/bin/
-sudo chmod +x /usr/local/bin/skopeo
-popd
-
 sudo apt update
 sudo apt install -y distro-info
 

--- a/src/shared/skopeo.py
+++ b/src/shared/skopeo.py
@@ -1,0 +1,4 @@
+"""Shared Skopeo container configuration."""
+
+# Skopeo v1.22.2.
+DEFAULT_SKOPEO_IMAGE = "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"

--- a/src/tests/get_released_revisions.py
+++ b/src/tests/get_released_revisions.py
@@ -19,8 +19,9 @@ from datetime import datetime, timezone
 import docker
 
 from ..shared.logs import get_logger
+from ..shared.skopeo import DEFAULT_SKOPEO_IMAGE
 
-SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", "quay.io/skopeo/stable:v1.20.0")
+SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", DEFAULT_SKOPEO_IMAGE)
 REGISTRY = "ghcr.io/canonical/oci-factory"
 
 logger = get_logger(stream=sys.stdout, level="INFO")

--- a/src/uploads/oci_registry_upload.py
+++ b/src/uploads/oci_registry_upload.py
@@ -12,6 +12,7 @@ from subprocess import check_call
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from shared.logs import get_logger
+from shared.skopeo import DEFAULT_SKOPEO_IMAGE
 
 logger = get_logger()
 
@@ -30,23 +31,28 @@ def parse_args():
 
 def main():
     args = parse_args()
-    # --insecure-policy is required on private-endpoint runners.
-    base_cmd = [
-        "skopeo",
-        "--insecure-policy",
-        "copy",
-        "--preserve-digests",
-        args.source_uri,
-    ]
 
     with tempfile.TemporaryDirectory() as tmp_dir:
+        # --insecure-policy is required on private-endpoint runners.
+        base_cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{tmp_dir}:/skopeo-auth:ro",
+            os.environ.get("SKOPEO_IMAGE", DEFAULT_SKOPEO_IMAGE),
+            "--insecure-policy",
+            "copy",
+            "--preserve-digests",
+            args.source_uri,
+        ]
         if args.registry_auth:
             auth_config = {"auths": {args.target_name: {"auth": args.registry_auth}}}
             auth_file = os.path.join(tmp_dir, "auth.json")
             with open(auth_file, "w") as f:
                 os.fchmod(f.fileno(), 0o600)
                 json.dump(auth_config, f)
-            base_cmd += ["--authfile", auth_file]
+            base_cmd += ["--authfile", "/skopeo-auth/auth.json"]
 
         target_uri = "docker://" + args.target_name + ":" + args.target_tags[0]
         cmd = base_cmd + ["--multi-arch", "all", target_uri]


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR changes the usage of the `skopeo` command to use the prebuilt container images, such that no expensive on-the-fly builds will be incurred.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
