### PR TITLE
feat: enable comsume v2 ingored-vuln in cont-testing

### DIFF
--- a/.github/workflows/Continuous-Testing.yaml
+++ b/.github/workflows/Continuous-Testing.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   prepare-test-matrix:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
     name: Prepare released image revisions to be tested
     outputs:
       released-revisions-matrix: ${{ steps.prepare-test-matrix.outputs.released-revisions-matrix }}
@@ -27,6 +27,13 @@ jobs:
 
       - name: Prepare test matrix
         id: prepare-test-matrix
+        env:
+          OS_AUTH_URL: ${{ secrets.SWIFT_OS_AUTH_URL_PS7 }}
+          OS_USERNAME: ${{ secrets.SWIFT_OS_USERNAME_PS7 }}
+          OS_PASSWORD: ${{ secrets.SWIFT_OS_PASSWORD_PS7 }}
+          OS_PROJECT_NAME: ${{ secrets.SWIFT_OS_TENANT_NAME_PS7 }}
+          OS_STORAGE_URL: ${{ secrets.SWIFT_OS_STORAGE_URL_PS7 }}
+          SWIFT_CONTAINER_NAME: ${{ vars.SWIFT_CONTAINER_NAME }}
         run: python3 -m src.tests.get_released_revisions --oci-images-path "$PWD/oci"
 
       - name: Infer date of last scan
@@ -51,7 +58,8 @@ jobs:
     with:
       oci-image-name: "${{ matrix.source-image }}"
       oci-image-path: "oci/${{ matrix.name }}"
-      trivyignore-path: "oci/${{ matrix.name }}/.trivyignore"
+      trivyignore-path: ${{ matrix.ignored-vulnerabilities == '' && format('oci/{0}/.trivyignore', matrix.name) || '' }}
+      ignored-vulnerabilities: ${{ matrix.ignored-vulnerabilities }}
       date-last-scan: ${{ needs.prepare-test-matrix.outputs.last-scan }}
       create-issue: true
     secrets: inherit

--- a/.github/workflows/Vulnerability-Scan.yaml
+++ b/.github/workflows/Vulnerability-Scan.yaml
@@ -16,6 +16,11 @@ on:
         description: 'Path to the .trivygnore file'
         required: false
         type: string
+      ignored-vulnerabilities:
+        description: 'Space-separated list of vulnerability IDs to ignore'
+        required: false
+        type: string
+        default: ''
       date-last-scan:
         description: 'If there are new CVEs after this date, we notify'
         required: false
@@ -81,6 +86,7 @@ jobs:
       oci-archive-name: ${{ needs.configure-scan.outputs.oci-image }}
       test-vulnerabilities: true # just incase we set this to false by default in the future
       trivyignore-path: ${{ inputs.trivyignore-path }}
+      ignored-vulnerabilities: ${{ inputs.ignored-vulnerabilities }}
       test-black-box: false
       test-efficiency: false
       test-malware: false

--- a/src/tests/get_released_revisions.py
+++ b/src/tests/get_released_revisions.py
@@ -15,16 +15,77 @@ import json
 import os
 import sys
 from datetime import datetime, timezone
+from fnmatch import fnmatchcase
 
 import docker
+import swiftclient
 
 from ..shared.logs import get_logger
 from ..shared.skopeo import DEFAULT_SKOPEO_IMAGE
 
 SKOPEO_IMAGE = os.getenv("SKOPEO_IMAGE", DEFAULT_SKOPEO_IMAGE)
 REGISTRY = "ghcr.io/canonical/oci-factory"
+SWIFT_CONTAINER = os.getenv("SWIFT_CONTAINER_NAME", "oci-factory")
 
 logger = get_logger(stream=sys.stdout, level="INFO")
+
+
+def get_swift_connection() -> swiftclient.client.Connection:
+    """Open a connection to the Swift object storage holding the build metadata."""
+    return swiftclient.client.Connection(
+        authurl=os.environ["OS_AUTH_URL"],
+        user=os.environ["OS_USERNAME"],
+        key=os.environ["OS_PASSWORD"],
+        os_options={
+            "user_domain_name": os.getenv("OS_USER_DOMAIN_NAME", "Default"),
+            "project_domain_name": os.getenv("OS_PROJECT_DOMAIN_NAME", "Default"),
+            "project_name": os.environ["OS_PROJECT_NAME"],
+            "object_storage_url": os.environ["OS_STORAGE_URL"],
+        },
+        auth_version=os.getenv("OS_IDENTITY_API_VERSION", "3"),
+    )
+
+
+def get_ignored_vulnerabilities(
+    swift_conn: swiftclient.client.Connection,
+    swift_objs: list,
+    img_name: str,
+    revision: str,
+) -> str:
+    """Read the space-separated 'ignored-vulnerabilities' string for a given
+    image revision from its build_metadata.json in Swift.
+
+    Revisions are globally unique per image, so we match the build metadata
+    object regardless of the track it was built under, i.e.:
+        <img-name>/<track>/<revision>/build_metadata.json
+
+    :param swift_conn: an open connection to Swift
+    :param swift_objs: the listing of objects in the Swift container
+    :param img_name: name of the container image
+    :param revision: revision number of the image to look up
+    """
+    matches = [
+        obj
+        for obj in swift_objs
+        if fnmatchcase(obj["name"], f"{img_name}/*/{revision}/build_metadata.json")
+    ]
+    if not matches:
+        logger.warning(
+            f"No build metadata in Swift for {img_name} revision {revision}; "
+            "assuming no ignored vulnerabilities"
+        )
+        return ""
+
+    try:
+        _, build_metadata_raw = swift_conn.get_object(
+            SWIFT_CONTAINER, matches[0]["name"]
+        )
+    except swiftclient.exceptions.ClientException:
+        logger.exception(f"Unable to get {matches[0]['name']} from Swift")
+        return ""
+
+    build_metadata = json.loads(build_metadata_raw.decode())
+    return build_metadata.get("ignored-vulnerabilities", "") or ""
 
 
 def get_image_name_in_registry(img_name: str, revision: str) -> str:
@@ -76,6 +137,11 @@ if __name__ == "__main__":
 
     logger.info(f"Looping through OCI images in {args.oci_images_path}")
 
+    # We need the build metadata (stored in Swift) to recover the v2
+    # 'ignored-vulnerabilities' for each released revision.
+    swift_conn = get_swift_connection()
+    _, swift_objs = swift_conn.get_container(SWIFT_CONTAINER, full_listing=True)
+
     released_revisions = {}
     ghcr_images = []
     for img in os.listdir(args.oci_images_path):
@@ -116,6 +182,9 @@ if __name__ == "__main__":
                         "name": img,
                         "source-image": get_image_name_in_registry(
                             img, targets["target"]
+                        ),
+                        "ignored-vulnerabilities": get_ignored_vulnerabilities(
+                            swift_conn, swift_objs, img, targets["target"]
                         ),
                     }
                 )

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -1,3 +1,5 @@
 docker
 pydantic==2.12.3
+python-keystoneclient==5.2.0
+python-swiftclient==4.4.0
 requests==2.31


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

This PR allows the continuous testing workflow to consume the cached ignored vulnerabilities in the build metadata from the v2 image trigger.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

---

*Picture of a cool rock:*
