### PR TITLE
fix(ci): pin skopeo to immutable digests

### DIFF
--- a/.github/actions/upload-rock/action.yml
+++ b/.github/actions/upload-rock/action.yml
@@ -28,8 +28,8 @@ inputs:
   skopeo-image:
     description: "Skopeo image used to inspect and upload the artifact."
     required: false
-    # Skopeo v1.22.2.
-    default: "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
+    # Skopeo v1.22.2 (immutable tag; mutable digests get GC'd by quay).
+    default: "quay.io/skopeo/stable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810"
 outputs:
   digest:
     description: "The digest of the uploaded image"

--- a/.github/workflows/Image.yaml
+++ b/.github/workflows/Image.yaml
@@ -47,8 +47,8 @@ on:
 env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"
   ROCK_REPO_DIR: rock-repo
-  # Skopeo v1.22.2.
-  SKOPEO_IMAGE: "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
+  # Skopeo v1.22.2 (immutable tag; mutable digests get GC'd by quay).
+  SKOPEO_IMAGE: "quay.io/skopeo/stable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810"
 
 jobs:
   prepare-build:

--- a/.github/workflows/Test-Rock.yaml
+++ b/.github/workflows/Test-Rock.yaml
@@ -64,8 +64,8 @@ env:
   VULNERABILITY_REPORT_SUFFIX: ".vulnerability-report.json"  # TODO: inherit string from caller
   TEST_IMAGE_NAME: "test-img"
   TEST_IMAGE_TAG: "test"
-  # Skopeo v1.22.2.
-  SKOPEO_IMAGE: "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
+  # Skopeo v1.22.2 (immutable tag; mutable digests get GC'd by quay).
+  SKOPEO_IMAGE: "quay.io/skopeo/stable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810"
   UMOCI_VERSION: "v0.4.7"
   UMOCI_BINARY: "umoci.amd64"
   DIVE_IMAGE: "wagoodman/dive:v0.13.1"

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -29,8 +29,8 @@ on:
 
 env:
   VULNERABILITY_REPORT_SUFFIX: '.vulnerability-report.json' # TODO: inherit string from caller
-  # Skopeo v1.22.2.
-  SKOPEO_IMAGE: 'quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615'
+  # Skopeo v1.22.2 (immutable tag; mutable digests get GC'd by quay).
+  SKOPEO_IMAGE: 'quay.io/skopeo/stable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810'
 
 jobs:
   configure-scan:

--- a/src/shared/skopeo.py
+++ b/src/shared/skopeo.py
@@ -1,4 +1,4 @@
 """Shared Skopeo container configuration."""
 
-# Skopeo v1.22.2.
-DEFAULT_SKOPEO_IMAGE = "quay.io/skopeo/stable@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615"
+# Skopeo v1.22.2 (immutable tag; mutable digests get GC'd by quay).
+DEFAULT_SKOPEO_IMAGE = "quay.io/skopeo/stable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810"

--- a/src/tests/tester.py
+++ b/src/tests/tester.py
@@ -8,6 +8,7 @@ import docker
 from pydantic import BaseModel, PrivateAttr
 
 from ..shared.logs import get_logger
+from ..shared.skopeo import DEFAULT_SKOPEO_IMAGE
 
 logger = get_logger()
 
@@ -63,7 +64,7 @@ class Test(BaseModel):
                 f"copy {origin_format}:{mounted_origin} {dest_format}:{mounted_dest}"
             )
             skopeo = self._docker_client.containers.run(
-                "quay.io/skopeo/stable:v1.8",
+                DEFAULT_SKOPEO_IMAGE,
                 working_dir="/rock",
                 volumes={
                     "/": {"bind": "/rootfs"},


### PR DESCRIPTION
Skopeo receives rebuilds, and the mutable digests will get GC'ed in quay.io. We pin them to the immutable digest instead to avoid such situations in the future.

- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR pins the digests of the skopeo image references in the CI to an immutable digest to avoid the mutable digest being GC'ed in `quay.io` after the skopeo images are rebuilt.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Example of a failed CI run: https://github.com/canonical/oci-factory/actions/runs/32208838423/job/95963767718#step:6:24

---

*Picture of a cool rock:*
