### PR TITLE
feat(oathkeeper): onboard oathkeeper rock with image.yaml v2

### DIFF
--- a/oci/oathkeeper/contacts.yaml
+++ b/oci/oathkeeper/contacts.yaml
@@ -1,0 +1,7 @@
+notify:
+  emails:
+    - identity.charmers@lists.launchpad.net
+  mattermost-channels:
+    - ofi4for9obfq8m978h318x56ar
+maintainers:
+  - canonical-iam

--- a/oci/oathkeeper/documentation.yaml
+++ b/oci/oathkeeper/documentation.yaml
@@ -1,0 +1,32 @@
+version: 2
+application: oathkeeper
+description: |
+  Ory Oathkeeper is a cloud native Identity & Access Proxy / API (IAP) and Access Control Decision API
+  that authenticates, authorizes, and mutates incoming HTTP(s) requests.
+website: https://github.com/ory/oathkeeper
+issues: https://github.com/canonical/oathkeeper-rock/issues
+source-code: https://github.com/canonical/oathkeeper-rock
+
+docker:
+  parameters: >-
+    -p 4455:4455
+    -p 4456:4456
+  run_conclusion: |
+    Access the Oathkeeper Proxy API at `http://localhost:4455`, Decision/API at `http://localhost:4456`.
+
+config:
+  '`-v <path>:/oathkeeper.yaml`':
+    type: mount
+    description: >-
+      Oathkeeper config contains all the information needed to configure authentication and authorization rules,
+      see https://github.com/ory/oathkeeper/blob/master/.oathkeeper.yaml as a reference
+  '`-p <port>:4455`':
+    type: port
+    description: Expose Oathkeeper Proxy port 4455 on the host's `<port>`.
+  '`-p <port>:4456`':
+    type: port
+    description: Expose Oathkeeper API port 4456 on the host's `<port>`.
+  '`--args oathkeeper -- serve --config /oathkeeper.yaml`':
+    type: app
+    description: >-
+      Launch Oathkeeper proxy server using configuration mounted via volume.

--- a/oci/oathkeeper/image.yaml
+++ b/oci/oathkeeper/image.yaml
@@ -2,7 +2,7 @@ version: 2
 
 upload:
   - source: "canonical/oathkeeper-rock"
-    commit: 6aca981a8b92b51206f366110901e149c7170566
+    commit: 6aca981a1d64aa327069242014d3628db66d08bd
     directory: .
     release:
       0.40.6-26.04:

--- a/oci/oathkeeper/image.yaml
+++ b/oci/oathkeeper/image.yaml
@@ -1,0 +1,33 @@
+version: 2
+
+upload:
+  - source: "canonical/oathkeeper-rock"
+    commit: 6aca981a8b92b51206f366110901e149c7170566
+    directory: .
+    release:
+      0.40.6-26.04:
+        risks:
+          - stable
+          - candidate
+          - edge
+        end-of-life: "2031-05-01T00:00:00Z"
+    ignored-vulnerabilities:
+      - CVE-2023-45142  # opentelemetry: DoS vulnerability in otelhttp. Dep pinned in upstream Ory X. https://github.com/advisories/GHSA-cg3q-j54f-5p7p
+      - CVE-2024-28180  # jose-go: improper handling of highly compressed data. Dep pinned in upstream Oathkeeper. https://avd.aquasec.com/nvd/cve-2024-28180
+      - CVE-2026-32286  # Denial of Service via malicious PostgreSQL server (jackc/pgproto3/v2). No upstream fix. https://github.com/advisories/GHSA-jqcq-xjh3-6g23
+      - CVE-2026-33186  # google.golang.org/grpc/authz: Authorization bypass due to improper HTTP/2 path validation. https://avd.aquasec.com/nvd/cve-2026-33186
+      - CVE-2026-33494  # Ory Oathkeeper has a path traversal authorization bypass. Upstream unreleased fix. https://avd.aquasec.com/nvd/cve-2026-33494
+      - CVE-2026-33495  # Ory Oathkeeper has an authentication bypass by usage of untrusted header. Upstream unreleased fix. https://avd.aquasec.com/nvd/cve-2026-33495
+      - CVE-2026-33496  # Ory Oathkeeper has an authentication bypass by cache key confusion. Upstream unreleased fix. https://avd.aquasec.com/nvd/cve-2026-33496
+      - CVE-2026-33818  # encoding/asn1: DoS via excessive recursion in Unmarshal (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-33818
+      - CVE-2026-39821  # golang.org/x/net/idna: Privilege escalation via incorrect Punycode label processing (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-39821
+      - CVE-2026-39882  # OpenTelemetry-Go: Memory exhaustion via uncapped HTTP response body reading. Dep pinned in Ory X. https://avd.aquasec.com/nvd/cve-2026-39882
+      - CVE-2026-41889  # github.com/jackc/pgx/v4: SQL injection via specific query conditions. Dep pinned in Ory X. https://avd.aquasec.com/nvd/cve-2026-41889
+      - CVE-2026-46600  # golang.org/x/net/dns/dnsmessage: DoS via invalid DNS record parsing (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-46600
+      - CVE-2026-56853  # net/http: Unencrypted HTTP/2 connections vulnerable to DoS (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-56853
+      - CVE-2026-56858  # html/template: Cross-Site Scripting via pathological input (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-56858
+      - CVE-2026-56859  # encoding/xml: DoS via XML decoding recursion depth issue (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-56859
+      - CVE-2026-56860  # net/url: DoS from quadratic complexity in path resolution (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-56860
+      - CVE-2026-56862  # crypto/tls: DoS via indefinite KeyUpdate messages (Go stdlib). Fixed in Go 1.26.6+. https://avd.aquasec.com/nvd/cve-2026-56862
+      - GHSA-hrxh-6v49-42gf  # gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities. Dep pinned in Ory X. https://github.com/advisories/GHSA-hrxh-6v49-42gf
+      - GO-2026-5932    # golang.org/x/crypto/openpgp: Package is unmaintained/deprecated. https://pkg.go.dev/vuln/GO-2026-5932


### PR DESCRIPTION
This PR onboards the Oathkeeper rock into OCI factory using schema version 2:
- Add `oci/oathkeeper/image.yaml` (schema `version: 2`) referencing `canonical/oathkeeper-rock` commit `6aca981a8b92b51206f366110901e149c7170566`
- Add unresolvable active vulnerabilities to `ignored-vulnerabilities` with comments and links
- Add `oci/oathkeeper/contacts.yaml` and `oci/oathkeeper/documentation.yaml`