### PR TITLE
docs(ai): add reviewer guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,6 @@ is missing (the `rock/*` labels are applied by maintainers, not auto-labeled):
 | --- | --- | --- |
 | `rock/update` (`oci/<name>/image.yaml`) | Existing image-trigger update | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-source-recipe-rockcraftyaml-review) |
 | `rock/new` (new `oci/<name>/`, new track/base) | New rock / new track / new base | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-source-recipe-rockcraftyaml-review), [5](#5-documentation-documentationyaml-checklist) |
-| `rock/chore` (`oci/<name>/` digest/source/version bump) | Misc rock change, incl. bot/dependency updates | [2](#2-security--vulnerability-gating-hard-gate), [4](#4-source-recipe-rockcraftyaml-review), [7](#7-evidence--process-hygiene) |
 | `rock/docs` (`oci/<name>/documentation.yaml`) | Documentation change | [5](#5-documentation-documentationyaml-checklist) |
 | `onboarding` (issue) | Image onboarding request (intake) | [3](#3-release-policy-risk-tracks-eol-versioning), [5](#5-documentation-documentationyaml-checklist) |
 | no `rock/*` label (`.github/`, `src/`, `tools/`) | Factory source / CI workflow | [6](#6-ci--github-actions-review), [7](#7-evidence--process-hygiene) |
@@ -189,14 +188,16 @@ verdicts as described above.
   comment**, not to silence findings blindly.
 
 - The `.trivyignore` file is **deprecated**. Do not accept new `.trivyignore`
-  files. When ignore entries are added or modified, require the applicable
-  rules to move to `ignored-vulnerabilities` in the image trigger. Legacy files
-  may remain temporarily because released revisions can still depend on them.
+  files. When migrating an affected build to `ignored-vulnerabilities`, require
+  every still-applicable rule to move, not only the changed rules. Once
+  `ignored-vulnerabilities` is present, that build no longer uses
+  `.trivyignore`. The legacy file may remain temporarily because previously
+  released revisions can still depend on it.
   Example wording:
 
-  > Let's move these changed entries to `ignored-vulnerabilities`; new use of
-  > `.trivyignore` in OCI Factory is deprecated. The legacy file may remain for
-  > released revisions that still depend on it.
+  > Let's move every still-applicable rule to `ignored-vulnerabilities`; once
+  > present, that build no longer uses `.trivyignore`. The legacy file may
+  > remain for previously released revisions that still depend on it.
 
 - `ignored-vulnerabilities` requires a `version: 2` trigger. A `version: 1`
   trigger may stay as-is only until it needs this field; then it MUST switch to
@@ -244,7 +245,7 @@ verdicts as described above.
 
 ### 4. Source recipe (`rockcraft.yaml`) review
 
-For image-trigger changes (`rock/update`, `rock/new`, `rock/chore`), review the
+For image-trigger changes (`rock/update`, `rock/new`), review the
 build recipe behind the release, not just the trigger. For **each** `upload[]`
 item, fetch the `rockcraft.yaml` at that item's pinned `source` repository and
 `commit` (under the item's `directory` subpath when set) — via `gh`/`git` or the
@@ -281,9 +282,10 @@ when the file cannot be retrieved.
   directly from an external repository — e.g. a `source:` pointing at
   GitHub/Launchpad with `source-type: git`, or a plugin that compiles upstream
   code — treat the rock as upstream-sourced **even when the repository lives
-  under the `canonical` org**. When it is, apply the `end-of-life` cap from
-  [§3](#3-release-policy-risk-tracks-eol-versioning); do not restate the rule
-  here.
+  under the `canonical` org**. The sole exemption is a part sourced from
+  `https://github.com/canonical/rocks-security-manifest`. Otherwise, apply the
+  `end-of-life` cap from [§3](#3-release-policy-risk-tracks-eol-versioning); do
+  not restate the rule here.
 
 - **Recipe regression (blocker).** When the source is bumped (a new `commit` or
   `directory`) and the new recipe drops a `parts:` entry or a `services:` entry
@@ -374,8 +376,7 @@ uses three families:
 - **`rock/new`** — a new rock, or a new track/base for an existing rock.
 - **`rock/update`** — an existing rock's image trigger is modified (release or
   track change).
-- **`rock/chore`** — misc rock change (digest/source/version bump, incl.
-  bot/dependency updates).
+- **`rock/chore`** — maintainer contact changes in `contacts.yaml`.
 - **`rock/docs`** — a rock's `documentation.yaml` change.
 - **`onboarding`** — image onboarding request; auto-applied by the onboarding
   issue template.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,11 +153,12 @@ verdicts as described above.
   > `https://github.com/canonical/oci-factory/actions/runs/<run-id>/attempts/<n>#summary-<summary-id>`
 
 - Findings are addressed in the `ignored-vulnerabilities:` field of the image
-  trigger. Every new or modified entry must have an explanatory comment that:
-  identifies the affected package/source and ecosystem, and states the
-  maintainer's actual risk disposition with an image-specific reason the
-  finding may be ignored. Existing untouched entries do not need to be updated
-  solely to meet this comment format.
+  trigger. Every new or modified vulnerability entry must identify the affected
+  package/source and ecosystem; entries for other Trivy finding types must
+  instead identify the affected file/component and rule category. Every entry
+  must state the maintainer's actual risk disposition with an image-specific
+  reason the finding may be ignored. Existing untouched entries do not need to
+  be updated solely to meet this comment format.
 
   A package name, description, CVSS score, Ubuntu priority, or status such as
   `Needs evaluation` is useful supporting context, but is not by itself a risk
@@ -190,15 +191,17 @@ verdicts as described above.
 
 - The `.trivyignore` file is **deprecated**. Do not accept new `.trivyignore`
   files. When migrating an affected build to `ignored-vulnerabilities`, require
-  every still-applicable rule to move, not only the changed rules. Once
-  `ignored-vulnerabilities` is present, that build no longer uses
-  `.trivyignore`. The legacy file may remain temporarily because previously
-  released revisions can still depend on it.
+  every still-applicable rule to move, not only the changed rules. A non-empty
+  `ignored-vulnerabilities` list takes precedence over `.trivyignore`; an empty
+  or omitted list still falls back to the legacy file. The legacy file may
+  remain temporarily because previously released revisions can still depend on
+  it.
   Example wording:
 
-  > Let's move every still-applicable rule to `ignored-vulnerabilities`; once
-  > present, that build no longer uses `.trivyignore`. The legacy file may
-  > remain for previously released revisions that still depend on it.
+  > Let's move every still-applicable rule to `ignored-vulnerabilities`; a
+  > non-empty list takes precedence over `.trivyignore`, while an empty or
+  > omitted list still falls back to the legacy file. The file may remain for
+  > previously released revisions that still depend on it.
 
 - `ignored-vulnerabilities` requires a `version: 2` trigger. A `version: 1`
   trigger may stay as-is only until it needs this field; then it MUST switch to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,14 +71,17 @@ this guide.
   `git diff --cached` for staged-only), lists the touched files, and **triages
   by file path** — the `rock/*` labels don't exist yet, so use the fallback path
   column in [Triage](#1-triage-the-pr-first).
-- It then applies the matching checklists ([§2](#2-security--vulnerability-gating-hard-gate)–[§6](#6-evidence--process-hygiene)).
+- It then applies the matching checklists ([§2](#2-security--vulnerability-gating-hard-gate)–[§7](#7-evidence--process-hygiene)).
   The vulnerability scan itself is **CI-only** and does not affect a local
   dry-run verdict. Locally, the harness checks the static requirements: trigger
   `version: 2` where `ignored-vulnerabilities` is used, sufficient comments on
   new or modified ignored entries, and `.trivyignore` deprecation (see
-  [§2](#2-security--vulnerability-gating-hard-gate)). A local `Approve` means
-  only that the locally-checkable gates passed; it is not an approval of a real
-  PR and does not imply that its vulnerability scan is clean.
+  [§2](#2-security--vulnerability-gating-hard-gate)). It also fetches each
+  `upload[]` item's `rockcraft.yaml` (network permitting) to run the
+  [§4](#4-source-recipe-rockcraftyaml-review) recipe checks, and marks them *not
+  assessed* when the recipe cannot be retrieved. A local `Approve` means only
+  that the locally-checkable gates passed; it is not an approval of a real PR and
+  does not imply that its vulnerability scan is clean.
 
 **Output format (mimics a GitHub PR review — keep it concise)**
 
@@ -90,9 +93,11 @@ this guide.
   concrete fixes.
 - **Gate summary** — a compact pass / ⚠ / blocker checklist for the
   locally-checkable gates: one-image scope, edge-first, EOL cap, track naming,
-  docs checklist, `ignored-vulnerabilities` justification, and `.trivyignore`
-  deprecation. Mark the vulnerability scan itself as *not assessed locally;
-  verify in CI*.
+  docs checklist, `ignored-vulnerabilities` justification, `.trivyignore`
+  deprecation, deb security manifest, and recipe regression. Mark the
+  deb-manifest and recipe-regression gates *not assessed* when the recipe cannot
+  be fetched, and the vulnerability scan itself as *not assessed locally; verify
+  in CI*.
 
 **Example**
 
@@ -114,24 +119,24 @@ this guide.
 > SemVer patch component; use `1.2-24.04`. (§3)
 >
 > **Gates:** one-image ✅ · edge-first ❌ · EOL cap ✅ · track naming ❌ · docs
-> n/a · CVE justification ❌ · `.trivyignore` ✅ · vuln scan → not assessed
-> locally; verify in CI
+> n/a · CVE justification ❌ · `.trivyignore` ✅ · deb-manifest ✅ ·
+> recipe-regression ✅ · vuln scan → not assessed locally; verify in CI
 
 ### 1. Triage the PR first
 
 Classify the PR before reviewing, then jump to the matching sections. Triage
 primarily on the **type label** (`rock/*`, `onboarding`) — see
-[section 7](#7-pr-labels) — falling back to the touched file path when the label
+[section 8](#8-pr-labels) — falling back to the touched file path when the label
 is missing (the `rock/*` labels are applied by maintainers, not auto-labeled):
 
 | Label (fallback path) | PR / issue type | Primary sections |
 | --- | --- | --- |
-| `rock/update` (`oci/<name>/image.yaml`) | Existing image-trigger update | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning) |
-| `rock/new` (new `oci/<name>/`, new track/base) | New rock / new track / new base | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-documentation-documentationyaml-checklist) |
-| `rock/chore` (`oci/<name>/` digest/source/version bump) | Misc rock change, incl. bot/dependency updates | [2](#2-security--vulnerability-gating-hard-gate), [6](#6-evidence--process-hygiene) |
-| `rock/docs` (`oci/<name>/documentation.yaml`) | Documentation change | [4](#4-documentation-documentationyaml-checklist) |
-| `onboarding` (issue) | Image onboarding request (intake) | [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-documentation-documentationyaml-checklist) |
-| no `rock/*` label (`.github/`, `src/`, `tools/`) | Factory source / CI workflow | [5](#5-ci--github-actions-review), [6](#6-evidence--process-hygiene) |
+| `rock/update` (`oci/<name>/image.yaml`) | Existing image-trigger update | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-source-recipe-rockcraftyaml-review) |
+| `rock/new` (new `oci/<name>/`, new track/base) | New rock / new track / new base | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-source-recipe-rockcraftyaml-review), [5](#5-documentation-documentationyaml-checklist) |
+| `rock/chore` (`oci/<name>/` digest/source/version bump) | Misc rock change, incl. bot/dependency updates | [2](#2-security--vulnerability-gating-hard-gate), [4](#4-source-recipe-rockcraftyaml-review), [7](#7-evidence--process-hygiene) |
+| `rock/docs` (`oci/<name>/documentation.yaml`) | Documentation change | [5](#5-documentation-documentationyaml-checklist) |
+| `onboarding` (issue) | Image onboarding request (intake) | [3](#3-release-policy-risk-tracks-eol-versioning), [5](#5-documentation-documentationyaml-checklist) |
+| no `rock/*` label (`.github/`, `src/`, `tools/`) | Factory source / CI workflow | [6](#6-ci--github-actions-review), [7](#7-evidence--process-hygiene) |
 
 ### 2. Security & vulnerability gating (hard gate)
 
@@ -178,7 +183,7 @@ verdicts as described above.
   disposition.
 
 - When requesting changes for scan findings, apply the `pending cve` label (see
-  [section 7](#7-pr-labels)); remove it once every finding is fixed or justified.
+  [section 8](#8-pr-labels)); remove it once every finding is fixed or justified.
 
 - Ask maintainers to add ignored entries **with proper justifications in the
   comment**, not to silence findings blindly.
@@ -237,7 +242,62 @@ verdicts as described above.
   > update either this one or the other so they won't overwrite each other.
   > Marking this PR and #NNNN as invalid for now.
 
-### 4. Documentation (`documentation.yaml`) checklist
+### 4. Source recipe (`rockcraft.yaml`) review
+
+For image-trigger changes (`rock/update`, `rock/new`, `rock/chore`), review the
+build recipe behind the release, not just the trigger. For **each** `upload[]`
+item, fetch the `rockcraft.yaml` at that item's pinned `source` repository and
+`commit` (under the item's `directory` subpath when set) — via `gh`/`git` or the
+repository web UI — and apply the caveats below. This fetch is external: in a
+local dry-run it may be unavailable, so state that and skip the recipe checks
+when the file cannot be retrieved.
+
+- **deb security manifest (MUST).** If any part declares `stage-packages` — i.e.
+  the rock layers additional `.deb` packages on top of the Ubuntu base — the
+  recipe MUST include a security-manifest part whose `source` is
+  `https://github.com/canonical/rocks-security-manifest`, wired exactly as that
+  repository's README documents. The part name may differ, but the source and
+  usage must match. This enforces the maintainer obligation in
+  [`IMAGE_MAINTAINER_AGREEMENT.md`](/IMAGE_MAINTAINER_AGREEMENT.md#enable-security-monitoring).
+  If a `stage-packages` rock is missing this part, or wires it differently,
+  request changes:
+
+  ```yaml
+  parts:
+    deb-security-manifest:
+      plugin: make
+      source: https://github.com/canonical/rocks-security-manifest
+      source-type: git
+      source-branch: main
+      override-prime: gen_manifest
+  ```
+
+  > This rock stages `.deb` packages but the recipe does not include the
+  > standardized security manifest. Please add the `deb-security-manifest` part
+  > from `https://github.com/canonical/rocks-security-manifest`, wired per its
+  > README.
+
+- **External-source detection → EOL cap.** If any part is pulled and built
+  directly from an external repository — e.g. a `source:` pointing at
+  GitHub/Launchpad with `source-type: git`, or a plugin that compiles upstream
+  code — treat the rock as upstream-sourced **even when the repository lives
+  under the `canonical` org**. When it is, apply the `end-of-life` cap from
+  [§3](#3-release-policy-risk-tracks-eol-versioning); do not restate the rule
+  here.
+
+- **Recipe regression (blocker).** When the source is bumped (a new `commit` or
+  `directory`) and the new recipe drops a `parts:` entry or a `services:` entry
+  that the previously referenced recipe defined, treat it as a regression and
+  request changes as a **[blocker]**. Hold until the removed part/service is
+  restored, or the author confirms the removal is intentional and not a
+  regression (see [§9](#9-approve-vs-request-changes-criteria), "regressions are
+  ruled out"). Example:
+
+  > This source bump removes the `<name>` <part|service> that the previous
+  > revision shipped. Is this intentional? If so, please confirm it is not a
+  > regression; otherwise restore it. Marking as a blocker until then.
+
+### 5. Documentation (`documentation.yaml`) checklist
 
 - **Language:** US English spelling throughout; correct product capitalization
   (e.g., do not write an uncapitalized product name); no informal phrasing.
@@ -262,7 +322,7 @@ verdicts as described above.
 - Note: the GitHub web UI can mangle multi-line suggestions. If a suggestion is
   not applied correctly, ask the author to commit it manually.
 
-### 5. CI / GitHub Actions review
+### 6. CI / GitHub Actions review
 
 - **Least privilege for `GITHUB_TOKEN`.** OCI Factory inherits the read-only
   default configured by Canonical's organizational workflow-permission
@@ -286,7 +346,7 @@ verdicts as described above.
 - **Respect established patterns.** Avoid unnecessary changes to established,
   working workflows; remove genuinely dead code (e.g., retired build paths).
 
-### 6. Evidence & process hygiene
+### 7. Evidence & process hygiene
 
 - **Prove fixes.** Back a "fixed" or "works" claim with a link to a successful
   CI/test run or to upstream source. Example:
@@ -300,11 +360,11 @@ verdicts as described above.
 - **Close housekeeping PRs** that are stale (no activity for more than a month),
   outdated, or superseded by another PR — state the reason on close. Apply the
   `decaying` label after 2 weeks of no activity as an early warning (see
-  [section 7](#7-pr-labels)) before closing.
+  [section 8](#8-pr-labels)) before closing.
 - **Request a second reviewer** when the change is outside your area or warrants
   another set of eyes.
 
-### 7. PR labels
+### 8. PR labels
 
 Apply labels to make review state visible and to drive housekeeping. The repo
 uses three families:
@@ -340,7 +400,7 @@ uses three families:
 - **`decaying`** — apply to any PR with no update for **more than 2 weeks**. It
   is the early-warning step before closing: a `decaying` PR that stays inactive
   for more than a month should be closed as stale (see
-  [section 6](#6-evidence--process-hygiene)).
+  [section 7](#7-evidence--process-hygiene)).
 - **`invalid`** — apply to PRs that cannot proceed as-is, e.g. conflicting
   concurrent PRs on the same track (see
   [section 3](#3-release-policy-risk-tracks-eol-versioning)).
@@ -348,7 +408,7 @@ uses three families:
 **Priority labels** — `priority/critical`, `priority/high`, `priority/medium`,
 `priority/low` communicate urgency for triage and scheduling; set at most one.
 
-### 8. Approve vs. request-changes criteria
+### 9. Approve vs. request-changes criteria
 
 The following criteria govern actual GitHub PR reviews. For a local dry-run,
 exclude the CI-only vulnerability-scan result from the verdict while retaining
@@ -360,6 +420,11 @@ Request changes when any of the following holds:
 - The PR changes files below more than one distinct `oci/<name>/` directory.
 - A new rock/track/base first release is not restricted to `edge`.
 - The `end-of-life` exceeds the cap for an unsupported upstream-sourced rock.
+- A rock stages `.deb` packages but its recipe omits the `rocks-security-manifest`
+  part, or wires it differently (see [§4](#4-source-recipe-rockcraftyaml-review)).
+- A source bump drops a `parts:` or `services:` entry the previous recipe defined,
+  without the author confirming it is intentional (see
+  [§4](#4-source-recipe-rockcraftyaml-review)).
 - A documented default is unverified or wrong, or the documented run does not work.
 - A workflow grants more token/permission scope than necessary, or uses a PAT
   where `GITHUB_TOKEN` suffices.
@@ -371,7 +436,7 @@ release policy is satisfied, and regressions are ruled out. Keep approvals
 concise and, where relevant, note that no regressions/undermines were
 introduced.
 
-### 9. Related project conventions
+### 10. Related project conventions
 
 See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for authoring rules the review should
 enforce:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ this guide.
 - The harness scopes the diff (`git diff --merge-base origin/main`, or
   `git diff --cached` for staged-only), lists the touched files, and **triages
   by file path** — the `rock/*` labels don't exist yet, so use the fallback path
-  column in [Triage](#1-triage-the-pr-first).
+  column in [Triage](#1-triage-the-pr-first), as labels are only applied to
+  actual PRs.
 - It then applies the matching checklists ([§2](#2-security--vulnerability-gating-hard-gate)–[§7](#7-evidence--process-hygiene)).
   The vulnerability scan itself is **CI-only** and does not affect a local
   dry-run verdict. Locally, the harness checks the static requirements: trigger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ review standard.
   spec; squash commits by functional value.
 - In-progress PRs must be marked **Draft**; non-trivial changes should open an
   issue first.
+- A PR that changes files below `oci/` must affect only one `oci/<name>/`
+  directory. It may update multiple versions, tracks, or maintainer files for
+  that image, but changes for multiple images must be split into separate PRs.
 - See [`CONTRIBUTING.md`](/CONTRIBUTING.md) and [`README.md`](/README.md) for the
   full authoring and project reference, and
   [`IMAGE_MAINTAINER_AGREEMENT.md`](/IMAGE_MAINTAINER_AGREEMENT.md) for
@@ -69,10 +72,13 @@ this guide.
   by file path** — the `rock/*` labels don't exist yet, so use the fallback path
   column in [Triage](#1-triage-the-pr-first).
 - It then applies the matching checklists ([§2](#2-security--vulnerability-gating-hard-gate)–[§6](#6-evidence--process-hygiene)).
-  The blocking vulnerability scan is **CI-only**, so locally the harness just
-  confirms `version: 2` and that every `ignored-vulnerabilities` entry carries
-  a justification comment (see
-  [§2](#2-security--vulnerability-gating-hard-gate)).
+  The vulnerability scan itself is **CI-only** and does not affect a local
+  dry-run verdict. Locally, the harness checks the static requirements: trigger
+  `version: 2` where `ignored-vulnerabilities` is used, sufficient comments on
+  new or modified ignored entries, and `.trivyignore` deprecation (see
+  [§2](#2-security--vulnerability-gating-hard-gate)). A local `Approve` means
+  only that the locally-checkable gates passed; it is not an approval of a real
+  PR and does not imply that its vulnerability scan is clean.
 
 **Output format (mimics a GitHub PR review — keep it concise)**
 
@@ -83,9 +89,10 @@ this guide.
   pointer to the governing section. Use GitHub ```` ```suggestion ```` blocks for
   concrete fixes.
 - **Gate summary** — a compact pass / ⚠ / blocker checklist for the
-  locally-checkable gates: edge-first, EOL cap, semver, docs checklist,
-  `ignored-vulnerabilities` justification, `.trivyignore` deprecation. Mark the
-  vulnerability scan itself as *verify in CI*.
+  locally-checkable gates: one-image scope, edge-first, EOL cap, track naming,
+  docs checklist, `ignored-vulnerabilities` justification, and `.trivyignore`
+  deprecation. Mark the vulnerability scan itself as *not assessed locally;
+  verify in CI*.
 
 **Example**
 
@@ -99,15 +106,16 @@ this guide.
 >           - edge
 > ````
 >
-> `oci/foo/image.yaml:20` — [blocker] `ignored-vulnerabilities` entry has no
-> justification comment; add at least the affected package/source (fuller
-> description | CVSS | Ubuntu priority | Status preferred). (§2)
+> `oci/foo/image.yaml:20` — [blocker] This new `ignored-vulnerabilities` entry
+> lacks a sufficient justification; identify the affected package/source and
+> state the image-specific reason the risk can be accepted. (§2)
 >
-> `oci/foo/image.yaml:5` — [nit] Drop the patch from `version` since the rock
-> tracks a moving `stage-snap` channel. (§3)
+> `oci/foo/image.yaml:5` — [blocker] The new track `1.2.3-24.04` includes a
+> SemVer patch component; use `1.2-24.04`. (§3)
 >
-> **Gates:** edge-first ❌ · EOL cap ✅ · semver ⚠ · docs n/a · CVE justification
-> ❌ · `.trivyignore` ✅ · vuln scan → verify in CI
+> **Gates:** one-image ✅ · edge-first ❌ · EOL cap ✅ · track naming ❌ · docs
+> n/a · CVE justification ❌ · `.trivyignore` ✅ · vuln scan → not assessed
+> locally; verify in CI
 
 ### 1. Triage the PR first
 
@@ -127,8 +135,11 @@ is missing (the `rock/*` labels are applied by maintainers, not auto-labeled):
 
 ### 2. Security & vulnerability gating (hard gate)
 
-The vulnerability scan is a **blocking** gate. Any finding must be resolved
-before approval.
+For an actual GitHub PR review of an image change, the vulnerability scan is a
+**blocking** gate. Inspect the latest relevant CI run and do not approve until
+it succeeds. If the scan is pending or unavailable, withhold approval and
+re-review when it completes. This CI-only result is excluded from local dry-run
+verdicts as described above.
 
 - If the scan reports findings, request changes and link the exact run. Use the
   canonical phrasing:
@@ -137,18 +148,34 @@ before approval.
   > `https://github.com/canonical/oci-factory/actions/runs/<run-id>/attempts/<n>#summary-<summary-id>`
 
 - Findings are addressed in the `ignored-vulnerabilities:` field of the image
-  trigger, **each entry justified** with an explanatory comment. At minimum,
-  the comment must identify the affected package/source (e.g. `# werkzeug
-  (pip)`); entries should prefer the fuller justification format:
+  trigger. Every new or modified entry must have an explanatory comment that:
+  identifies the affected package/source and ecosystem, and states the
+  maintainer's actual risk disposition with an image-specific reason the
+  finding may be ignored. Existing untouched entries do not need to be updated
+  solely to meet this comment format.
+
+  A package name, description, CVSS score, Ubuntu priority, or status such as
+  `Needs evaluation` is useful supporting context, but is not by itself a risk
+  disposition or justification. For deb packages, link the Ubuntu Security
+  tracker at `https://ubuntu.com/security/<CVE-ID>` instead of creating an
+  internal ROCKS ticket. CVEs in language packages are not currently tracked
+  internally; state the upstream fix status and link an upstream advisory when
+  one is available.
 
   ```yaml
-  ignored-vulnerabilities:
-    - CVE-2026-42151  # prometheus: OAuth client secret exposed via /-/config endpoint | CVSS: 7.5 (High) | Ubuntu priority: Medium | Status (26.04 resolute): Needs evaluation
-    - CVE-2026-33186  # grpc: authorization bypass via malformed HTTP/2 :path pseudo-header | CVSS: 9.1 (Critical) | Ubuntu priority: High | Status (26.04 resolute): Needs evaluation
+  upload:
+    - source: canonical/foo-rock
+      commit: "<full-commit-sha>"
+      directory: .
+      ignored-vulnerabilities:
+        - CVE-XXXX-XXXXX  # libfoo (deb): temporarily accepted pending an Ubuntu fix | Ubuntu tracker: https://ubuntu.com/security/CVE-XXXX-XXXXX
+        - CVE-YYYY-YYYYY  # google.golang.org/grpc (Go): temporarily accepted; no fixed upstream release is available
   ```
 
-  The full comment should carry: short description, `CVSS: <score> (<severity>)`,
-  `Ubuntu priority: <priority>`, and `Status (<series>): <triage>`.
+  Prefer also including a short description, `CVSS: <score> (<severity>)`,
+  `Ubuntu priority: <priority>`, `Status (<series>): <triage>`, and relevant
+  upstream evidence. This metadata supplements, but does not replace, the risk
+  disposition.
 
 - When requesting changes for scan findings, apply the `pending cve` label (see
   [section 7](#7-pr-labels)); remove it once every finding is fixed or justified.
@@ -156,11 +183,15 @@ before approval.
 - Ask maintainers to add ignored entries **with proper justifications in the
   comment**, not to silence findings blindly.
 
-- The `.trivyignore` file is **deprecated**. Require migration to
-  `ignored-vulnerabilities` in the image trigger. Example wording:
+- The `.trivyignore` file is **deprecated**. Do not accept new `.trivyignore`
+  files. When ignore entries are added or modified, require the applicable
+  rules to move to `ignored-vulnerabilities` in the image trigger. Legacy files
+  may remain temporarily because released revisions can still depend on them.
+  Example wording:
 
-  > Let's move this file away since using the `.trivyignore` file in OCI Factory
-  > is now deprecated.
+  > Let's move these changed entries to `ignored-vulnerabilities`; new use of
+  > `.trivyignore` in OCI Factory is deprecated. The legacy file may remain for
+  > released revisions that still depend on it.
 
 - `ignored-vulnerabilities` requires a `version: 2` trigger. A `version: 1`
   trigger may stay as-is only until it needs this field; then it MUST switch to
@@ -188,11 +219,15 @@ before approval.
   promotion is **not automated**, require an issue/Jira ticket to track any
   intended future promotion.
 
-- **Versioning scrutiny.**
-  - Reject non-`major-minor-patch` semver in the `version` field.
-  - If the version is not a source of truth (e.g., the rock pulls a moving
-    channel via `stage-snap`), drop the minor/patch from both the `version`
-    field and the track name.
+- **Canonical track naming (MUST).** New or modified image track keys use
+  `<version>-<base>` (for example, `1.27-26.04`). Here, `<version>` is the
+  application's track version, not the image trigger's top-level schema
+  `version:` field. When the application follows SemVer, the track MUST omit
+  the patch component: upstream `1.27.3` belongs to `1.27-26.04`, not
+  `1.27.3-26.04`. Non-SemVer `<version>` values are exempt from the SemVer shape
+  but must remain aligned with the application's versioning scheme. Do not
+  require cleanup of unchanged legacy patch-level tracks in an otherwise
+  unrelated update.
 
 - **Track-conflict detection.** Flag concurrent PRs that write the same track;
   they cause the track to oscillate/overwrite between values. Mark the
@@ -229,9 +264,13 @@ before approval.
 
 ### 5. CI / GitHub Actions review
 
-- **Least privilege for `GITHUB_TOKEN`.** Grant only the "just enough" write
-  permissions a job needs; the default is read-only, so **do not** add explicit
-  `permissions: ...: read` entries.
+- **Least privilege for `GITHUB_TOKEN`.** OCI Factory inherits the read-only
+  default configured by Canonical's organizational workflow-permission
+  controls. When no applicable `permissions` block is declared, do not add one
+  solely to restate that inherited default. Once a `permissions` block is
+  declared at workflow or job level, it is exhaustive: every omitted scope is
+  set to `none`. List every read or write scope the job actually needs and no
+  others; `write` already includes `read` for the same scope.
 - **Prefer `GITHUB_TOKEN` over broad PATs.** Do not use `ROCKSBOT_TOKEN` where
   `GITHUB_TOKEN` suffices — the bot token carries far wider scope.
 - **PAT-tag anti-pattern.** Pushing tags/commits with a PAT/bot identity
@@ -311,9 +350,14 @@ uses three families:
 
 ### 8. Approve vs. request-changes criteria
 
+The following criteria govern actual GitHub PR reviews. For a local dry-run,
+exclude the CI-only vulnerability-scan result from the verdict while retaining
+all locally-checkable security requirements.
+
 Request changes when any of the following holds:
 
 - The vulnerability scan reports unresolved findings.
+- The PR changes files below more than one distinct `oci/<name>/` directory.
 - A new rock/track/base first release is not restricted to `edge`.
 - The `end-of-life` exceeds the cap for an unsupported upstream-sourced rock.
 - A documented default is unverified or wrong, or the documented run does not work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,341 @@
+# OCI Factory — Agent Guide
+
+The OCI Factory is the centralized gateway for Ubuntu OCI images published to
+Docker Hub, ECR, and other registries under the ROCKS Team-maintained `ubuntu`
+namespace. This file is the entry point for agents (and humans) working in the
+repository: it explains the layout and conventions, then encodes the maintainer
+review standard.
+
+## Repository overview
+
+- `oci/<name>/` — per-image maintainer files (the trigger surface most PRs
+  touch):
+  - `image.yaml` — image trigger: build/release definition, tracks, risks,
+    `end-of-life`, and (v2) `ignored-vulnerabilities`.
+  - `documentation.yaml` — documentation trigger consumed to render the image's
+    published docs.
+  - `contacts.yaml` — maintainer contacts.
+- `src/` — the factory source (build/test/release automation) invoked by CI.
+- `.github/workflows/` — reusable and top-level GitHub Actions workflows
+  (e.g. `Build-Rock.yaml`, `Test-Rock.yaml`).
+- `.github/ISSUE_TEMPLATE/` — issue intake, including the `onboarding` request
+  form.
+- `tools/` — helper scripts and utilities.
+- `tests/` — factory test suites.
+
+## Working conventions
+
+- Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+  spec; squash commits by functional value.
+- In-progress PRs must be marked **Draft**; non-trivial changes should open an
+  issue first.
+- See [`CONTRIBUTING.md`](/CONTRIBUTING.md) and [`README.md`](/README.md) for the
+  full authoring and project reference, and
+  [`IMAGE_MAINTAINER_AGREEMENT.md`](/IMAGE_MAINTAINER_AGREEMENT.md) for
+  maintainer obligations.
+
+## Reviewing Pull Requests in OCI Factory
+
+This section encodes the maintainer review standard for the OCI Factory
+repository. It is derived from established review practice and is meant to guide
+both human reviewers and AI review agents to a consistent bar.
+
+### How to use this guide
+
+- Apply the checklist that matches the PR type (see [Triage](#1-triage-the-pr-first)).
+- Ground every request-changes on **evidence**: link the exact CI run, the
+  upstream source, or the relevant documentation. Never approve on intent alone.
+- Distinguish **blockers** from **non-blockers** explicitly. Prefix optional
+  feedback with `Not a blocker, but ...`.
+- Keep comments concise: state the finding and only the reasoning needed to act
+  on it. Link evidence instead of restating it, and don't repeat unchanged
+  context or the diff back to the author.
+- Prefer GitHub *suggestions* for concrete wording/format fixes so authors can
+  apply them in one click.
+
+### Running a local review before you push
+
+Authors can dry-run this exact review locally, before pushing or opening the PR,
+to catch blockers ahead of CI and reviewers. Run it on demand — no git hook
+required — by asking an AI agent harness to review your working changes against
+this guide.
+
+**How to run it**
+
+- Stage or commit your changes, then prompt the harness, e.g.
+  *"Review my staged changes as an OCI Factory PR reviewer."*
+- The harness scopes the diff (`git diff --merge-base origin/main`, or
+  `git diff --cached` for staged-only), lists the touched files, and **triages
+  by file path** — the `rock/*` labels don't exist yet, so use the fallback path
+  column in [Triage](#1-triage-the-pr-first).
+- It then applies the matching checklists ([§2](#2-security--vulnerability-gating-hard-gate)–[§6](#6-evidence--process-hygiene)).
+  The blocking vulnerability scan is **CI-only**, so locally the harness just
+  confirms `version: 2` and that every `ignored-vulnerabilities` entry carries
+  a justification comment (see
+  [§2](#2-security--vulnerability-gating-hard-gate)).
+
+**Output format (mimics a GitHub PR review — keep it concise)**
+
+- **Verdict** — one of `Request changes` / `Comment` / `Approve`, plus a
+  one-sentence summary.
+- **Inline comments** — one per finding, each `` `oci/<name>/image.yaml:line` ``
+  followed by a one-line note prefixed `[blocker]` or `[nit]`, with a `(§N)`
+  pointer to the governing section. Use GitHub ```` ```suggestion ```` blocks for
+  concrete fixes.
+- **Gate summary** — a compact pass / ⚠ / blocker checklist for the
+  locally-checkable gates: edge-first, EOL cap, semver, docs checklist,
+  `ignored-vulnerabilities` justification, `.trivyignore` deprecation. Mark the
+  vulnerability scan itself as *verify in CI*.
+
+**Example**
+
+> **Request changes** — new track must start at `edge`, and the ignored CVE
+> lacks a justification.
+>
+> `oci/foo/image.yaml:12` — [blocker] First release of a new track must be
+> `- edge` only, not `stable`. (§3)
+> ````suggestion
+>         risks:
+>           - edge
+> ````
+>
+> `oci/foo/image.yaml:20` — [blocker] `ignored-vulnerabilities` entry has no
+> justification comment; add at least the affected package/source (fuller
+> description | CVSS | Ubuntu priority | Status preferred). (§2)
+>
+> `oci/foo/image.yaml:5` — [nit] Drop the patch from `version` since the rock
+> tracks a moving `stage-snap` channel. (§3)
+>
+> **Gates:** edge-first ❌ · EOL cap ✅ · semver ⚠ · docs n/a · CVE justification
+> ❌ · `.trivyignore` ✅ · vuln scan → verify in CI
+
+### 1. Triage the PR first
+
+Classify the PR before reviewing, then jump to the matching sections. Triage
+primarily on the **type label** (`rock/*`, `onboarding`) — see
+[section 7](#7-pr-labels) — falling back to the touched file path when the label
+is missing (the `rock/*` labels are applied by maintainers, not auto-labeled):
+
+| Label (fallback path) | PR / issue type | Primary sections |
+| --- | --- | --- |
+| `rock/update` (`oci/<name>/image.yaml`) | Existing image-trigger update | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning) |
+| `rock/new` (new `oci/<name>/`, new track/base) | New rock / new track / new base | [2](#2-security--vulnerability-gating-hard-gate), [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-documentation-documentationyaml-checklist) |
+| `rock/chore` (`oci/<name>/` digest/source/version bump) | Misc rock change, incl. bot/dependency updates | [2](#2-security--vulnerability-gating-hard-gate), [6](#6-evidence--process-hygiene) |
+| `rock/docs` (`oci/<name>/documentation.yaml`) | Documentation change | [4](#4-documentation-documentationyaml-checklist) |
+| `onboarding` (issue) | Image onboarding request (intake) | [3](#3-release-policy-risk-tracks-eol-versioning), [4](#4-documentation-documentationyaml-checklist) |
+| no `rock/*` label (`.github/`, `src/`, `tools/`) | Factory source / CI workflow | [5](#5-ci--github-actions-review), [6](#6-evidence--process-hygiene) |
+
+### 2. Security & vulnerability gating (hard gate)
+
+The vulnerability scan is a **blocking** gate. Any finding must be resolved
+before approval.
+
+- If the scan reports findings, request changes and link the exact run. Use the
+  canonical phrasing:
+
+  > Please observe the CVE findings:
+  > `https://github.com/canonical/oci-factory/actions/runs/<run-id>/attempts/<n>#summary-<summary-id>`
+
+- Findings are addressed in the `ignored-vulnerabilities:` field of the image
+  trigger, **each entry justified** with an explanatory comment. At minimum,
+  the comment must identify the affected package/source (e.g. `# werkzeug
+  (pip)`); entries should prefer the fuller justification format:
+
+  ```yaml
+  ignored-vulnerabilities:
+    - CVE-2026-42151  # prometheus: OAuth client secret exposed via /-/config endpoint | CVSS: 7.5 (High) | Ubuntu priority: Medium | Status (26.04 resolute): Needs evaluation
+    - CVE-2026-33186  # grpc: authorization bypass via malformed HTTP/2 :path pseudo-header | CVSS: 9.1 (Critical) | Ubuntu priority: High | Status (26.04 resolute): Needs evaluation
+  ```
+
+  The full comment should carry: short description, `CVSS: <score> (<severity>)`,
+  `Ubuntu priority: <priority>`, and `Status (<series>): <triage>`.
+
+- When requesting changes for scan findings, apply the `pending cve` label (see
+  [section 7](#7-pr-labels)); remove it once every finding is fixed or justified.
+
+- Ask maintainers to add ignored entries **with proper justifications in the
+  comment**, not to silence findings blindly.
+
+- The `.trivyignore` file is **deprecated**. Require migration to
+  `ignored-vulnerabilities` in the image trigger. Example wording:
+
+  > Let's move this file away since using the `.trivyignore` file in OCI Factory
+  > is now deprecated.
+
+- `ignored-vulnerabilities` requires a `version: 2` trigger. A `version: 1`
+  trigger may stay as-is only until it needs this field; then it MUST switch to
+  `version: 2`.
+
+### 3. Release policy: risk, tracks, EOL, versioning
+
+- **Edge-first rule (MUST).** A new rock, a new track, or a new base image's
+  *first* release must include only `- edge`. Do not land a first release
+  directly at `candidate` or `stable`. Example:
+
+  > `1.27-26.04` is a new track for this rock (and also a new base). Let's start
+  > with risk edge.
+
+- **EOL cap for upstream-sourced rocks.** If the main application is built from
+  a directly-pulled upstream source **without a stated support plan**, cap the
+  `end-of-life` at *merge day + 3 months* and ask the team to describe their
+  support plan. Example:
+
+  > Since this rock is built from upstream source without a support plan, please
+  > reduce the EOL to "today + 3 months" at most.
+
+- **Conservative stable promotion.** Be cautious bumping a rock to `stable`,
+  especially when a known upstream/tooling issue affects the build. Because risk
+  promotion is **not automated**, require an issue/Jira ticket to track any
+  intended future promotion.
+
+- **Versioning scrutiny.**
+  - Reject non-`major-minor-patch` semver in the `version` field.
+  - If the version is not a source of truth (e.g., the rock pulls a moving
+    channel via `stage-snap`), drop the minor/patch from both the `version`
+    field and the track name.
+
+- **Track-conflict detection.** Flag concurrent PRs that write the same track;
+  they cause the track to oscillate/overwrite between values. Mark the
+  conflicting PRs invalid and coordinate which one proceeds. Example:
+
+  > The image trigger file conflicts with #NNNN on the track `X-YY.MM`. Please
+  > update either this one or the other so they won't overwrite each other.
+  > Marking this PR and #NNNN as invalid for now.
+
+### 4. Documentation (`documentation.yaml`) checklist
+
+- **Language:** US English spelling throughout; correct product capitalization
+  (e.g., do not write an uncapitalized product name); no informal phrasing.
+- **Headings:** correct level — service configuration headings are h2 (`##`).
+- **Verify defaults against upstream.** Do not document a default value that the
+  program does not actually set. Confirm against upstream source and link it.
+  Only state a default when it is real.
+- **Field placement:** run flags belong in `parameters`, not `run_cmd`.
+- **No template duplication:** remove content already provided by the template.
+- **Completeness:** include all env/config the rock declares (cross-check the
+  rock's `rockcraft.yaml` `environment:`), and provide concrete examples in env
+  descriptions.
+- **Runnable:** the documented `docker run ...` must actually work; verify it
+  before approving.
+- **Migrations (v1 -> v2) must not regress.** Approve a migration only when it
+  is at least equivalent to the v1 doc and nothing is undermined. Example
+  approval language:
+
+  > It seems there are no regressions or undermines from this change to the
+  > original documentation. Happy to move forward.
+
+- Note: the GitHub web UI can mangle multi-line suggestions. If a suggestion is
+  not applied correctly, ask the author to commit it manually.
+
+### 5. CI / GitHub Actions review
+
+- **Least privilege for `GITHUB_TOKEN`.** Grant only the "just enough" write
+  permissions a job needs; the default is read-only, so **do not** add explicit
+  `permissions: ...: read` entries.
+- **Prefer `GITHUB_TOKEN` over broad PATs.** Do not use `ROCKSBOT_TOKEN` where
+  `GITHUB_TOKEN` suffices — the bot token carries far wider scope.
+- **PAT-tag anti-pattern.** Pushing tags/commits with a PAT/bot identity
+  bypasses GitHub's protection against triggering infinite downstream workflow
+  runs. GitHub suppresses triggers for pushes made by `GITHUB_TOKEN` because it
+  treats them as CI actions; a PAT push voids that protection. Flag this.
+- **Reusable-workflow permission propagation.** A caller invoking a
+  fully-capable reusable workflow must grant the required permissions in the
+  caller job; the called workflow keeps default permissions when none are
+  specified. Understand this before requesting permission changes.
+- **Cite the docs.** Justify workflow-permission and token decisions with links
+  to the relevant GitHub documentation.
+- **Respect established patterns.** Avoid unnecessary changes to established,
+  working workflows; remove genuinely dead code (e.g., retired build paths).
+
+### 6. Evidence & process hygiene
+
+- **Prove fixes.** Back a "fixed" or "works" claim with a link to a successful
+  CI/test run or to upstream source. Example:
+
+  > Test workflow succeeds after applying this patch: `<actions run link>`
+
+- **Resolve linter warnings.** Do not leave yamllint (or other linter) warnings
+  unaddressed — e.g., "too few spaces before comment".
+- **Track deferred work.** File a follow-up issue (e.g., `ROCKS-####`) for items
+  intentionally deferred, and reference it in the thread.
+- **Close housekeeping PRs** that are stale (no activity for more than a month),
+  outdated, or superseded by another PR — state the reason on close. Apply the
+  `decaying` label after 2 weeks of no activity as an early warning (see
+  [section 7](#7-pr-labels)) before closing.
+- **Request a second reviewer** when the change is outside your area or warrants
+  another set of eyes.
+
+### 7. PR labels
+
+Apply labels to make review state visible and to drive housekeeping. The repo
+uses three families:
+
+**Type labels** — set the review path (see [Triage](#1-triage-the-pr-first)):
+
+- **`rock/new`** — a new rock, or a new track/base for an existing rock.
+- **`rock/update`** — an existing rock's image trigger is modified (release or
+  track change).
+- **`rock/chore`** — misc rock change (digest/source/version bump, incl.
+  bot/dependency updates).
+- **`rock/docs`** — a rock's `documentation.yaml` change.
+- **`onboarding`** — image onboarding request; auto-applied by the onboarding
+  issue template.
+- **`bug`** / **`duplicate`** — standard issue triage (`bug` also auto-applied
+  by the bug-report template; `duplicate` when the item already exists).
+
+  Note: `rock/*` labels are applied by maintainers, not auto-labeled; fall back
+  to the touched file path when they are missing.
+
+**Review-state labels** — track blockers and housekeeping:
+
+- **`pending cve`** — apply to any PR whose vulnerability scan reports
+  unresolved findings (see [section 2](#2-security--vulnerability-gating-hard-gate)).
+  Keep it until every finding is either fixed or justified in
+  `ignored-vulnerabilities`; remove it once the scan is clean.
+- **`blocked`** — apply when the PR cannot make progress until an external or
+  upstream dependency is resolved (e.g. a vuln fix pending in the base, an
+  upstream/tooling bug). Do not merge while set; record what it is blocked on.
+- **`do-not-merge`** — an explicit merge hold even if checks are green (e.g. a
+  proposal/spike, or work that must land in a specific order). Never merge while
+  set.
+- **`decaying`** — apply to any PR with no update for **more than 2 weeks**. It
+  is the early-warning step before closing: a `decaying` PR that stays inactive
+  for more than a month should be closed as stale (see
+  [section 6](#6-evidence--process-hygiene)).
+- **`invalid`** — apply to PRs that cannot proceed as-is, e.g. conflicting
+  concurrent PRs on the same track (see
+  [section 3](#3-release-policy-risk-tracks-eol-versioning)).
+
+**Priority labels** — `priority/critical`, `priority/high`, `priority/medium`,
+`priority/low` communicate urgency for triage and scheduling; set at most one.
+
+### 8. Approve vs. request-changes criteria
+
+Request changes when any of the following holds:
+
+- The vulnerability scan reports unresolved findings.
+- A new rock/track/base first release is not restricted to `edge`.
+- The `end-of-life` exceeds the cap for an unsupported upstream-sourced rock.
+- A documented default is unverified or wrong, or the documented run does not work.
+- A workflow grants more token/permission scope than necessary, or uses a PAT
+  where `GITHUB_TOKEN` suffices.
+- Concurrent PRs conflict on the same track.
+
+Never approve or merge while a `do-not-merge` or `blocked` label is set, even
+when all checks are green. Approve only when the security gate is clean, the
+release policy is satisfied, and regressions are ruled out. Keep approvals
+concise and, where relevant, note that no regressions/undermines were
+introduced.
+
+### 9. Related project conventions
+
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for authoring rules the review should
+enforce:
+
+- Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec.
+- Squash commits by functional value; no multiple commits fixing one issue in
+  the same code block.
+- In-progress PRs must be marked **Draft**.
+- Non-trivial changes should open an issue for discussion before the PR.
+- **Maintainers** must acknowledge the
+  [Image Maintainer Agreement](/IMAGE_MAINTAINER_AGREEMENT.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,9 +313,14 @@ when the file cannot be retrieved.
   Only state a default when it is real.
 - **Field placement:** run flags belong in `parameters`, not `run_cmd`.
 - **No template duplication:** remove content already provided by the template.
-- **Completeness:** include all env/config the rock declares (cross-check the
-  rock's `rockcraft.yaml` `environment:`), and provide concrete examples in env
-  descriptions.
+- **Completeness:** document user-configurable runtime environment and
+  configuration, with concrete examples. Cross-check `rockcraft.yaml`
+  `environment:`, Pebble service configuration, and service or entrypoint
+  scripts. Do not require documentation for implementation details fixed by
+  `services.<name>.environment`: Pebble service values override same-named
+  environment values supplied to the container. Document a variable when a
+  `docker run -e` value can reach and influence the user-facing service,
+  including variables consumed by entrypoint scripts.
 - **Runnable:** the documented `docker run ...` must actually work; verify it
   before approving.
 - **Migrations (v1 -> v2) must not regress.** Approve a migration only when it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,13 @@ specification](https://www.conventionalcommits.org/en/v1.0.0/). Example:
 functional value, e.g. you shouldn't have multiple commits for fixing a single
 bug within the same code block,
 - if a PR is still being worked on, make sure to set it to "Draft",
+- before raising your PR, it's recommended to run a self-review with an AI agent
+that can read [`AGENTS.md`](/AGENTS.md) — which encodes the maintainer review
+standard — and check your working changes against it, so you catch blockers
+ahead of CI and reviewers (see [Running a local review before you
+push](/AGENTS.md#running-a-local-review-before-you-push)). For example, prompt
+your agent harness with: *"Review my staged changes as an OCI Factory PR
+reviewer, following the guidelines in AGENTS.md."*,
 - unless it's a trivial fix/improvement, it's generally worth [opening an
 issue](https://github.com/canonical/oci-factory/issues) (making sure a similar
 one doesn't exist already) to discuss the item before submitting a PR,

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ upload:
 ##### Legacy *.trivyignore* files
 
 Existing `.trivyignore` files follow [Trivy's upstream
-syntax](<https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/#by-vulnerability-ids>)
+syntax](<https://trivy.dev/docs/latest/configuration/filtering/#by-finding-ids>)
 and remain supported temporarily for released revisions. Do not add new files
 or rules. When migrating an affected build to `ignored-vulnerabilities`, copy
 every still-applicable rule, not only the changed rules. Once

--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ OCI Factory's CI to notify the Maintainer when an event of interest occurs.
 - `.trivyignore`: this legacy vulnerability-filtering file is deprecated and
 must not be added for new filtering rules. Existing files remain temporarily
 supported because released image revisions may still depend on them. Use
-`upload[*].ignored-vulnerabilities` for new or modified rules.
+`upload[*].ignored-vulnerabilities` for new filtering rules. When migrating an
+affected build, copy every still-applicable rule because that build no longer
+uses `.trivyignore` once `ignored-vulnerabilities` is present.
 
 #### Contacts
 
@@ -430,9 +432,11 @@ upload:
 Existing `.trivyignore` files follow [Trivy's upstream
 syntax](<https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/#by-vulnerability-ids>)
 and remain supported temporarily for released revisions. Do not add new files
-or rules; migrate changed rules to `ignored-vulnerabilities`. The reusable
-workflow's `trivyignore-path` input remains available as a deprecated
-compatibility interface.
+or rules. When migrating an affected build to `ignored-vulnerabilities`, copy
+every still-applicable rule, not only the changed rules. Once
+`ignored-vulnerabilities` is present, that build no longer uses `.trivyignore`.
+The reusable workflow's `trivyignore-path` input remains available as a
+deprecated compatibility interface.
 
 ## 📦 Reusable workflows
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
       - [Contacts](#contacts)
         - [Example: *contacts.yaml*](#example-contactsyaml)
       - [Vulnerability Filtering](#vulnerability-filtering)
-        - [Example: *.trivyignore*](#example-trivyignore)
+        - [Example: *ignored-vulnerabilities*](#example-ignored-vulnerabilities)
+        - [Legacy *.trivyignore* files](#legacy-trivyignore-files)
   - [📦 Reusable workflows](#-reusable-workflows)
     - [Build-Rock Workflow](#build-rock-workflow)
     - [Test-Rock Workflow](#test-rock-workflow)
@@ -204,7 +205,7 @@ Having said that this trigger's syntax is as follows:
 | upload[*].source | True | str | Git repository hosting the image's project. |
 | upload[*].commit | True | str | Specific reference in the source, where to run the build from. |
 | upload[*].directory | True | str | Path to the "rockcraft.yaml". Where the build will run from. |
-| upload[*].ignored-vulnerabilities | False | conlist[str, unique_items=true] | List of vulnerability IDs (CVE or GHSA) to ignore during vulnerability scanning. These IDs will be added to the image's build metadata for future reference. When specifying this field, the `.trivyignore` file will be ignored. |
+| upload[*].ignored-vulnerabilities | False | conlist[str, unique_items=true] | List of Trivy finding IDs (for example, CVE, GHSA, or secret rule IDs) to ignore during vulnerability scanning. These IDs will be added to the image's build metadata for future reference. When specifying this field, the legacy `.trivyignore` file will be ignored. |
 | upload[*].release | False | Dict[Dict[str, Any]] | Immediately release this (yet unknown) revision to the given channels. Same as using `--release <channels>` with `rockcraft upload`. |
 | upload[*].release.\<track\> | True | Dict[str, Any] | Track to release this revision to. Canonical track `<version>-<base>` MUST be explicit, always! |
 | upload[*].release.\<track\>.end-of-life | True* | str | Same as `release.<track>` above. |
@@ -367,11 +368,10 @@ text dashboard).
 - `contacts.yaml`: this file is required for each OCI image. Although it won't
 trigger new builds/releases when updated by the Maintainer, it is used by the
 OCI Factory's CI to notify the Maintainer when an event of interest occurs.
-- `.trivyignore`: the vulnerability tests **should not be bypassed**!
-*However*, certain OCI images might have unfixed CVEs and/or vulnerabilities
-that come directly from the source upstream software that is being packaged. In
-these cases, it is acceptable to ignore specific CVEs, provided that the risks
-are acknowledged and proper justifications are provided.
+- `.trivyignore`: this legacy vulnerability-filtering file is deprecated and
+must not be added for new filtering rules. Existing files remain temporarily
+supported because released image revisions may still depend on them. Use
+`upload[*].ignored-vulnerabilities` for new or modified rules.
 
 #### Contacts
 
@@ -400,19 +400,39 @@ maintainers:
 
 #### Vulnerability Filtering
 
-The `.trivyignore` file follows [Trivy's upstream
-syntax](<https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/#by-vulnerability-ids>).
+Vulnerability tests **should not be bypassed**. Certain images may nevertheless
+contain unfixed findings inherited from upstream software. Add new or modified
+filtering rules to `upload[*].ignored-vulnerabilities` in a `version: 2` image
+trigger only when the risk is acknowledged and justified.
 
-##### Example: *.trivyignore*
+Each new or modified entry must identify the affected package/source and
+ecosystem, and state the maintainer's risk disposition with an image-specific
+reason the finding may be ignored. For deb packages, link the Ubuntu Security
+tracker at `https://ubuntu.com/security/<CVE-ID>`. CVEs in language packages are
+not currently tracked internally; state the upstream fix status and link an
+upstream advisory when one is available.
 
-```text
-# <justifications>
-CVE-2024-0000
+##### Example: *ignored-vulnerabilities*
 
-# Trivy-specific rules
-# <justification>
-private-key
+```yaml
+version: 2
+upload:
+  - source: canonical/foo-rock
+    commit: "<full-commit-sha>"
+    directory: .
+    ignored-vulnerabilities:
+      - CVE-XXXX-XXXXX  # libfoo (deb): temporarily accepted pending an Ubuntu fix | Ubuntu tracker: https://ubuntu.com/security/CVE-XXXX-XXXXX
+      - CVE-YYYY-YYYYY  # google.golang.org/grpc (Go): temporarily accepted; no fixed upstream release is available
 ```
+
+##### Legacy *.trivyignore* files
+
+Existing `.trivyignore` files follow [Trivy's upstream
+syntax](<https://aquasecurity.github.io/trivy/v0.19.2/vulnerability/examples/filter/#by-vulnerability-ids>)
+and remain supported temporarily for released revisions. Do not add new files
+or rules; migrate changed rules to `ignored-vulnerabilities`. The reusable
+workflow's `trivyignore-path` input remains available as a deprecated
+compatibility interface.
 
 ## 📦 Reusable workflows
 
@@ -518,8 +538,8 @@ needed.
 |`test-efficiency`| False | bool | Enable Dive image efficiency test. Enabled by default. |
 |`test-vulnerabilities`| False | bool | Enable Trivy vulnerability test. Enabled by default. |
 |`vulnerability-report-artifact-name`| False | str | Custom filename for Trivy vulnerability report. |
-|`trivyignore-path`| False | str | Optional path to `.trivyignore` file used in vulnerability scan. When specifying this input, the `ignored-vulnerabilities` must be left empty. |
-|`ignored-vulnerabilities`| False | JSON str | Space separated list of vulnerability IDs (CVE or GHSA) to ignore during vulnerability scanning. When specifying this input, the `trivyignore-path` must be left empty. |
+|`trivyignore-path`| False | str | Deprecated compatibility input for an optional `.trivyignore` path. When specifying this input, `ignored-vulnerabilities` must be empty. |
+|`ignored-vulnerabilities`| False | str | Space-separated list of Trivy finding IDs to ignore during vulnerability scanning. When specifying this input, `trivyignore-path` must be empty. |
 |`test-malware`| False | bool | Enable ClamAV malware test. Enabled by default. |
 
 **Workflow Secrets:**

--- a/README.md
+++ b/README.md
@@ -407,11 +407,13 @@ contain unfixed findings inherited from upstream software. Add new or modified
 filtering rules to `upload[*].ignored-vulnerabilities` in a `version: 2` image
 trigger only when the risk is acknowledged and justified.
 
-Each new or modified entry must identify the affected package/source and
-ecosystem, and state the maintainer's risk disposition with an image-specific
-reason the finding may be ignored. For deb packages, link the Ubuntu Security
-tracker at `https://ubuntu.com/security/<CVE-ID>`. CVEs in language packages are
-not currently tracked internally; state the upstream fix status and link an
+Each new or modified vulnerability entry must identify the affected
+package/source and ecosystem; entries for other Trivy finding types must instead
+identify the affected file/component and rule category. Every entry must state
+the maintainer's risk disposition with an image-specific reason the finding may
+be ignored. For deb packages, link the Ubuntu Security tracker at
+`https://ubuntu.com/security/<CVE-ID>`. CVEs in language packages are not
+currently tracked internally; state the upstream fix status and link an
 upstream advisory when one is available.
 
 ##### Example: *ignored-vulnerabilities*


### PR DESCRIPTION
- [x] I have signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] I am following the [CONTRIBUTING](https://github.com/canonical/oci-factory/blob/main/CONTRIBUTING.md) guidelines

---

## Description
<!--- Describe your changes in detail -->

* Adds the `AGENTS.md` file that provides the guideline to help AI agents review this repo, both locally and with Copilot.
* Adds the hints in the `CONTRIBUTING.md` to instruct the contributor using the AI to pre-review before submitting the PR.
* Align `README.md` with `AGENTS.md` for our current policy regarding the vulnerability managements.

### Related issues
<!--- If related to an issue, reference it -->
<!--- Link the issue using GitHub's keywords -->
<!--- https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A
---

*Picture of a cool rock:*
